### PR TITLE
coverage: lower optimization level on code-coverage builds

### DIFF
--- a/.github/workflows/run_coverage.yml
+++ b/.github/workflows/run_coverage.yml
@@ -27,7 +27,7 @@ jobs:
         python -m pip install pytest-cov gcovr ninja pybind11 meson-python
     - name: Install APyTypes
       run: |
-        export CPPFLAGS='--coverage -fprofile-abs-path'
+        export CPPFLAGS='-O0 --coverage -fprofile-abs-path'
         python -m pip install --no-deps --no-build-isolation -v --editable .
         unset CPPFLAGS
     - name: Test with pytest


### PR DESCRIPTION
I don't yet know if this is desirable. The general rule of thumb for code-coverage builds is to set the optimization level as low as possible, as lines from the initial source code will have a better correlation to the reported source code coverage.

I noticed the following difference in the reported code coverage when lowering the optimization level for the code-coverage build:
* There is a greater number of total lines reported (as missing, partial, or hit) in the codebase
* There is a greater number of lines reported as having hits
* The overall code-coverage percentage is lowered as there are many more new lines reported in  the coverage report

EDIT:
Subjectively, I also think that the reported partial hits make more sense when studying the coverage report from the non-optimized build.  