### PR TITLE
Simplify version management

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ builddir/
 .vscode/
 *.so
 *~
+_version.py
 
 # Apple debuging symbol files
 *.dSYM

--- a/lib/apytypes/__init__.py
+++ b/lib/apytypes/__init__.py
@@ -10,6 +10,8 @@ from apytypes._apytypes import (
     set_rounding_mode,
 )
 
+from apytypes._version import version as __version__
+
 __all__ = [
     "APyFloat",
     "APyFixed",
@@ -20,6 +22,7 @@ __all__ = [
     "RoundingMode",
     "get_rounding_mode",
     "set_rounding_mode",
+    "__version__",
 ]
 
 APyFloat.__doc__ = """

--- a/lib/apytypes/_version.py.in
+++ b/lib/apytypes/_version.py.in
@@ -1,0 +1,1 @@
+version = @VCS_TAG@

--- a/meson.build
+++ b/meson.build
@@ -2,7 +2,7 @@ project(
     'apytypes',
     'cpp', 'c',
     default_options : ['cpp_std=c++17', 'c_std=c17'],
-    version : '0.0.1',
+    version : '0.0.1.dev0',
 )
 
 # Python module incudes
@@ -17,6 +17,20 @@ py3.install_sources(
   ],
   subdir: 'apytypes'
 )
+# Version handling
+fs = import('fs')
+if fs.exists('_version.py')
+    py3.install_sources('_version.py', subdir: 'apytypes')
+else
+  cfg = configuration_data()
+  cfg.set_quoted('VCS_TAG', meson.project_version())
+  configure_file(
+    input: 'lib/apytypes/_version.py.in', output: '_version.py',
+    configuration: cfg,
+    install: true,
+    install_tag: 'python-runtime',
+    install_dir: py3.get_install_dir() / 'apytypes')
+endif
 
 # Python module
 py3.extension_module(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ requires = ['meson-python', 'pybind11']
 
 [project]
 name = "apytypes"
-version = "0.0.1"
+dynamic = ['version']
 authors = [
   { name="Example Author", email="author@example.com" }
 ]

--- a/src/apytypes_wrapper.cc
+++ b/src/apytypes_wrapper.cc
@@ -42,7 +42,4 @@ void bind_common(py::module& m)
 
     m.def("set_rounding_mode", &set_rounding_mode);
     m.def("get_rounding_mode", &get_rounding_mode);
-
-    // APyTypes version number
-    m.attr("__version__") = "0.0.1";
 }


### PR DESCRIPTION
Now it is enough to change the version in `meson.build` (and `apytypes.__version__` works).

This will create a file `_version.py` in the build directory.