### PR TITLE
Add support for division in APyFloat

### DIFF
--- a/lib/test/apyfloat/test_apyfloat_arithmetic.py
+++ b/lib/test/apyfloat/test_apyfloat_arithmetic.py
@@ -187,10 +187,26 @@ def test_div_underflow():
     assert (APyFloat(0, 1, 3, 5, 2) / APyFloat(1, 30, 3, 5, 2)) == 0
 
 
+@pytest.mark.float_div
+@pytest.mark.parametrize("x", [0, 1, float("inf"), float("nan")])
+@pytest.mark.parametrize("y", [0, 1, float("inf"), float("nan")])
+def test_div_special_cases(x, y):
+    """Test the special cases for division."""
+    try:
+        assert (
+            s := str(float(APyFloat.from_float(x, 4, 4) / APyFloat.from_float(y, 4, 4)))
+        ) == str(x / y)
+    except ZeroDivisionError:
+        if x == 1 or x == float("inf"):
+            assert s == "inf"
+        else:
+            assert s == "nan"
+
+
 # Power
 @pytest.mark.float_pow
 def test_power():
-    """Test that a multiplication can underflow to zero."""
+    """Test the power function."""
     assert APyFloat.from_float(4.5, 8, 10) ** 2 == APyFloat.from_float(4.5**2, 8, 10)
     assert APyFloat.from_float(-4.5, 8, 10) ** 3 == APyFloat.from_float(
         (-4.5) ** 3, 8, 10
@@ -250,7 +266,7 @@ def test_power_underflow():
     ],
 )
 def test_power_special_cases(x, n, test_exp):
-    """Test that a multiplication can underflow to zero."""
+    """Test the special cases for the power function."""
     if str(test_exp) == "nan":
         assert eval(f"(APyFloat.from_float(float({x}), 9, 7)**{n}).is_nan")
     else:

