### PR TITLE
AccumulatorContext support for APyFloatArray

### DIFF
--- a/lib/test/apyfloatarray/test_constructors.py
+++ b/lib/test/apyfloatarray/test_constructors.py
@@ -8,6 +8,8 @@ def test_constructor_raises():
         APyFloatArray([1], [5, 2], [4], 10, 10)
     with pytest.raises(RuntimeError, match="Inhomogeneous sequence"):
         APyFloatArray([1, 2], [5, 2], [4, "str"], 10, 10)
+    with pytest.raises(RuntimeError, match="Not.*implemented.*bias"):
+        APyFloatArray([1], [5], [4], 10, 10, 12)
 
 
 @pytest.mark.float_array
@@ -19,12 +21,12 @@ def test_explicit_constructor():
     assert arr.man_bits == 5
     assert arr.bias == 7  # Default when using 4 exponent bits
 
-    arr2d = APyFloatArray([[0, 1], [0, 1]], [[2, 3], [2, 3]], [[4, 5], [4, 5]], 6, 7, 8)
+    arr2d = APyFloatArray([[0, 1], [0, 1]], [[2, 3], [2, 3]], [[4, 5], [4, 5]], 6, 7)
     assert len(arr2d) == 2
     assert arr2d.shape == (2, 2)
     assert arr2d.exp_bits == 6
     assert arr2d.man_bits == 7
-    assert arr2d.bias == 8
+    assert arr2d.bias == 31  # Default for 6 bits
 
 
 @pytest.mark.float_array

--- a/lib/test/apyfloatarray/test_matmul.py
+++ b/lib/test/apyfloatarray/test_matmul.py
@@ -123,6 +123,21 @@ def test_matrix_multiplication_accumulator_context():
         man_bits=3,
     )
 
