### PR TITLE
More rounding modes for APyFloat

### DIFF
--- a/lib/apytypes/__init__.py
+++ b/lib/apytypes/__init__.py
@@ -11,6 +11,8 @@ from apytypes._apytypes import (
     RoundingMode,
     get_rounding_mode,
     set_rounding_mode,
+    get_rounding_seed,
+    set_rounding_seed,
 )
 
 from apytypes._version import version as __version__
@@ -27,6 +29,8 @@ __all__ = [
     "__version__",
     "get_rounding_mode",
     "set_rounding_mode",
+    "get_rounding_seed",
+    "set_rounding_seed",
 ]
 
 APyFloat.__doc__ = """

--- a/lib/test/apyfloat/test_rounding.py
+++ b/lib/test/apyfloat/test_rounding.py
@@ -379,6 +379,84 @@ class TestAPyFloatRounding:
             1, 5, 0b110, 5, 3
         )  # Round up
 
+    def test_rounding_jamming(self):
+        apytypes.set_rounding_mode(RoundingMode.JAM)
+        # Rounding from 0.xx
+        assert APyFloat(0, 5, 0b10000, 5, 5).resize(5, 3) == APyFloat(0, 5, 0b101, 5, 3)
+        assert APyFloat(0, 5, 0b10001, 5, 5).resize(5, 3) == APyFloat(0, 5, 0b101, 5, 3)
+        assert APyFloat(0, 5, 0b10010, 5, 5).resize(5, 3) == APyFloat(0, 5, 0b101, 5, 3)
+        assert APyFloat(0, 5, 0b10011, 5, 5).resize(5, 3) == APyFloat(0, 5, 0b101, 5, 3)
+
+        # Rounding from 1.xx
+        assert APyFloat(0, 5, 0b10100, 5, 5).resize(5, 3) == APyFloat(0, 5, 0b101, 5, 3)
+        assert APyFloat(0, 5, 0b10101, 5, 5).resize(5, 3) == APyFloat(0, 5, 0b101, 5, 3)
+        assert APyFloat(0, 5, 0b10110, 5, 5).resize(5, 3) == APyFloat(0, 5, 0b101, 5, 3)
+        assert APyFloat(0, 5, 0b10111, 5, 5).resize(5, 3) == APyFloat(0, 5, 0b101, 5, 3)
+
+        # Rounding from 0.xx, negative sign
+        assert APyFloat(1, 5, 0b10000, 5, 5).resize(5, 3) == APyFloat(1, 5, 0b101, 5, 3)
+        assert APyFloat(1, 5, 0b10001, 5, 5).resize(5, 3) == APyFloat(1, 5, 0b101, 5, 3)
+        assert APyFloat(1, 5, 0b10010, 5, 5).resize(5, 3) == APyFloat(1, 5, 0b101, 5, 3)
+        assert APyFloat(1, 5, 0b10011, 5, 5).resize(5, 3) == APyFloat(1, 5, 0b101, 5, 3)
+
+        # Rounding from 1.xx, negative sign
+        assert APyFloat(1, 5, 0b10100, 5, 5).resize(5, 3) == APyFloat(1, 5, 0b101, 5, 3)
+        assert APyFloat(1, 5, 0b10101, 5, 5).resize(5, 3) == APyFloat(1, 5, 0b101, 5, 3)
+        assert APyFloat(1, 5, 0b10110, 5, 5).resize(5, 3) == APyFloat(1, 5, 0b101, 5, 3)
+        assert APyFloat(1, 5, 0b10111, 5, 5).resize(5, 3) == APyFloat(1, 5, 0b101, 5, 3)
+
+    def test_rounding_stochastic_weighted(self):
+        """
+        A bit naive, but test that a value can be rounded both up and down in 1000 tries.
+        An exact value should however not be rounded.
+        """
+        apytypes.set_rounding_mode(RoundingMode.STOCHASTIC_WEIGHTED)
+        larger_format = APyFloat(0, 5, 0b10000, 5, 5)
+        assert larger_format.resize(5, 3) == APyFloat(0, 5, 0b100, 5, 3)
+
+        larger_format = APyFloat(0, 5, 0b10001, 5, 5)
+        rounded_down = APyFloat(0, 5, 0b100, 5, 3)
+        rounded_up = APyFloat(0, 5, 0b101, 5, 3)
+
+        done_up = False
+        done_down = False
+        for i in range(1000):
+            smaller_format = larger_format.resize(5, 3)
+            if smaller_format == rounded_down:
+                done_down = True
+            elif smaller_format == rounded_up:
+                done_up = True
+            else:
+                self.fail(f"{larger_format} was rounded to {smaller_format}")
+            if done_down and done_up:
+                break
+
+    def test_rounding_stochastic_equal(self):
+        """
+        A bit naive, but test that a value can be rounded both up and down in 1000 tries.
+        An exact value should however not be rounded.
+        """
+        apytypes.set_rounding_mode(RoundingMode.STOCHASTIC_EQUAL)
+        larger_format = APyFloat(0, 5, 0b10000, 5, 5)
+        assert larger_format.resize(5, 3) == APyFloat(0, 5, 0b100, 5, 3)
+
+        larger_format = APyFloat(0, 5, 0b10001, 5, 5)
+        rounded_down = APyFloat(0, 5, 0b100, 5, 3)
+        rounded_up = APyFloat(0, 5, 0b101, 5, 3)
+
+        done_up = False
+        done_down = False
+        for i in range(1000):
+            smaller_format = larger_format.resize(5, 3)
+            if smaller_format == rounded_down:
+                done_down = True
+            elif smaller_format == rounded_up:
+                done_up = True
+            else:
+                pytest.fail(f"{larger_format} was rounded to {smaller_format}")
+            if done_down and done_up:
+                break
+
 
 # Floating-point divison is implemented quite differently and should therefore be tested seperately
 @pytest.mark.float_div

--- a/lib/test/apyfloat/test_rounding.py
+++ b/lib/test/apyfloat/test_rounding.py
@@ -97,13 +97,13 @@ class TestAPyFloatRounding:
         )  # No rounding needed
         assert APyFloat(0, 5, 0b10001, 5, 5).resize(5, 3) == APyFloat(
             0, 5, 0b100, 5, 3
-        )  # Round up
+        )  # Round down
         assert APyFloat(0, 5, 0b10010, 5, 5).resize(5, 3) == APyFloat(
             0, 5, 0b100, 5, 3
-        )  # Tie break, round up
+        )  # Tie break, round down
         assert APyFloat(0, 5, 0b10011, 5, 5).resize(5, 3) == APyFloat(
             0, 5, 0b100, 5, 3
-        )  # Round up
+        )  # Round down
 
         # Rounding from 1.xx
         assert APyFloat(0, 5, 0b10100, 5, 5).resize(5, 3) == APyFloat(
@@ -111,13 +111,13 @@ class TestAPyFloatRounding:
         )  # No rounding needed
         assert APyFloat(0, 5, 0b10101, 5, 5).resize(5, 3) == APyFloat(
             0, 5, 0b101, 5, 3
-        )  # Round up
+        )  # Round down
         assert APyFloat(0, 5, 0b10110, 5, 5).resize(5, 3) == APyFloat(
             0, 5, 0b101, 5, 3
-        )  # Tie break, round up
+        )  # Tie break, round down
         assert APyFloat(0, 5, 0b10111, 5, 5).resize(5, 3) == APyFloat(
             0, 5, 0b101, 5, 3
-        )  # Round up
+        )  # Round down
 
         # Rounding from 0.xx, negative sign
         assert APyFloat(1, 5, 0b10000, 5, 5).resize(5, 3) == APyFloat(
@@ -142,10 +142,10 @@ class TestAPyFloatRounding:
         )  # Round up
         assert APyFloat(1, 5, 0b10110, 5, 5).resize(5, 3) == APyFloat(
             1, 5, 0b110, 5, 3
-        )  # Tie break, round ip
+        )  # Tie break, round up
         assert APyFloat(1, 5, 0b10111, 5, 5).resize(5, 3) == APyFloat(
             1, 5, 0b110, 5, 3
-        )  # Round ip
+        )  # Round up
 
     def test_rounding_to_zero(self):
         apytypes.set_rounding_mode(RoundingMode.TO_ZERO)
@@ -317,6 +317,64 @@ class TestAPyFloatRounding:
         assert APyFloat(1, 5, 0b10110, 5, 5).resize(5, 3) == APyFloat(
             1, 5, 0b110, 5, 3
         )  # Tie break, round up
+        assert APyFloat(1, 5, 0b10111, 5, 5).resize(5, 3) == APyFloat(
+            1, 5, 0b110, 5, 3
+        )  # Round up
+
+    def test_rounding_ties_to_zero(self):
+        apytypes.set_rounding_mode(RoundingMode.TIES_ZERO)
+        # Rounding from 0.xx
+        assert APyFloat(0, 5, 0b10000, 5, 5).resize(5, 3) == APyFloat(
+            0, 5, 0b100, 5, 3
+        )  # No rounding needed
+        assert APyFloat(0, 5, 0b10001, 5, 5).resize(5, 3) == APyFloat(
+            0, 5, 0b100, 5, 3
+        )  # Round down
+        assert APyFloat(0, 5, 0b10010, 5, 5).resize(5, 3) == APyFloat(
+            0, 5, 0b100, 5, 3
+        )  # Tie break, round down
+        assert APyFloat(0, 5, 0b10011, 5, 5).resize(5, 3) == APyFloat(
+            0, 5, 0b101, 5, 3
+        )  # Round up
+
+        # Rounding from 1.xx
+        assert APyFloat(0, 5, 0b10100, 5, 5).resize(5, 3) == APyFloat(
+            0, 5, 0b101, 5, 3
+        )  # No rounding needed
+        assert APyFloat(0, 5, 0b10101, 5, 5).resize(5, 3) == APyFloat(
+            0, 5, 0b101, 5, 3
+        )  # Round down
+        assert APyFloat(0, 5, 0b10110, 5, 5).resize(5, 3) == APyFloat(
+            0, 5, 0b101, 5, 3
+        )  # Tie break, round down
+        assert APyFloat(0, 5, 0b10111, 5, 5).resize(5, 3) == APyFloat(
+            0, 5, 0b110, 5, 3
+        )  # Round up
+
+        # Rounding from 0.xx, negative sign
+        assert APyFloat(1, 5, 0b10000, 5, 5).resize(5, 3) == APyFloat(
+            1, 5, 0b100, 5, 3
+        )  # No rounding needed
+        assert APyFloat(1, 5, 0b10001, 5, 5).resize(5, 3) == APyFloat(
+            1, 5, 0b100, 5, 3
+        )  # Round down
+        assert APyFloat(1, 5, 0b10010, 5, 5).resize(5, 3) == APyFloat(
+            1, 5, 0b100, 5, 3
+        )  # Tie break, round down
+        assert APyFloat(1, 5, 0b10011, 5, 5).resize(5, 3) == APyFloat(
+            1, 5, 0b101, 5, 3
+        )  # Round up
+
+        # Rounding from 1.xx, negative sign
+        assert APyFloat(1, 5, 0b10100, 5, 5).resize(5, 3) == APyFloat(
+            1, 5, 0b101, 5, 3
+        )  # No rounding needed
+        assert APyFloat(1, 5, 0b10101, 5, 5).resize(5, 3) == APyFloat(
+            1, 5, 0b101, 5, 3
+        )  # Round down
+        assert APyFloat(1, 5, 0b10110, 5, 5).resize(5, 3) == APyFloat(
+            1, 5, 0b101, 5, 3
+        )  # Tie break, round down
         assert APyFloat(1, 5, 0b10111, 5, 5).resize(5, 3) == APyFloat(
             1, 5, 0b110, 5, 3
         )  # Round up

--- a/src/apyfloat.cc
+++ b/src/apyfloat.cc
@@ -181,6 +181,9 @@ APyFloat APyFloat::resize(
         case RoundingMode::RND_INF: // TIES_TO_AWAY
             B = G;
             break;
+        case RoundingMode::RND_ZERO: // TIES_TO_ZERO
+            B = G & T;
+            break;
         case RoundingMode::JAM:
             throw NotImplementedException(
                 "APyFloat: rounding mode jamming has not been implemented."

--- a/src/apyfloat.cc
+++ b/src/apyfloat.cc
@@ -160,8 +160,9 @@ APyFloat APyFloat::resize(
             T,   // Sticky bit, logical OR of all the bits after the guard bit
             B;   // Rounding bit to add to LSB
 
-        G = (prev_man >> (std::abs(man_bits_delta) - 1)) & 1;
-        T = (prev_man & ((1ULL << (std::abs(man_bits_delta) - 1)) - 1)) != 0;
+        const man_t bits_to_discard = std::abs(man_bits_delta);
+        G = (prev_man >> (bits_to_discard - 1)) & 1;
+        T = (prev_man & ((1ULL << (bits_to_discard - 1)) - 1)) != 0;
 
         switch (rounding_mode.value_or(get_rounding_mode())) {
         case RoundingMode::TRN_INF: // TO_POSITIVE
@@ -185,9 +186,20 @@ APyFloat APyFloat::resize(
             B = G & T;
             break;
         case RoundingMode::JAM:
-            throw NotImplementedException(
-                "APyFloat: rounding mode jamming has not been implemented."
-            );
+            B = 0;
+            new_man |= 1;
+            break;
+        case RoundingMode::STOCHASTIC_WEIGHTED: {
+            const man_t trailing_bits = prev_man & ((1ULL << bits_to_discard) - 1);
+            const man_t weight = random_number() & ((1ULL << bits_to_discard) - 1);
+            // Since the weight won't be greater than the discarded bits,
+            // this will never round an already exact number.
+            B = (trailing_bits + weight) >> bits_to_discard;
+        } break;
+        case RoundingMode::STOCHASTIC_EQUAL:
+            // Only perform the rounding if the result is not exact.
+            B = (G || T) ? random_number() & 1 : 0;
+            break;
         default:
             throw NotImplementedException("APyFloat: Unknown rounding mode.");
         }

--- a/src/apytypes_common.h
+++ b/src/apytypes_common.h
@@ -68,19 +68,32 @@ public:
 
 class RoundingContext : public ContextManager {
 public:
-    RoundingContext(const RoundingMode& new_mode);
+    RoundingContext(
+        const RoundingMode& new_mode,
+        std::optional<std::uint64_t> new_seed = std::nullopt
+    );
     void enter_context() override;
     void exit_context() override;
 
 private:
     RoundingMode new_mode, prev_mode;
+    std::uint64_t new_seed, prev_seed;
 };
 
-// Set the global roudning mdoe
+// Set the global rounding mdoe
 void set_rounding_mode(RoundingMode mode);
 
 // Retrieve the global rounding mode
 RoundingMode get_rounding_mode();
+
+// Set the global seed for stochastic rounding
+void set_rounding_seed(std::uint64_t);
+
+// Get the global seed for stochastic rounding
+std::uint64_t get_rounding_seed();
+
+// Retreive a random 64-bit number
+std::uint64_t random_number();
 
 using exp_t = std::uint32_t;
 using man_t = std::uint64_t;

--- a/src/apytypes_context_wrapper.cc
+++ b/src/apytypes_context_wrapper.cc
@@ -25,12 +25,14 @@ void context_exit_handler(
 void bind_float_context(py::module& m)
 {
     py::class_<RoundingContext, ContextManager>(m, "RoundingContext")
-        .def(py::init<RoundingMode>(), py::arg("rounding_mode"))
+        .def(
+            py::init<RoundingMode, std::optional<std::uint64_t>>(),
+            py::arg("rounding_mode"),
+            py::arg("rounding_seed") = std::nullopt
+        )
+
         .def("__enter__", &context_enter_handler)
         .def("__exit__", &context_exit_handler);
-
-    m.def("set_rounding_mode", &set_rounding_mode);
-    m.def("get_rounding_mode", &get_rounding_mode);
 }
 
 void bind_accumulator_context(py::module& m)

--- a/src/apytypes_wrapper.cc
+++ b/src/apytypes_wrapper.cc
@@ -60,4 +60,6 @@ void bind_common(py::module& m)
 
     m.def("set_rounding_mode", &set_rounding_mode);
     m.def("get_rounding_mode", &get_rounding_mode);
+    m.def("set_rounding_seed", &set_rounding_seed);
+    m.def("get_rounding_seed", &get_rounding_seed);
 }


### PR DESCRIPTION
Adding support for the new rounding methods `TIES_ZERO`, `JAM`, `STOCHASTIC_WEIGHTED`, and `STOCHASTIC_EQUAL` in APyFloat:

* Ties-to-zero: Round to closest number but ties are rounded towards zero.
* Jamming: Truncate and force LSB to 1, also known as Von-Neumann rounding.
* Stochastic-weighted: rounds up with a probability proportional to the relative distance $(x-\lfloor x \rfloor)/(\lceil x \rceil - \lfloor x \rfloor)$.
* Stochastic-equal: rounds up and down with equal probability.

**(Note, stochasting-weighted doesn't truly work for addition and subtraction due  to the sticky bit that is used.)**

Two new functions are also added to the Python API: `set_rounding_seed` and `get_rounding_seed`.

Additionally, an optional argument is added to `RoundingContext` such that a seed can be provided, e.g.:
```python
with RoundingContext(RoundingMode.STOCHASTIC_EQUAL, 0x123546789):
    # Perform operations
```
An exception is raised if a seed is provided for a non-stochastic rounding mode.

[std::mt19937_64](https://cplusplus.com/reference/random/mt19937_64/) is used as random number generator, but is seeded upon program start up by [std::random_device](https://en.cppreference.com/w/cpp/numeric/random/random_device) so that each run will be different by default. 