### PR TITLE
src: optimizations to APyFixedArray::matmul()

### DIFF
--- a/src/apybuffer.h
+++ b/src/apybuffer.h
@@ -76,11 +76,13 @@ protected:
     // result in loss of data.
     void buffer_resize(const std::vector<std::size_t> shape, std::size_t itemsize)
     {
-        _itemsize = itemsize;
-        _shape = shape;
-        _strides = strides_from_shape<T>(shape, itemsize);
-        _data.resize(itemsize * fold_shape(shape));
-        _ndim = shape.size();
+        if ((_itemsize != itemsize) || (_shape != shape)) {
+            _itemsize = itemsize;
+            _shape = shape;
+            _strides = strides_from_shape<T>(shape, itemsize);
+            _data.resize(itemsize * fold_shape(shape));
+            _ndim = shape.size();
+        }
     }
 
     std::size_t _itemsize;             // Size of item (in number of objects `T`)

--- a/src/apyfixed.cc
+++ b/src/apyfixed.cc
@@ -835,7 +835,9 @@ void APyFixed::cast_correct_wl(
         std::fill(it_begin + vector_size(), it_end, is_negative() ? mp_limb_t(-1) : 0);
     }
     int new_frac_bits = new_bits - new_int_bits;
-    limb_vector_lsl(it_begin, it_end, new_frac_bits - frac_bits());
+    if (new_frac_bits - frac_bits() >= 0) {
+        limb_vector_lsl(it_begin, it_end, new_frac_bits - frac_bits());
+    }
 }
 
 void APyFixed::_quantize(

--- a/src/apyfixed.h
+++ b/src/apyfixed.h
@@ -64,9 +64,6 @@ public:
     //! No default constructed APyFixed types
     APyFixed() = delete;
 
-    //! Constructor: initialize from other APyFixed
-    APyFixed(const APyFixed& other);
-
     //! Constructor: construct from a Python arbitrary long integer object and
     //! optionally set bit specifiers
     explicit APyFixed(
@@ -81,6 +78,9 @@ public:
      * ****************************************************************************** */
 
 public:
+    //! Constructor: initialize from other APyFixed
+    APyFixed(const APyFixed& other);
+
     //! Constructor: specify only size, and zero data on construction
     explicit APyFixed(int bits, int int_bits);
 

--- a/src/apyfixedarray.h
+++ b/src/apyfixedarray.h
@@ -223,7 +223,8 @@ private:
         APyFixedArray& hadamard_scratch,      // scratch: hadamard product
         std::vector<mp_limb_t>& prod_scratch, // scratch: product result
         std::vector<mp_limb_t>& op1_scratch,  // scratch: absolute value operand 1
-        std::vector<mp_limb_t>& op2_scratch   // scratch: absolute value operand 2
+        std::vector<mp_limb_t>& op2_scratch,  // scratch: absolute value operand 2
+        std::optional<AccumulatorOption> mode // optional accumulation mode
     ) const;
 
     /*!
@@ -231,14 +232,24 @@ private:
      * the shape of `*this` and `rhs` have been checked to match a 2D matrix-matrix or
      * matrix-vector multiplication. Anything else is undefined behaviour.
      */
-    APyFixedArray _checked_2d_matmul(const APyFixedArray& rhs) const;
+    APyFixedArray _checked_2d_matmul(
+        const APyFixedArray& rhs,             // rhs
+        std::optional<AccumulatorOption> mode // optional accumulation mode
+    ) const;
 
     APyFixedArray _cast_correct_wl(int new_bits, int new_int_bits) const;
 
-    //! The internal cast method used to place cast data onto a vector
+    /*!
+     * The internal cast method used to place cast data onto a pair of iterators.
+     * See `APyFixedArray::cast` for example usage.
+     * Importantly:
+     *   * The `caster` must be an `APyFixed` object with same bit specifier as `*this`
+     *   * If `new_bits` > `_bits`, the output must contain pad limbs
+     */
     void _cast(
         std::vector<mp_limb_t>::iterator it_begin,
         std::vector<mp_limb_t>::iterator it_end,
+        APyFixed& caster,
         int new_bits,
         int new_int_bits,
         QuantizationMode quantization,

--- a/src/apyfixedarray.h
+++ b/src/apyfixedarray.h
@@ -197,10 +197,12 @@ private:
      * *                          Private member functions                          * *
      * ****************************************************************************** */
 
-    //! Perform hadamard product between `*this` and `rhs` using scratch memories. Store
-    //! the result in the vector pointed to by `res_begin`. This method assums the the
-    //! shape of `*this` and `rhs` are equally long. Anyghing else is undefined
-    //! behaviour.
+    /*!
+     * Perform hadamard product between `*this` and `rhs` using scratch memories. Store
+     * the result in the vector pointed to by `res_begin`. This method assumes that the
+     * shape of `*this` and `rhs` are equally long. Anyghing else is undefined
+     * behaviour.
+     */
     void _checked_hadamard_product(
         const APyFixedArray& rhs,
         std::vector<mp_limb_t>::iterator res_out, // output iterator
@@ -209,10 +211,20 @@ private:
         std::vector<mp_limb_t>& op2_abs           // scratch: absolute value operand 2
     ) const;
 
-    //! Evaluate the inner between two vectors. This method assumes that the the shape
-    //! of both `*this` and `rhs` are equally long. Anything else is undefined
-    //! behaviour.
-    APyFixedArray _checked_inner_product(const APyFixedArray& rhs) const;
+    /*!
+     * Evaluate the inner between `*this* and `rhs` using scratch memories. Store the
+     * result in the vector pointed to by `res_begin`. This method assumes that the the
+     * shape of both `*this` and `rhs` are equally long. Anything else is undefined
+     * behaviour.
+     */
+    void _checked_inner_product(
+        const APyFixedArray& rhs,         // rhs
+        APyFixedArray& result,            // result
+        APyFixedArray& hadamard_tmp,      // scratch: hadamard product
+        std::vector<mp_limb_t>& prod_tmp, // scratch: product result
+        std::vector<mp_limb_t>& op1_abs,  // scratch: absolute value operand 1
+        std::vector<mp_limb_t>& op2_abs   // scratch: absolute value operand 2
+    ) const;
 
     //! Evaluate the matrix product between two 2D matrices. This method assumes that
     //! the shape of `*this` and `rhs` have been checked to match a 2D matrix-matrix or
@@ -220,6 +232,16 @@ private:
     APyFixedArray _checked_2d_matmul(const APyFixedArray& rhs) const;
 
     APyFixedArray _cast_correct_wl(int new_bits, int new_int_bits) const;
+
+    //! The internal cast method used to place cast data onto a vector
+    void _cast(
+        std::vector<mp_limb_t>::iterator it_begin,
+        std::vector<mp_limb_t>::iterator it_end,
+        int new_bits,
+        int new_int_bits,
+        QuantizationMode quantization,
+        OverflowMode overflow
+    ) const;
 };
 
 #endif // _APYFIXED_ARRAY_H

--- a/src/apyfixedarray.h
+++ b/src/apyfixedarray.h
@@ -171,11 +171,11 @@ public:
     ) const;
 
     /*!
-     * Test if two `APyFixedArray` objects are identical. Two `APyFixedArray` objects
-     * are considered identical if, and only if:
+     * Test if `*this` is identical to another `APyFixedArray`. Two `APyFixedArray`
+     * objects are considered identical if, and only if:
      *   * They represent exatly the same tensor shape
      *   * They store the exact same fixed-point values in all tensor elements
-     *   * They have the exact same bit format (`exp_bits`, `man_bits`, and `bias`)
+     *   * They have the exact same bit format (`bits`, `int_bits`, and `frac_bits`)
      */
     bool is_identical(const APyFixedArray& other) const;
 
