### PR TITLE
src: fix memory access bug in APyFixed::_cast()

### DIFF
--- a/lib/test/apyfixed/test_quantization.py
+++ b/lib/test/apyfixed/test_quantization.py
@@ -200,6 +200,11 @@ def test_stochastic_equal():
     pass
 
 
+def test_huge_narrowing_cast():
+    mode = QuantizationMode.RND
+    assert float(APyFixed.from_float(-0.75, 1000, 500).cast(5, 1, mode)) == -0.75
+
+
 # All of the non-implemented Python quantization methods for APyFixed
 @pytest.mark.parametrize(
     "mode",

--- a/src/apyfixed.cc
+++ b/src/apyfixed.cc
@@ -763,7 +763,8 @@ APyFixed APyFixed::cast(
     int new_bits = bits_from_optional(bits, int_bits, frac_bits);
     int new_int_bits = int_bits_from_optional(bits, int_bits, frac_bits);
 
-    APyFixed result(new_bits, new_int_bits);
+    // Result that temporarily can hold all the necessary bits
+    APyFixed result(std::max(new_bits, _bits), std::max(new_int_bits, _int_bits));
     _cast(
         result._data.begin(), // output start
         result._data.end(),   // output sentinel
@@ -773,6 +774,9 @@ APyFixed APyFixed::cast(
         overflow
     );
 
+    result._bits = new_bits;
+    result._int_bits = new_int_bits;
+    result._data.resize(bits_to_limbs(new_bits));
     return result;
 }
 


### PR DESCRIPTION
Fix a memory bug where a huge narrowing (multiple limb narrowing) during a `APyFixed::_cast` can access data out of bounds. 