### PR TITLE
src: add APyFixedArray.to_numpy()

### DIFF
--- a/.github/workflows/run_coverage.yml
+++ b/.github/workflows/run_coverage.yml
@@ -24,7 +24,7 @@ jobs:
     - name: Install dependencies
       run: |
         sudo apt-get install -yy lcov
-        python -m pip install pytest-cov gcovr ninja pybind11 meson-python
+        python -m pip install pytest-cov gcovr ninja pybind11 meson-python numpy
     - name: Install APyTypes
       run: |
         export CPPFLAGS='-O0 --coverage -fprofile-abs-path'

--- a/lib/apytypes/_apytypes.pyi
+++ b/lib/apytypes/_apytypes.pyi
@@ -302,8 +302,8 @@ class APyFixedArray:
 
     def to_numpy(self) -> numpy.ndarray[numpy.float64]:
         """
-        Retrieve a :class:`Numpy.ndarray` object of :class:`Numpy.float64` from this
-        array.
+        Retrieve a :class:`Numpy.ndarray` object of :class:`Numpy.float64` from
+        `self`.
 
         The returned array has the same `shape` and stored value as `self`. This
         method rounds away from infinity on ties.

--- a/lib/apytypes/_apytypes.pyi
+++ b/lib/apytypes/_apytypes.pyi
@@ -1,4 +1,5 @@
 from __future__ import annotations
+import numpy
 import typing
 
 __all__ = [
@@ -297,6 +298,19 @@ class APyFixedArray:
         Returns
         -------
         :class:`bool`
+        """
+
+    def to_numpy(self) -> numpy.ndarray[numpy.float64]:
+        """
+        Retrieve a :class:`Numpy.ndarray` object of :class:`Numpy.float64` from this
+        array.
+
+        The returned array has the same `shape` and stored value as `self`. This
+        method rounds away from infinity on ties.
+
+        Returns
+        -------
+        :class:`Numpy.ndarray`
         """
 
     def transpose(self) -> APyFixedArray:

--- a/lib/test/apyfixedarray/test_methods.py
+++ b/lib/test/apyfixedarray/test_methods.py
@@ -21,9 +21,13 @@ def test_to_numpy():
     # Skip this test if `NumPy` is not present on the machine
     np = pytest.importorskip("numpy")
 
+    assert np.array_equal(APyFixedArray([], 1, 0).to_numpy(), np.array([]))
+    assert np.array_equal(APyFixedArray([1], 2, 2).to_numpy(), np.array([1.0]))
+
     float_seq = [
         [[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]],
         [[7.0, 8.0, 9.0], [10.0, 11.0, 12.0]],
     ]
     fx_arr = APyFixedArray.from_float(float_seq, bits=10, int_bits=10)
-    np.array_equal(fx_arr.to_numpy(), np.array(float_seq))
+    assert fx_arr.to_numpy().shape == (2, 2, 3)
+    assert np.array_equal(fx_arr.to_numpy(), np.array(float_seq))

--- a/lib/test/apyfixedarray/test_methods.py
+++ b/lib/test/apyfixedarray/test_methods.py
@@ -1,5 +1,7 @@
 from apytypes import APyFixedArray
 
+import pytest
+
 
 def test_shape():
     assert APyFixedArray([], bits=1, int_bits=0).shape == (0,)
@@ -13,3 +15,15 @@ def test_ndim():
     assert APyFixedArray([1], bits=1, int_bits=0).ndim == 1
     assert APyFixedArray([[range(3), range(3)]], bits=1, int_bits=0).ndim == 3
     assert APyFixedArray([range(3), range(3)], bits=1, int_bits=0).ndim == 2