@@ -204,31 +204,33 @@ private:
      * behaviour.
      */
     void _checked_hadamard_product(
-        const APyFixedArray& rhs,
+        const APyFixedArray& rhs,                 // rhs
         std::vector<mp_limb_t>::iterator res_out, // output iterator
-        std::vector<mp_limb_t>& prod_tmp,         // scratch: product result
-        std::vector<mp_limb_t>& op1_abs,          // scratch: absolute value operand 1
-        std::vector<mp_limb_t>& op2_abs           // scratch: absolute value operand 2
+        std::vector<mp_limb_t>& prod_scratch,     // scratch: product result
+        std::vector<mp_limb_t>& op1_scratch,      // scratch: absolute value operand 1
+        std::vector<mp_limb_t>& op2_scratch       // scratch: absolute value operand 2
     ) const;
 
     /*!
-     * Evaluate the inner between `*this* and `rhs` using scratch memories. Store the
-     * result in the vector pointed to by `res_begin`. This method assumes that the the
-     * shape of both `*this` and `rhs` are equally long. Anything else is undefined
-     * behaviour.
+     * Evaluate the inner product between `*this` and `rhs` using scratch memories.
+     * Store the result in the vector pointed to by `res_begin`. This method assumes
+     * that the the shape of both `*this` and `rhs` are equally long. Anything else is
+     * undefined behaviour.
      */
     void _checked_inner_product(
-        const APyFixedArray& rhs,         // rhs
-        APyFixedArray& result,            // result
-        APyFixedArray& hadamard_tmp,      // scratch: hadamard product
-        std::vector<mp_limb_t>& prod_tmp, // scratch: product result
-        std::vector<mp_limb_t>& op1_abs,  // scratch: absolute value operand 1
-        std::vector<mp_limb_t>& op2_abs   // scratch: absolute value operand 2
+        const APyFixedArray& rhs,             // rhs
+        APyFixedArray& result,                // result
+        APyFixedArray& hadamard_scratch,      // scratch: hadamard product
+        std::vector<mp_limb_t>& prod_scratch, // scratch: product result
+        std::vector<mp_limb_t>& op1_scratch,  // scratch: absolute value operand 1
+        std::vector<mp_limb_t>& op2_scratch   // scratch: absolute value operand 2
     ) const;
 