--- a/lib/test/apyfloat/test_apyfloat_comparisons.py
+++ b/lib/test/apyfloat/test_apyfloat_comparisons.py
@@ -1,0 +1,151 @@
+from itertools import permutations as perm
+import pytest
+from apytypes import APyFloat, APyFixed
+
+
+@pytest.mark.float_comp
+def test_comparisons_with_floats():
+    a = APyFloat.from_float(0.5, 3, 3)
+    assert a > 0
+    assert a > 0.0
+    assert a >= 0
+    assert not a < 0
+    assert not a <= 0
+    assert a != 0
+
+    a = APyFloat.from_float(0.0, 3, 3)
+    assert a == 0
+    assert a == 0.0
+
+
+@pytest.mark.float_comp
+def test_comparisons_with_apyfixed():
+    a = APyFloat.from_float(2.5, 5, 5)
+    b = APyFixed.from_float(5, 5, 5)
+    assert a != b
+    assert b > a
+    assert a < b
+    assert a > -b
+    assert a == (b >> 1)
+
+    assert APyFloat.from_float(float("inf"), 4, 3) > APyFixed.from_float(1000, 16, 16)
+    assert APyFloat.from_float(0, 4, 5) <= APyFixed.from_float(0, 16, 16)
+    assert APyFloat.from_float(0.125, 4, 3) >= APyFixed.from_float(0.125, 16, 16)
+
+
+@pytest.mark.float_comp
+@pytest.mark.parametrize(
+    "lhs,rhs,test_exp",
+    [
+        ("APyFloat.from_float(2.75, 5, 5)", "APyFloat.from_float(2.75, 5, 5)", True),
+        ("APyFloat.from_float(2.75, 5, 6)", "APyFloat.from_float(2.75, 5, 5)", True),
+        ("APyFloat.from_float(2.75, 6, 5)", "APyFloat.from_float(2.75, 5, 5)", True),
+        ("APyFloat.from_float(2.75, 5, 5)", "APyFloat.from_float(-2.75, 5, 5)", False),
+        ("APyFloat.from_float(3.5, 5, 5)", "APyFloat.from_float(6.5, 5, 5)", False),
+        ("APyFloat.from_float(3.5, 5, 5)", "APyFloat.from_float(3.75, 5, 5)", False),
+        ("APyFloat.from_float(2**-9, 4, 3)", "APyFloat.from_float(2**-9, 5, 2)", True),
+    ],
+)
+def test_equality(lhs, rhs, test_exp):
+    assert (eval(lhs) == eval(rhs)) == test_exp
+    assert (eval(lhs) != eval(rhs)) == (not test_exp)
+
+
+@pytest.mark.float_comp
+@pytest.mark.parametrize("exp", list(perm(["5", "6", "7", "8"], 2)))
+@pytest.mark.parametrize("man", list(perm(["5", "6", "7", "8"], 2)))
+@pytest.mark.parametrize(
+    "lhs,rhs,test_exp",
+    [
+        ("3.5", "6.75", True),
+        ("3.5", "6.25", True),
+        ("3.5", "2.75", False),
+        ("3.5", "3.5", False),
+        ("3.5", "-6.75", False),
+    ],
+)
+def test_less_greater_than(exp, man, lhs, rhs, test_exp):
+    assert (
+        eval(
+            f"APyFloat.from_float({lhs}, {exp[0]}, {man[0]}) < APyFloat.from_float({rhs}, {exp[1]}, {man[1]})"
+        )
+    ) == test_exp
+    assert (
+        eval(
+            f"APyFloat.from_float({rhs}, {exp[0]}, {man[0]}) > APyFloat.from_float({lhs}, {exp[1]}, {man[1]})"
+        )
+    ) == test_exp
+
+
+@pytest.mark.float_comp
+@pytest.mark.parametrize(
+    "lhs,rhs,test_exp",
+    [
+        ("APyFloat.from_float(3.5, 5, 5)", "APyFloat.from_float(6.75, 5, 5)", True),
+        ("APyFloat.from_float(3.5, 5, 5)", "APyFloat.from_float(6.25, 5, 5)", True),
+        ("APyFloat.from_float(3.5, 5, 5)", "APyFloat.from_float(2.75, 5, 5)", False),
+        ("APyFloat.from_float(3.5, 5, 5)", "APyFloat.from_float(3.5, 5, 5)", True),
+        ("APyFloat.from_float(3.5, 5, 5)", "APyFloat.from_float(-6.75, 5, 5)", False),
+    ],
+)
+def test_leq_geq(lhs, rhs, test_exp):
+    assert (eval(lhs) <= eval(rhs)) == test_exp
+    assert (eval(rhs) >= eval(lhs)) == test_exp
+
+
+@pytest.mark.float_comp
+@pytest.mark.float_special
+@pytest.mark.parametrize(
+    "lhs,rhs",
+    list(
+        perm(
+            [
+                "APyFloat.from_float(2.75, 5, 5)",
+                "APyFloat.from_float(float('nan'), 5, 5)",
+            ]
+        )
+    )
+    + list(
+        perm(
+            [
+                "APyFloat.from_float(float('nan'), 5, 5)",
+                "APyFloat.from_float(float('nan'), 5, 5)",
+            ]
+        )
+    )
+    + list(
+        perm(
+            ["APyFloat.from_float(float('nan'), 5, 5)", "APyFloat.from_float(0, 5, 5)"]
+        )
+    )
+    + [
+        (
+            "APyFloat.from_float(float('nan'), 5, 5)",
+            "APyFloat.from_float(float('nan'), 5, 5)",
+        )
+    ],
+)
+def test_nan_comparison(lhs, rhs):
+    assert not (eval(lhs) == eval(rhs))
+    assert not (eval(lhs) != eval(rhs))
+    assert not (eval(lhs) < eval(rhs))
+    assert not (eval(lhs) > eval(rhs))
+    assert not (eval(lhs) <= eval(rhs))
+    assert not (eval(lhs) >= eval(rhs))
+
+
+@pytest.mark.float_comp
+@pytest.mark.float_special
+def test_inf_comparison():
+    assert APyFloat.from_float(12, 4, 1) < APyFloat.from_float(float("inf"), 5, 5)
+    assert APyFloat.from_float(-12, 4, 1) > APyFloat.from_float(float("-inf"), 5, 5)
+    assert APyFloat.from_float(0, 5, 5) > APyFloat.from_float(float("-inf"), 5, 5)
+    assert APyFloat.from_float(float("inf"), 5, 5) == APyFloat.from_float(
+        float("inf"), 5, 5
+    )
+    assert APyFloat.from_float(float("inf"), 5, 5) == APyFloat.from_float(
+        float("inf"), 3, 2
+    )
+    assert APyFloat.from_float(float("inf"), 5, 5) != APyFloat.from_float(
+        float("-inf"), 5, 5
+    )