+
+
+def test_to_numpy():
+    # Skip this test if `NumPy` is not present on the machine
+    np = pytest.importorskip("numpy")
+
+    float_seq = [
+        [[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]],
+        [[7.0, 8.0, 9.0], [10.0, 11.0, 12.0]],
+    ]
+    fx_arr = APyFixedArray.from_float(float_seq, bits=10, int_bits=10)
+    np.array_equal(fx_arr.to_numpy(), np.array(float_seq))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,8 +25,19 @@ classifiers = [
 setup = ['--default-library=static']
 
 [project.optional-dependencies]
-docs = ["furo", "numpydoc", "sphinx", "sphinx_copybutton", "breathe", "sphinx_gallery", "matplotlib"]
-test = ["pytest"]
+docs = [
+    "breathe",
+    "furo",
+    "matplotlib",
+    "numpydoc",
+    "sphinx",
+    "sphinx_copybutton",
+    "sphinx_gallery",
+]
+test = [
+    "numpy",
+    "pytest",
+]
 
 [tool.pytest.ini_options]
 markers = [
@@ -38,4 +49,4 @@ markers = [
     "float_pow : custom marker for grouping tests for floating-point power function",
     "float_comp : custom marker for grouping tests for floating-point comparisons",
     "float_special : custom marker for grouping tests for floating-point special values"
-    ]
+]

--- a/src/apyfixed.h
+++ b/src/apyfixed.h
@@ -266,6 +266,11 @@ private:
     // of the APyFixed range.
     void _twos_complement_overflow() noexcept;
 
+    //! `APyFixedArray` is a friend class of APyFixed, and can access all data of an
+    //! `APyFixed` object
+public:
+    friend class APyFixedArray;
+
 }; // end: class APyFixed
 
 /* ********************************************************************************** *

--- a/src/apyfixedarray.h
+++ b/src/apyfixedarray.h
@@ -5,6 +5,7 @@
 #ifndef _APYFIXED_ARRAY_H
 #define _APYFIXED_ARRAY_H
 
+#include <pybind11/numpy.h>    // pybind11::array_t
 #include <pybind11/pybind11.h> // pybind11::object
 #include <pybind11/pytypes.h>  // pybind11::sequence
 
@@ -98,6 +99,9 @@ public:
 
     //! The `frac_bits` specifier for this APyFixedArray
     int frac_bits() const noexcept { return _bits - _int_bits; }
+
+    //! Convert this array to a NumPy array
+    pybind11::array_t<double> to_numpy() const;
 
     /*!
      * Test if two `APyFixedArray` objects are identical. Two `APyFixedArray` objects

--- a/src/apyfixedarray_wrapper.cc
+++ b/src/apyfixedarray_wrapper.cc
@@ -46,6 +46,7 @@ void bind_fixed_array(py::module& m)
             -------
             :class:`int`
             )pbdoc")
+
         .def_property_readonly("int_bits", &APyFixedArray::int_bits, R"pbdoc(
             The number of integer bits in this :class:`APyFixedArray` object.
 
@@ -53,6 +54,7 @@ void bind_fixed_array(py::module& m)
             -------
             :class:`int`
             )pbdoc")
+
         .def_property_readonly("frac_bits", &APyFixedArray::frac_bits, R"pbdoc(
             The number of fractional bits in this :class:`APyFixedArray` object.
 
@@ -68,6 +70,7 @@ void bind_fixed_array(py::module& m)
             -------
             :class:`tuple` of :class:`int`
             )pbdoc")
+
         .def_property_readonly("ndim", &APyFixedArray::ndim, R"pbdoc(
             Number of dimensions in this `class`APyFixedArray` object.
 
@@ -75,6 +78,19 @@ void bind_fixed_array(py::module& m)
             -------
             :class:`int`
             )pbdoc")
+
+        .def("to_numpy", &APyFixedArray::to_numpy, R"pbdoc(
+            Retrieve a :class:`Numpy.ndarray` object of :class:`Numpy.float64` from
+            `self`.
+
+            The returned array has the same `shape` and stored value as `self`. This
+            method rounds away from infinity on ties.
+
+            Returns
+            -------
+            :class:`Numpy.ndarray`
+            )pbdoc")
+
         .def("is_identical", &APyFixedArray::is_identical, py::arg("other"), R"pbdoc(
             Test if two :class:`APyFixedArray` objects are identical.
 


### PR DESCRIPTION
Using method `APyFixed.to_numpy()` requires NumPy to be installed. Not having NumPy installed when using `to_numpy()` triggers a `MoudleNotFoundError` exception.

Example:
```Python
=================================== FAILURES ===================================
________________________________ test_to_numpy _________________________________

    def test_to_numpy():
        float_seq = [
            [[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]],
            [[7.0, 8.0, 9.0], [10.0, 11.0, 12.0]],
        ]
        fx_arr = APyFixedArray.from_float(float_seq, bits=10, int_bits=10)
>       np_arr = fx_arr.to_numpy()
E       ModuleNotFoundError: No module named 'numpy'

lib/test/apyfixedarray/test_methods.py:24: ModuleNotFoundError
=========================== short test summary info ============================
FAILED lib/test/apyfixedarray/test_methods.py::test_to_numpy - ModuleNotFoundError: No module named 'numpy'
================== 1 failed, 6719 passed, 1 xpassed in 6.02s ===================
Error: Process completed with exit code 1.
```