### PR TITLE
NumPy and SciPy example

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -39,8 +39,10 @@ html_static_path = ["_static"]
 
 intersphinx_mapping = {
     "python": ("https://docs.python.org/3/", None),
+    "matplotlib": ("https://matplotlib.org/", None),
     "numpy": ("https://numpy.org/doc/stable/", None),
     "nanobind": ("https://nanobind.readthedocs.io/en/latest/", None),
+    "scipy": ("https://docs.scipy.org/doc/scipy/", None),
 }
 
 # Breathe Configuration

--- a/examples/numpy.py
+++ b/examples/numpy.py
@@ -1,0 +1,42 @@
+"""
+NumPy integration
+=================
+
+It is possible to easily go between numpy and apytypes and therefore also use plotting tools like Matplotlib in an integrated manner.
+
+Consider the example from https://docs.scipy.org/doc/scipy/reference/generated/scipy.signal.convolve.html implemented using fixed-point arithmetic
+
+"""
+
+import numpy as np
+from scipy import signal
+from apytypes import APyFixedArray
+import matplotlib.pyplot as plt
+
+sig = np.repeat([0.0, 1.0, 0.0], 100)
+sig_fx = APyFixedArray.from_float(sig, 12, 2)
+
+win = signal.windows.hann(50)
+win_fx = APyFixedArray.from_float(win, 10, 2)
+
+filtered = signal.convolve(sig, win, mode="same") / sum(win)
+filtered_fx = signal.convolve(sig_fx, win_fx, mode="same") / sum(win_fx)
+
+# %%
+# The results can then be plotted in Matplotlib
+
+fig, (ax_orig, ax_win, ax_filt) = plt.subplots(3, 1, sharex=True)
+ax_orig.plot(sig)
+ax_orig.plot(sig_fx)
+ax_orig.set_title("Original pulse")
+ax_orig.margins(0, 0.1)
+ax_win.plot(win)
+ax_win.plot(win_fx)
+ax_win.set_title("Filter impulse response")
+ax_win.margins(0, 0.1)
+ax_filt.plot(filtered)
+ax_filt.plot(filtered_fx)
+ax_filt.set_title("Filtered signal")
+ax_filt.margins(0, 0.1)
+fig.tight_layout()
+fig.show()

--- a/examples/numpy.py
+++ b/examples/numpy.py
@@ -10,7 +10,7 @@ Consider the example from https://docs.scipy.org/doc/scipy/reference/generated/s
 
 import numpy as np
 from scipy import signal
-from apytypes import APyFixedArray
+from apytypes import APyFixedArray, convolve
 import matplotlib.pyplot as plt
 
 sig = np.repeat([0.0, 1.0, 0.0], 100)
@@ -20,7 +20,7 @@ win = signal.windows.hann(50)
 win_fx = APyFixedArray.from_float(win, 10, 2)
 
 filtered = signal.convolve(sig, win, mode="same") / sum(win)
-filtered_fx = signal.convolve(sig_fx, win_fx, mode="same") / sum(win_fx)
+filtered_fx = convolve(sig_fx, win_fx, mode="same") / sum(win_fx)
 
 # %%
 # The results can then be plotted in Matplotlib

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,9 +42,11 @@ docs = [
     "sphinx_gallery>=0.16",
     "m2r2",
     "docutils<=0.20",  # Pin to get around limitation in m2r2
+    "numpy>=1.25",
+    "scipy",
 ]
 test = ["numpy>=1.25", "pytest>=8.2"]
-dev = ["nanobind>=2.0.0"]
+dev = ["nanobind>=2.1.0"]
 benchmark = ["numpy>=1.25", "pytest>=8.2", "pytest-benchmark"]
 comparison = [
     "fpbinary",


### PR DESCRIPTION
There is an error here @miklhh that we probably should try to sort out.

```
In [3]: filtered = signal.convolve(sig_fx, win_fx, mode='same') / sum(win_fx)
Traceback (most recent call last):

  Cell In[3], line 1
    filtered = signal.convolve(sig_fx, win_fx, mode='same') / sum(win_fx)

  File /local/data1/miniconda3/lib/python3.10/site-packages/scipy/signal/_signaltools.py:1401 in convolve
    return volume * kernel

RuntimeError: In APyFixedArray.__mul__: shape missmatch
```

A start is to write out the missmatching shapes to get some hint.