-    //! Evaluate the matrix product between two 2D matrices. This method assumes that
-    //! the shape of `*this` and `rhs` have been checked to match a 2D matrix-matrix or
-    //! matrix-vector multiplication. Anything else is undefined behaviour.
+    /*!
+     * Evaluate the matrix product between two 2D matrices. This method assumes that
+     * the shape of `*this` and `rhs` have been checked to match a 2D matrix-matrix or
+     * matrix-vector multiplication. Anything else is undefined behaviour.
+     */
     APyFixedArray _checked_2d_matmul(const APyFixedArray& rhs) const;
 
     APyFixedArray _cast_correct_wl(int new_bits, int new_int_bits) const;

--- a/src/apyfixedarray.h
+++ b/src/apyfixedarray.h
@@ -169,6 +169,7 @@ public:
         OverflowMode overflow = OverflowMode::WRAP,
         std::optional<int> frac_bits = std::nullopt
     ) const;
+
     /*!
      * Test if two `APyFixedArray` objects are identical. Two `APyFixedArray` objects
      * are considered identical if, and only if:
@@ -195,6 +196,18 @@ private:
     /* ****************************************************************************** *
      * *                          Private member functions                          * *
      * ****************************************************************************** */
+
+    //! Perform hadamard product between `*this` and `rhs` using scratch memories. Store
+    //! the result in the vector pointed to by `res_begin`. This method assums the the
+    //! shape of `*this` and `rhs` are equally long. Anyghing else is undefined
+    //! behaviour.
+    void _checked_hadamard_product(
+        const APyFixedArray& rhs,
+        std::vector<mp_limb_t>::iterator res_out, // output iterator
+        std::vector<mp_limb_t>& prod_tmp,         // scratch: product result
+        std::vector<mp_limb_t>& op1_abs,          // scratch: absolute value operand 1
+        std::vector<mp_limb_t>& op2_abs           // scratch: absolute value operand 2
+    ) const;
 
     //! Evaluate the inner between two vectors. This method assumes that the the shape
     //! of both `*this` and `rhs` are equally long. Anything else is undefined

--- a/src/apyfixedarray_wrapper.cc
+++ b/src/apyfixedarray_wrapper.cc
@@ -139,6 +139,7 @@ void bind_fixed_array(py::module& m)
             },
             py::is_operator()
         )
+        //.def(py::self - APyFixed(1,0))
         .def(
             "__sub__",
             [](const APyFixedArray& a, const APyFixed& b) { return a - b; },


### PR DESCRIPTION
### Benchmark:
```python
from apytypes import APyFixedArray

a = APyFixedArray([range(100), range(100), range(100)], bits=32, int_bits=16)
b = a.T

for _ in range(10000):
    c = b @ a
```

### Before:
```
❯ time python3 bench_matmul.py
python3 bench_matmul.py  22,76s user 0,00s system 99% cpu 22,766 total
```

### After:
```
❯ time python3 bench_matmul.py
python3 bench_matmul.py  2,78s user 0,00s system 99% cpu 2,787 total
```