### PR TITLE
APyFloat: add comparisons with APyFixed/float/int #16

### DIFF
--- a/lib/test/test_floating_point.py
+++ b/lib/test/test_floating_point.py
@@ -97,8 +97,8 @@ def test_comparisons_with_apyfixed():
     assert a < b
     assert a > -b
     assert a == (b >> 1)
-    
-    assert APyFloat.from_float(float('inf'), 4, 3) > APyFixed.from_float(1000, 16, 16)
+
+    assert APyFloat.from_float(float("inf"), 4, 3) > APyFixed.from_float(1000, 16, 16)
     assert APyFloat.from_float(0, 4, 5) <= APyFixed.from_float(0, 16, 16)
     assert APyFloat.from_float(0.125, 4, 3) >= APyFixed.from_float(0.125, 16, 16)
 

--- a/src/apyfloat.h
+++ b/src/apyfloat.h
@@ -115,6 +115,7 @@ public:
     inline bool get_sign() const { return sign; }
     inline man_t get_man() const { return man; }
     inline exp_t get_exp() const { return exp; }
+    inline exp_t get_bias() const { return bias; }
     inline std::uint8_t get_man_bits() const { return man_bits; }
     inline std::uint8_t get_exp_bits() const { return exp_bits; }
 

--- a/src/apyfloat_wrapper.cc
+++ b/src/apyfloat_wrapper.cc
@@ -79,6 +79,13 @@ void bind_float(py::module& m)
         .def(py::self <= py::self)
         .def(py::self >= py::self)
 
+        .def(py::self == float())
+        .def(py::self != float())
+        .def(py::self < float())
+        .def(py::self > float())
+        .def(py::self <= float())
+        .def(py::self >= float())
+
         .def("__abs__", &APyFloat::abs)
         .def("__pow__", &APyFloat::pow)
         .def("__pow__", &APyFloat::pown)
@@ -88,11 +95,9 @@ void bind_float(py::module& m)
          */
         .def_property_readonly("is_normal", &APyFloat::is_normal)
         .def_property_readonly("is_subnormal", &APyFloat::is_subnormal)
-        .def_property_readonly("is_zero", &APyFloat::is_zero)
         .def_property_readonly("is_finite", &APyFloat::is_finite)
         .def_property_readonly("is_nan", &APyFloat::is_nan)
         .def_property_readonly("is_inf", &APyFloat::is_inf)
-        .def_property_readonly("is_sign_neg", &APyFloat::is_sign_neg)
 
         /*
          * Properties
@@ -100,6 +105,7 @@ void bind_float(py::module& m)
         .def_property_readonly("sign", &APyFloat::get_sign)
         .def_property_readonly("man", &APyFloat::get_man)
         .def_property_readonly("exp", &APyFloat::get_exp)
+        .def_property_readonly("bias", &APyFloat::get_bias)
         .def_property_readonly("man_bits", &APyFloat::get_man_bits)
         .def_property_readonly("exp_bits", &APyFloat::get_exp_bits);
 }


### PR DESCRIPTION
This PR, relating to #16, adds comparisons between APyFloat with int, floats, and APyFloat.

The comparison is made by the object converting itself to a Python float. An obvious edge case here is if one would simulate a number format that doesn't fit inside the double precision format, but since high-precision simulations isn't really the use case this should be acceptable. This also allows for comparisons between APyFloat and APyFixed, by converting both to Python floats. Note that comparisons between two APyFloats objects is still done the same way as before and are not silently converted to floats.

Removed the properties `is_sign_neg` and `is_zero`, but added `bias` since it was missing from before.