+    # Changing only the rounding mode will produce the same answer as the QuantizationContext
+    ans = None
+    with QuantizationContext(QuantizationMode.TO_POS):
+        ans = A @ B
+
+    with QuantizationContext(QuantizationMode.TO_NEG):
+        print(A @ B)
+
+    with AccumulatorContext(
+        exp_bits=4, man_bits=3, quantization=QuantizationMode.TO_POS
+    ):
+        print(ans)
+        print(A @ B)
+        assert ans.is_identical(A @ B)
+
     # Using more mantissa bits, the result will be the same
     with AccumulatorContext(
         exp_bits=4, man_bits=10, quantization=QuantizationMode.TIES_EVEN
@@ -146,38 +161,3 @@ def test_matrix_multiplication_accumulator_context():
 
     with AccumulatorContext(exp_bits=10, man_bits=3):
         assert (a @ b).is_identical(APyFloatArray.from_float([192], 4, 3))
-    # Truncating quantization mode
-    # with AccumulatorContext(int_bits=2, frac_bits=4, quantization=QuantizationMode.TRN):
-    #     assert (A @ B).is_identical(
-    #         APyFixedArray.from_float([[0.3125, 0.5000], [0.8125, 1.2500]], 6, 2)
-    #     )
-    # with AccumulatorContext(int_bits=2, frac_bits=3, quantization=QuantizationMode.TRN):
-    #     assert (A @ B).is_identical(
-    #         APyFixedArray.from_float([[0.2500, 0.5000], [0.7500, 1.2500]], 5, 2)
-    #     )
-    # with AccumulatorContext(int_bits=2, frac_bits=2, quantization=QuantizationMode.TRN):
-    #     assert (A @ B).is_identical(
-    #         APyFixedArray.from_float([[0.0000, 0.5000], [0.7500, 1.2500]], 4, 2)
-    #     )
-    # with AccumulatorContext(int_bits=2, frac_bits=1, quantization=QuantizationMode.TRN):
-    #     assert (A @ B).is_identical(
-    #         APyFixedArray.from_float([[0.0000, 0.0000], [0.5000, 1.0000]], 3, 2)
-    #     )
-
-    # # Quantization, ties to plus infinity quantization
-    # with AccumulatorContext(int_bits=2, frac_bits=4, quantization=QuantizationMode.RND):
-    #     assert (A @ B).is_identical(
-    #         APyFixedArray.from_float([[0.3125, 0.5000], [0.8125, 1.2500]], 6, 2)
-    #     )
-    # with AccumulatorContext(int_bits=2, frac_bits=3, quantization=QuantizationMode.RND):
-    #     assert (A @ B).is_identical(
-    #         APyFixedArray.from_float([[0.3750, 0.5000], [0.875, 1.2500]], 5, 2)
-    #     )
-    # with AccumulatorContext(int_bits=2, frac_bits=2, quantization=QuantizationMode.RND):
-    #     assert (A @ B).is_identical(
-    #         APyFixedArray.from_float([[0.5000, 0.5000], [0.7500, 1.2500]], 4, 2)
-    #     )
-    # with AccumulatorContext(int_bits=2, frac_bits=1, quantization=QuantizationMode.RND):
-    #     assert (A @ B).is_identical(
-    #         APyFixedArray.from_float([[0.0000, 1.0000], [1.0000, 1.5000]], 3, 2)
-    #     )

--- a/lib/test/apyfloatarray/test_methods.py
+++ b/lib/test/apyfloatarray/test_methods.py
@@ -13,7 +13,6 @@ def test_is_identical():
     assert not a.is_identical(APyFloatArray([1], [2], [3], 5, 5))
     assert not a.is_identical(APyFloatArray([1], [2], [3], 4, 6))
     assert not a.is_identical(APyFloatArray([1], [2], [6], 4, 6))  # Same value
-    assert not a.is_identical(APyFloatArray([1], [2], [3], 4, 5, 9))
 
 
 @pytest.mark.float_array

--- a/lib/test/apyfloatarray/test_representation.py
+++ b/lib/test/apyfloatarray/test_representation.py
@@ -4,10 +4,10 @@ from apytypes import APyFloatArray
 
 @pytest.mark.float_array
 def test_repr():
-    arr = APyFloatArray([], [], [], 6, 7, 8)
+    arr = APyFloatArray([], [], [], 6, 7)
     assert (
         repr(arr)
-        == "APyFloatArray([], [], [], shape=(0), exp_bits=6, man_bits=7, bias=8)"
+        == "APyFloatArray([], [], [], shape=(0), exp_bits=6, man_bits=7, bias=31)"
     )
 
     arr = APyFloatArray([1], [5], [3], 5, 2)

--- a/lib/test/test_contextmanagers.py
+++ b/lib/test/test_contextmanagers.py
@@ -30,6 +30,19 @@ class TestAccumulatorContext:
             with AccumulatorContext(bits=5, int_bits=2, exp_bits=5, man_bits=2):
                 pass
 
+    def test_with_quantization_context(self):
+        """Test that the AccumulatorContext interacts correctly with the QuanizationContext."""
+        with QuantizationContext(QuantizationMode.TO_POS):
+            assert apytypes.get_quantization_mode() == QuantizationMode.TO_POS
+
+            with AccumulatorContext(exp_bits=5, man_bits=3):
+                assert apytypes.get_quantization_mode() == QuantizationMode.TO_POS
+
+            with AccumulatorContext(
+                exp_bits=5, man_bits=3, quantization=QuantizationMode.TO_NEG
+            ):
+                assert apytypes.get_quantization_mode() == QuantizationMode.TO_POS
+
 
 class TestQuantizationContext:
     """

--- a/lib/test/test_contextmanagers.py
+++ b/lib/test/test_contextmanagers.py
@@ -1,6 +1,34 @@
 import apytypes
-from apytypes import QuantizationContext, QuantizationMode
+from apytypes import QuantizationContext, QuantizationMode, AccumulatorContext
 import pytest
+
+
+class TestAccumulatorContext:
+    """
+    This test class doesn't test if the accumulation itself works,
+    just that the context manager acts correctly.
+    """
+
+    def test_raises(self):
+        with pytest.raises(ValueError, match="Invalid.*parameters"):
+            with AccumulatorContext():
+                pass
+
+        with pytest.raises(TypeError):  # keyword only
+            with AccumulatorContext(5, 2):
+                pass
+
+        with AccumulatorContext(bits=5, int_bits=2):  # should not thow
+            pass
+
+        with AccumulatorContext(exp_bits=5, man_bits=2):  # should not thow
+            pass
+
+        with pytest.raises(
+            ValueError, match="Invalid.*parameters"
+        ):  # mixing APyFixed and APyFloat parameters not allowed
+            with AccumulatorContext(bits=5, int_bits=2, exp_bits=5, man_bits=2):
+                pass
 
 
 class TestQuantizationContext:

--- a/src/apyfloatarray.h
+++ b/src/apyfloatarray.h
@@ -103,6 +103,7 @@ public:
     enum class ArithmeticOperation { ADDITION, SUBTRACTION, MULTIPLICATION, DIVISION };
 
 private:
+    APyFloatArray() = default;
     APyFloatArray(
         const std::vector<std::size_t>& shape,
         exp_t exp_bits,

--- a/src/apytypes_common.cc
+++ b/src/apytypes_common.cc
@@ -101,6 +101,7 @@ AccumulatorContext::AccumulatorContext(
     }
 
     AccumulatorOption new_mode = get_accumulator_mode().value_or(AccumulatorOption {});
+    QuantizationMode acc_quantization;
 
     if (any_apfixed_parameters) {
         // Sanitize the input bits
@@ -113,11 +114,10 @@ AccumulatorContext::AccumulatorContext(
         // Store the previous accumulator mode
         previous_mode = global_accumulator_option;
 
-        // Set the current mode
-        QuantizationMode acc_quantization
-            = quantization.value_or(QuantizationMode::TRN);
+        acc_quantization = quantization.value_or(QuantizationMode::TRN);
         OverflowMode acc_overflow_mode = overflow.value_or(OverflowMode::WRAP);
 
+        // Set the current mode
         new_mode.bits = acc_bits;
         new_mode.int_bits = acc_int_bits;
         new_mode.quantization = acc_quantization;
@@ -126,8 +126,10 @@ AccumulatorContext::AccumulatorContext(
         new_mode.exp_bits = _exp_bits.value();
         new_mode.man_bits = _man_bits.value();
         new_mode.bias = _bias.value_or(APyFloat::ieee_bias(new_mode.exp_bits));
+        acc_quantization = quantization.value_or(get_quantization_mode());
     }
 
+    new_mode.quantization = acc_quantization;
     current_mode = new_mode;
 }
 

--- a/src/apytypes_common.h
+++ b/src/apytypes_common.h
@@ -121,6 +121,11 @@ struct AccumulatorOption {
     int int_bits;
     QuantizationMode quantization;
     OverflowMode overflow;
+
+    // APyFloat specific options
+    int exp_bits;
+    int man_bits;
+    exp_t bias;
 };
 
 // Accumulator context
@@ -131,7 +136,10 @@ public:
         std::optional<int> int_bits = std::nullopt,
         std::optional<int> frac_bits = std::nullopt,
         std::optional<QuantizationMode> quantization = std::nullopt,
-        std::optional<OverflowMode> overflow = std::nullopt
+        std::optional<OverflowMode> overflow = std::nullopt,
+        std::optional<std::uint8_t> = std::nullopt,
+        std::optional<std::uint8_t> = std::nullopt,
+        std::optional<exp_t> = std::nullopt
     );
     void enter_context() override;
     void exit_context() override;

--- a/src/apytypes_context_wrapper.cc
+++ b/src/apytypes_context_wrapper.cc
@@ -44,12 +44,19 @@ void bind_accumulator_context(py::module& m)
                 std::optional<int>,
                 std::optional<int>,
                 std::optional<QuantizationMode>,
-                std::optional<OverflowMode>>(),
+                std::optional<OverflowMode>,
+                std::optional<std::uint8_t>,
+                std::optional<std::uint8_t>,
+                std::optional<exp_t>>(),
+            py::kw_only(), // All parameters are keyword only
             py::arg("bits") = std::nullopt,
             py::arg("int_bits") = std::nullopt,
             py::arg("frac_bits") = std::nullopt,
             py::arg("quantization") = std::nullopt,
-            py::arg("overflow") = std::nullopt
+            py::arg("overflow") = std::nullopt,
+            py::arg("exp_bits") = std::nullopt,
+            py::arg("man_bits") = std::nullopt,
+            py::arg("bias") = std::nullopt
         )
         .def("__enter__", &context_enter_handler)
         .def("__exit__", &context_exit_handler);


### PR DESCRIPTION
This PR adds support for `AccumulatorContext` for `APyFloatArray`.

The same class is used for both APyFixedArray and APyFloatArray. Keyword only arguments are now enforced to handle this, and a `ValueError` exception is thrown if one tries to mix the parameters.

Note, the way `AccumulatorContext` interracts with `QuantizationContext` is by `AccumulatorContext` only changes the quantization mode for matmul. However I'm not if this is the desired behavior, or if `AccumulatorContext` should only change the mode for other operations. What do you guys think? My impression is that `AccumulatorContext` should change the characteristics of the accumulator.

Example:
```Python
with QuantizationContext(QuantizationMode.TO_POS):
    with AccumulatorContext(exp_bits=5, man_bits=3, quantization=QuantizationMode.TO_NEG):
        x + y # done with TO_POS
        A @ B # done with TO_NEG
        
with QuantizationContext(QuantizationMode.TO_POS):
    x + y # done with TO_POS
    A @ B # done with TO_POS
```