--- a/lib/test/apyfloat/test_apyfloat_methods.py
+++ b/lib/test/apyfloat/test_apyfloat_methods.py
@@ -1,0 +1,88 @@
+from itertools import permutations as perm
+import pytest
+from apytypes import APyFloat, APyFixed
+
+
+@pytest.mark.float_special
+@pytest.mark.parametrize("float_s", ["nan", "inf", "-inf", "0.0", "-0.0"])
+def test_special_conversions(float_s):
+    assert (
+        str(float(APyFloat.from_float(float(float_s), 5, 5)))
+        == str(float(float_s))
+        == float_s
+    )
+
+
+@pytest.mark.parametrize("exp", list(perm([5, 6, 7, 8], 2)))
+@pytest.mark.parametrize("man", list(perm([5, 6, 7, 8], 2)))
+@pytest.mark.parametrize("val", [2.625, 12])
+@pytest.mark.parametrize("neg", [-1.0, 1.0])
+def test_normal_conversions(exp, man, val, neg):
+    val *= neg
+    assert (
+        float(APyFloat.from_float(val, exp[0], man[0]))
+        == float(APyFloat.from_float(val, exp[1], man[1]))
+        == val
+    )
+
+
+@pytest.mark.parametrize("sign", ["1", "0"])
+@pytest.mark.parametrize(
+    "absx,ans",
+    [
+        ("00000_00", "0.0"),  # Zero
+        ("0000_001", "1*2**-9"),  # Min subnorm
+        ("0000_010", "2*2**-9"),
+        ("0000_011", "3*2**-9"),
+        ("0000_100", "4*2**-9"),
+        ("0000_101", "5*2**-9"),
+        ("0000_110", "6*2**-9"),
+        ("0000_111", "7*2**-9"),  # Max subnorm
+        ("0001_000", "2**-6"),  # Min normal
+        ("1110_111", "240.0"),  # Max normal
+        ("1111_000", 'float("inf")'),  # Infinity
+    ],
+)
+def test_bit_conversions_e4m3(absx, sign, ans):
+    assert float(APyFloat.from_bits(int(f"{sign}_{absx}", 2), 4, 3)) == eval(
+        f'{"-" if sign == "1" else ""}{ans}'
+    )
+    assert APyFloat.from_float(
+        eval(f'{"-" if sign == "1" else ""}{ans}'), 4, 3
+    ).to_bits() == int(f"{sign}_{absx}", 2)
+
+
+@pytest.mark.parametrize("sign", ["1", "0"])
+@pytest.mark.parametrize(
+    "absx,ans",
+    [
+        ("11111_01", 'float("nan")'),  # NaN
+        ("11111_10", 'float("nan")'),  # NaN
+        ("11111_11", 'float("nan")'),  # NaN
+    ],
+)
+def test_bit_conversion_nan_e5m2(absx, sign, ans):
+    assert str(float(APyFloat.from_bits(int(f"{sign}_{absx}", 2), 5, 2))) == str(
+        eval(f'{"-" if sign == "1" else ""}{ans}')
+    )
+    bits = APyFloat.from_float(
+        eval(f'{"-" if sign == "1" else ""}{ans}'), 5, 2
+    ).to_bits()
+    assert (bits & 0x3) != 0
+
+
+def test_latex():
+    assert APyFloat.from_float(0, 2, 2)._repr_latex_() == "$0$"
+    assert APyFloat.from_float(20, 2, 2)._repr_latex_() == r"$\infty$"
+    assert (
+        APyFloat.from_float(0.5, 2, 2)._repr_latex_()
+        == r"$\frac{2}{2^{2}}2^{1-1} = 2\times 2^{-2}$"
+    )
+    assert (
+        APyFloat.from_float(-0.5, 2, 2)._repr_latex_()
+        == r"$-\frac{2}{2^{2}}2^{1-1} = -2\times 2^{-2}$"
+    )
+    assert (
+        APyFloat.from_float(1.5, 2, 2)._repr_latex_()
+        == r"$\left(1 + \frac{2}{2^{2}}\right)2^{1-1} = 6\times 2^{-2}$"
+    )

