### PR TITLE
APyFixed: specialize arithmetic when result fits single limb

### DIFF
--- a/lib/test/apyfixed/test_arithmetic.py
+++ b/lib/test/apyfixed/test_arithmetic.py
@@ -84,6 +84,16 @@ def test_float_comparison():
     assert APyFixed.from_float(-1.0, 256, 128) >= -3.0
 
 
+def test_narrow_add_sub():
+    for a_bits in range(10, 30):
+        for b_bits in range(10, 30):
+            a = APyFixed.from_float(a_bits + b_bits, bits=a_bits + 20, int_bits=b_bits)
+            b = APyFixed.from_float(a_bits + b_bits, bits=b_bits + 20, int_bits=a_bits)
+            assert float(a + b) == float(2 * (a_bits + b_bits))
+            assert float(a - b) == 0.0
+            assert float(a * b) == float(a_bits + b_bits) ** 2
+
+
 def test_wide_operations():
     """
     Tests for wider additions and subtractions


### PR DESCRIPTION
### Benchmark
```python
from apytypes import APyFixed
from time import time

a = APyFixed(123456, bits=24, int_bits=12)
b = APyFixed(654321, bits=25, int_bits=12)

t1 = time()
for i in range(1000000):
    c = a + b
t2 = time()
print(f"Add: {(t2 - t1)*1e3} ms")

t1 = time()
for i in range(1000000):
    c = a - b
t2 = time()
print(f"Sub: {(t2 - t1)*1e3} ms")

t1 = time()
for i in range(1000000):
    c = a * b
t2 = time()
print(f"Mul: {(t2 - t1)*1e3} ms")
```

### Before commit
```
Add: 209.1515064239502 ms
Sub: 210.9079360961914 ms
Mul: 237.6255989074707 ms
```

### After commit
```
Add: 178.8461208343506 ms
Sub: 179.54015731811523 ms
Mul: 167.3893928527832 ms
```