--- a/lib/test/apyfloat/test_floating_point_rounding.py
+++ b/lib/test/apyfloat/test_floating_point_rounding.py
@@ -1,5 +1,6 @@
 import apytypes
-from apytypes import APyFloat, RoundingMode
+from apytypes import APyFloat, RoundingMode, RoundingContext
+import pytest
 
 
 class TestAPyFloatRounding:
@@ -323,3 +324,40 @@ class TestAPyFloatRounding:
         assert APyFloat(1, 5, 0b10111, 5, 5).cast_to(5, 3) == APyFloat(
             1, 5, 0b110, 5, 3
         )  # Round up
+
+
+# Floating-point divison is implemented quite differently and should therefore be tested seperately
+@pytest.mark.float_div
+@pytest.mark.parametrize("a", [14, 20])
+@pytest.mark.parametrize("b", [14, 20])
+@pytest.mark.parametrize("sign", [1, -1])
+class TestAPyFloatRoundingDiv:
+    def test_to_positive(self, a, b, sign):
+        with RoundingContext(RoundingMode.TO_POSITIVE):
+            assert APyFloat.from_float(sign * a, 5, 5) / APyFloat.from_float(
+                b, 5, 5
+            ) == APyFloat.from_float(sign * a / b, 5, 5)
+
+    def test_to_negative(self, a, b, sign):
+        with RoundingContext(RoundingMode.TO_NEGATIVE):
+            assert APyFloat.from_float(sign * a, 5, 5) / APyFloat.from_float(
+                b, 5, 5
+            ) == APyFloat.from_float(sign * a / b, 5, 5)
+
+    def test_to_zero(self, a, b, sign):
+        with RoundingContext(RoundingMode.TO_ZERO):
+            assert APyFloat.from_float(sign * a, 5, 5) / APyFloat.from_float(
+                b, 5, 5
+            ) == APyFloat.from_float(sign * a / b, 5, 5)
+
+    def test_to_ties_to_even(self, a, b, sign):
+        with RoundingContext(RoundingMode.TIES_TO_EVEN):
+            assert APyFloat.from_float(sign * a, 5, 5) / APyFloat.from_float(
+                b, 5, 5
+            ) == APyFloat.from_float(sign * a / b, 5, 5)
+
+    def test_to_ties_to_away(self, a, b, sign):
+        with RoundingContext(RoundingMode.TIES_TO_AWAY):
+            assert APyFloat.from_float(sign * a, 5, 5) / APyFloat.from_float(
+                b, 5, 5
+            ) == APyFloat.from_float(sign * a / b, 5, 5)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,7 @@ markers = [
     "float_add : custom marker for grouping tests for floating-point addition",
     "float_sub : custom marker for grouping tests for floating-point subtraction",
     "float_mul : custom marker for grouping tests for floating-point multiplication",
+    "float_div : custom marker for grouping tests for floating-point division",
     "float_pow : custom marker for grouping tests for floating-point power function",
     "float_comp : custom marker for grouping tests for floating-point comparisons",
     "float_special : custom marker for grouping tests for floating-point special values"

--- a/src/apyfloat.cc
+++ b/src/apyfloat.cc
@@ -515,8 +515,8 @@ APyFloat APyFloat::operator/(const APyFloat& y) const
     res.sign = sign ^ y.sign;
 
     // Handle special operands
-    if ((is_nan() || y.is_nan()) || (is_inf() && y.is_zero())
-        || (is_zero() && y.is_zero())) {
+    if ((is_nan() || y.is_nan()) || (is_zero() && y.is_zero())
+        || (is_inf() && y.is_inf())) {
         return res.construct_nan();
     }
 

--- a/src/apytypes_common.cc
+++ b/src/apytypes_common.cc
@@ -6,35 +6,3 @@ RoundingMode rounding_mode = RoundingMode::TIES_TO_EVEN;
 void set_rounding_mode(RoundingMode mode) { rounding_mode = mode; }
 
 RoundingMode get_rounding_mode() { return rounding_mode; }
-
-APyFixedRoundingMode translate_rounding_mode(RoundingMode mode)
-{
-    switch (mode) {
-    case RoundingMode::TO_ZERO:
-        return APyFixedRoundingMode::TRN;
-    case RoundingMode::TIES_TO_EVEN:
-        return APyFixedRoundingMode::RND_CONV;
-    case RoundingMode::TIES_TO_AWAY:
-        return APyFixedRoundingMode::RND;
-    default:
-        throw std::domain_error(
-            "No corresponding rounding mode between APyFloat and APyFixed."
-        );
-    }
-}
-
-RoundingMode translate_rounding_mode(APyFixedRoundingMode mode)
-{
-    switch (mode) {
-    case APyFixedRoundingMode::TRN:
-        return RoundingMode::TO_ZERO;
-    case APyFixedRoundingMode::RND_CONV:
-        return RoundingMode::TIES_TO_EVEN;
-    case APyFixedRoundingMode::RND:
-        return RoundingMode::TIES_TO_AWAY;
-    default:
-        throw std::domain_error(
-            "No corresponding rounding mode between APyFloat and APyFixed."
-        );
-    }
-}

--- a/src/apytypes_common.cc
+++ b/src/apytypes_common.cc
@@ -1,7 +1,40 @@
 #include "apytypes_common.h"
+#include <stdexcept>
 
 RoundingMode rounding_mode = RoundingMode::TIES_TO_EVEN;
 
 void set_rounding_mode(RoundingMode mode) { rounding_mode = mode; }
 
 RoundingMode get_rounding_mode() { return rounding_mode; }
+
+APyFixedRoundingMode translate_rounding_mode(RoundingMode mode)
+{
+    switch (mode) {
+    case RoundingMode::TO_ZERO:
+        return APyFixedRoundingMode::TRN;
+    case RoundingMode::TIES_TO_EVEN:
+        return APyFixedRoundingMode::RND_CONV;
+    case RoundingMode::TIES_TO_AWAY:
+        return APyFixedRoundingMode::RND;
+    default:
+        throw std::domain_error(
+            "No corresponding rounding mode between APyFloat and APyFixed."
+        );
+    }
+}
+
+RoundingMode translate_rounding_mode(APyFixedRoundingMode mode)
+{
+    switch (mode) {
+    case APyFixedRoundingMode::TRN:
+        return RoundingMode::TO_ZERO;
+    case APyFixedRoundingMode::RND_CONV:
+        return RoundingMode::TIES_TO_EVEN;
+    case APyFixedRoundingMode::RND:
+        return RoundingMode::TIES_TO_AWAY;
+    default:
+        throw std::domain_error(
+            "No corresponding rounding mode between APyFloat and APyFixed."
+        );
+    }
+}

--- a/src/apytypes_common.h
+++ b/src/apytypes_common.h
@@ -34,4 +34,7 @@ enum class RoundingMode {
 void set_rounding_mode(RoundingMode);
 RoundingMode get_rounding_mode();
 
+APyFixedRoundingMode translate_rounding_mode(RoundingMode);
+RoundingMode translate_rounding_mode(APyFixedRoundingMode);
+
 #endif // _APYTYPES_COMMON_H

--- a/src/apytypes_common.h
+++ b/src/apytypes_common.h
@@ -34,7 +34,4 @@ enum class RoundingMode {
 void set_rounding_mode(RoundingMode);
 RoundingMode get_rounding_mode();
 
-APyFixedRoundingMode translate_rounding_mode(RoundingMode);
-RoundingMode translate_rounding_mode(APyFixedRoundingMode);
-
 #endif // _APYTYPES_COMMON_H


### PR DESCRIPTION
The mantissa division is made using APyFixed. Special cases for 0, NaN, and infinity are also handled.

Subnormal operands however are not handled. Support for subnormals should probably be added by normalizing them using a larger exponent format, but that will be a future task. The support for subnormal operands in general is currently a bit "flaky" in the code and they have no test cases yet, I therefore think full subnormal support can be another PR by itself.