### PR TITLE
ci: add PyPi publishing workflow

### DIFF
--- a/.github/workflows/publish-test-pypi.yml
+++ b/.github/workflows/publish-test-pypi.yml
@@ -32,8 +32,7 @@ jobs:
 
   # Official publication to PyPi (on new tags)
   publish-to-pypi:
-    name: >-
-      Publish Python 🐍 distribution 📦 to PyPI
+    name: Publish to PyPI 📦
     if: startsWith(github.ref, 'refs/tags/')  # only publish to PyPI on tag pushes
     needs:
     - build
@@ -54,51 +53,8 @@ jobs:
     - name: Publish distribution 📦 to PyPI
       uses: pypa/gh-action-pypi-publish@release/v1
 
-  github-release:
-    name: >-
-      Sign the Python 🐍 distribution 📦 with Sigstore
-      and upload them to GitHub Release
-    needs:
-    - publish-to-pypi
-    runs-on: ubuntu-latest
-
-    permissions:
-      contents: write  # IMPORTANT: mandatory for making GitHub Releases
-      id-token: write  # IMPORTANT: mandatory for sigstore
-
-    steps:
-    - name: Download all the dists
-      uses: actions/download-artifact@v4
-      with:
-        name: python-package-distributions
-        path: dist/
-    - name: Sign the dists with Sigstore
-      uses: sigstore/gh-action-sigstore-python@v1.2.3
-      with:
-        inputs: >-
-          ./dist/*.tar.gz
-          ./dist/*.whl
-    - name: Create GitHub Release
-      env:
-        GITHUB_TOKEN: ${{ github.token }}
-      run: >-
-        gh release create
-        '${{ github.ref_name }}'
-        --repo '${{ github.repository }}'
-        --notes ""
-    - name: Upload artifact signatures to GitHub Release
-      env:
-        GITHUB_TOKEN: ${{ github.token }}
-      # Upload to GitHub Release using the `gh` CLI.
-      # `dist/` contains the built packages, and the
-      # sigstore-produced signatures and certificates.
-      run: >-
-        gh release upload
-        '${{ github.ref_name }}' dist/**
-        --repo '${{ github.repository }}'
-
   publish-to-testpypi:
-    name: Publish Python 🐍 distribution 📦 to TestPyPI
+    name: Publish to TestPyPI 📦
     needs:
     - build
     runs-on: ubuntu-latest

--- a/.github/workflows/publish-test-pypi.yml
+++ b/.github/workflows/publish-test-pypi.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: ["ubuntu-latest", "macos-14", "windows-latest"] # TODO: "macos-12"
+        os: ["ubuntu-latest", "macos-12", "macos-14", "windows-latest"]
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/publish-test-pypi.yml
+++ b/.github/workflows/publish-test-pypi.yml
@@ -52,27 +52,3 @@ jobs:
         merge-multiple: true
     - name: Publish distribution 📦 to PyPI
       uses: pypa/gh-action-pypi-publish@release/v1
-
-  publish-to-testpypi:
-    name: Publish to TestPyPI 📦
-    needs:
-    - build
-    runs-on: ubuntu-latest
-    environment:
-      name: testpypi
-      url: https://test.pypi.org/p/apytypes/
-    permissions:
-      id-token: write  # IMPORTANT: mandatory for trusted publishing
-
-    steps:
-    - name: Download all the wheels
-      uses: actions/download-artifact@v4
-      with:
-        pattern: apytypes-wheels-*
-        path: dist
-        merge-multiple: true
-    - name: Publish distribution 📦 to TestPyPI
-      uses: pypa/gh-action-pypi-publish@release/v1
-      with:
-        repository-url: https://test.pypi.org/legacy/
-        skip-existing: true  # Skip if already published this exact version

--- a/.github/workflows/publish-test-pypi.yml
+++ b/.github/workflows/publish-test-pypi.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: ["ubuntu-latest", "macos-14"] # TODO: "macos-12", "windows-latest"
+        os: ["ubuntu-latest", "macos-14", "windows-latest"] # TODO: "macos-12"
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/publish-test-pypi.yml
+++ b/.github/workflows/publish-test-pypi.yml
@@ -5,30 +5,30 @@ on: push
 
 jobs:
 
-  # Building job-step
+  # Wheel-building job-step using cibuildwheel
   build:
-    name: Build distribution 📦
-    runs-on: ubuntu-latest
+    name: Build wheel ${{ matrix.os }} 📦
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: ["ubuntu-latest"] # TODO: "windows-latest", "macos-12", "macos14"
 
     steps:
-    - uses: actions/checkout@v4
-    - name: Set up Python
-      uses: actions/setup-python@v4
-      with:
-        python-version: "3.x"
-    - name: Install pypa/build
-      run: >-
-        python3 -m
-        pip install
-        build
-        --user
-    - name: Build a binary wheel and a source tarball
-      run: python3 -m build
-    - name: Store the distribution packages
-      uses: actions/upload-artifact@v3
-      with:
-        name: python-package-distributions
-        path: dist/
+      - uses: actions/checkout@v4
+      - uses: ilammy/msvc-dev-cmd@v1  # Active MSVC environment on Windows virtual env
+      - uses: actions/setup-python@v3
+
+      - name: Install cibuildwheel
+        run: python -m pip install cibuildwheel==2.17.0
+
+      - name: Build wheels
+        run: python -m cibuildwheel --output-dir wheelhouse
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: apytypes-wheels-${{ matrix.os }}-${{ strategy.job-index }}
+          path: ./wheelhouse/*.whl
+          if-no-files-found: error
 
 
   # Official publication to PyPi (on new tags)
@@ -41,13 +41,13 @@ jobs:
     runs-on: ubuntu-latest
     environment:
       name: pypi
-      url: https://pypi.org/p/<package-name>  # Replace <package-name> with your PyPI project name
+      url: https://pypi.org/p/apytypes/
     permissions:
       id-token: write  # IMPORTANT: mandatory for trusted publishing
 
     steps:
     - name: Download all the dists
-      uses: actions/download-artifact@v3
+      uses: actions/download-artifact@v4
       with:
         name: python-package-distributions
         path: dist/
@@ -68,7 +68,7 @@ jobs:
 
     steps:
     - name: Download all the dists
-      uses: actions/download-artifact@v3
+      uses: actions/download-artifact@v4
       with:
         name: python-package-distributions
         path: dist/
@@ -102,20 +102,19 @@ jobs:
     needs:
     - build
     runs-on: ubuntu-latest
-
     environment:
       name: testpypi
-      url: https://test.pypi.org/p/<package-name>
-
+      url: https://test.pypi.org/p/apytypes/
     permissions:
       id-token: write  # IMPORTANT: mandatory for trusted publishing
 
     steps:
     - name: Download all the dists
-      uses: actions/download-artifact@v3
+      uses: actions/download-artifact@v4
       with:
-        name: python-package-distributions
-        path: dist/
+        pattern: apytypes-wheels-*
+        path: dist
+        merge-multiple: true
     - name: Publish distribution 📦 to TestPyPI
       uses: pypa/gh-action-pypi-publish@release/v1
       with:

--- a/.github/workflows/publish-test-pypi.yml
+++ b/.github/workflows/publish-test-pypi.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: ["ubuntu-latest"] # TODO: "windows-latest", "macos-12", "macos14"
+        os: ["ubuntu-latest", "macos-14"] # TODO: "macos-12", "windows-latest"
 
     steps:
       - uses: actions/checkout@v4
@@ -30,7 +30,6 @@ jobs:
           path: ./wheelhouse/*.whl
           if-no-files-found: error
 
-
   # Official publication to PyPi (on new tags)
   publish-to-pypi:
     name: >-
@@ -46,11 +45,12 @@ jobs:
       id-token: write  # IMPORTANT: mandatory for trusted publishing
 
     steps:
-    - name: Download all the dists
+    - name: Download all the wheels
       uses: actions/download-artifact@v4
       with:
-        name: python-package-distributions
-        path: dist/
+        pattern: apytypes-wheels-*
+        path: dist
+        merge-multiple: true
     - name: Publish distribution 📦 to PyPI
       uses: pypa/gh-action-pypi-publish@release/v1
 
@@ -109,7 +109,7 @@ jobs:
       id-token: write  # IMPORTANT: mandatory for trusted publishing
 
     steps:
-    - name: Download all the dists
+    - name: Download all the wheels
       uses: actions/download-artifact@v4
       with:
         pattern: apytypes-wheels-*

--- a/.github/workflows/publish-test-pypi.yml
+++ b/.github/workflows/publish-test-pypi.yml
@@ -1,0 +1,122 @@
+name: Publish APyTypes to PyPi and TestPyPi
+
+# This workflow runs on all pushes, which is needed to capture tag pushes
+on: push
+
+jobs:
+
+  # Building job-step
+  build:
+    name: Build distribution 📦
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+    - name: Set up Python
+      uses: actions/setup-python@v4
+      with:
+        python-version: "3.x"
+    - name: Install pypa/build
+      run: >-
+        python3 -m
+        pip install
+        build
+        --user
+    - name: Build a binary wheel and a source tarball
+      run: python3 -m build
+    - name: Store the distribution packages
+      uses: actions/upload-artifact@v3
+      with:
+        name: python-package-distributions
+        path: dist/
+
+
+  # Official publication to PyPi (on new tags)
+  publish-to-pypi:
+    name: >-
+      Publish Python 🐍 distribution 📦 to PyPI
+    if: startsWith(github.ref, 'refs/tags/')  # only publish to PyPI on tag pushes
+    needs:
+    - build
+    runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/p/<package-name>  # Replace <package-name> with your PyPI project name
+    permissions:
+      id-token: write  # IMPORTANT: mandatory for trusted publishing
+
+    steps:
+    - name: Download all the dists
+      uses: actions/download-artifact@v3
+      with:
+        name: python-package-distributions
+        path: dist/
+    - name: Publish distribution 📦 to PyPI
+      uses: pypa/gh-action-pypi-publish@release/v1
+
+  github-release:
+    name: >-
+      Sign the Python 🐍 distribution 📦 with Sigstore
+      and upload them to GitHub Release
+    needs:
+    - publish-to-pypi
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: write  # IMPORTANT: mandatory for making GitHub Releases
+      id-token: write  # IMPORTANT: mandatory for sigstore
+
+    steps:
+    - name: Download all the dists
+      uses: actions/download-artifact@v3
+      with:
+        name: python-package-distributions
+        path: dist/
+    - name: Sign the dists with Sigstore
+      uses: sigstore/gh-action-sigstore-python@v1.2.3
+      with:
+        inputs: >-
+          ./dist/*.tar.gz
+          ./dist/*.whl
+    - name: Create GitHub Release
+      env:
+        GITHUB_TOKEN: ${{ github.token }}
+      run: >-
+        gh release create
+        '${{ github.ref_name }}'
+        --repo '${{ github.repository }}'
+        --notes ""
+    - name: Upload artifact signatures to GitHub Release
+      env:
+        GITHUB_TOKEN: ${{ github.token }}
+      # Upload to GitHub Release using the `gh` CLI.
+      # `dist/` contains the built packages, and the
+      # sigstore-produced signatures and certificates.
+      run: >-
+        gh release upload
+        '${{ github.ref_name }}' dist/**
+        --repo '${{ github.repository }}'
+
+  publish-to-testpypi:
+    name: Publish Python 🐍 distribution 📦 to TestPyPI
+    needs:
+    - build
+    runs-on: ubuntu-latest
+
+    environment:
+      name: testpypi
+      url: https://test.pypi.org/p/<package-name>
+
+    permissions:
+      id-token: write  # IMPORTANT: mandatory for trusted publishing
+
+    steps:
+    - name: Download all the dists
+      uses: actions/download-artifact@v3
+      with:
+        name: python-package-distributions
+        path: dist/
+    - name: Publish distribution 📦 to TestPyPI
+      uses: pypa/gh-action-pypi-publish@release/v1
+      with:
+        repository-url: https://test.pypi.org/legacy/

--- a/.github/workflows/publish-test-pypi.yml
+++ b/.github/workflows/publish-test-pypi.yml
@@ -119,3 +119,4 @@ jobs:
       uses: pypa/gh-action-pypi-publish@release/v1
       with:
         repository-url: https://test.pypi.org/legacy/
+        skip-existing: true  # Skip if already published this exact version

--- a/README.md
+++ b/README.md
@@ -1,11 +1,10 @@
 # APyTypes
 
+[![PyPI](https://img.shields.io/pypi/v/apytypes)](https://pypi.org/project/apytypes/)
 [![pre-commit.ci status](https://results.pre-commit.ci/badge/github/apytypes/apytypes/main.svg)](https://results.pre-commit.ci/latest/github/apytypes/apytypes/main)
-![License](https://img.shields.io/github/license/apytypes/apytypes)
+[![License](https://img.shields.io/github/license/apytypes/apytypes)](https://github.com/apytypes/apytypes/blob/main/LICENSE.txt)
 ![Workflow Status](https://img.shields.io/github/actions/workflow/status/apytypes/apytypes/tests.yml)
 [![codecov](https://codecov.io/gh/apytypes/apytypes/graph/badge.svg?token=734MDWN7SU)](https://codecov.io/gh/apytypes/apytypes)
-![PyPI - Python Version](https://img.shields.io/pypi/pyversions/:apytypes)
-
 
 ## Documentation
 
@@ -14,13 +13,13 @@
 ## Installation
 
 APyTypes is available in the [Python Package Index](https://pypi.org/p/apytypes/) and
-can be installed with the [pip](https://pypi.org/p/pip/) package installer
+can be installed with the [pip](https://pypi.org/p/pip/) package installer:
 
 ```bash
 pip install apytypes
 ```
 
-Uninstall APyTypes with
+Uninstall APyTypes with:
 
 ```bash
 pip uninstall apytypes

--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@
 ![License](https://img.shields.io/github/license/apytypes/apytypes)
 ![Workflow Status](https://img.shields.io/github/actions/workflow/status/apytypes/apytypes/tests.yml)
 [![codecov](https://codecov.io/gh/apytypes/apytypes/graph/badge.svg?token=734MDWN7SU)](https://codecov.io/gh/apytypes/apytypes)
+![PyPI - Python Version](https://img.shields.io/pypi/pyversions/:apytypes)
+
 
 ## Documentation
 
@@ -11,9 +13,18 @@
 
 ## Installation
 
-The package can be install by running `pip3 install .` from the top level of
-the project, and uninstalled by running `pip3 uninstall apytypes`.
-This should also install the required dependencies.
+APyTypes is available in the [Python Package Index](https://pypi.org/p/apytypes/) and
+can be installed with the [pip](https://pypi.org/p/pip/) package installer
+
+```bash
+pip install apytypes
+```
+
+Uninstall APyTypes with
+
+```bash
+pip uninstall apytypes
+```
 
 ### Running
 

--- a/README.md
+++ b/README.md
@@ -12,8 +12,9 @@
 
 ## Installation
 
-APyTypes is available in the [Python Package Index](https://pypi.org/p/apytypes/) and
-can be installed with the [pip](https://pypi.org/p/pip/) package installer:
+APyTypes is available in the
+[Python Package Index](https://pypi.org/p/apytypes/) and can be installed with
+the [pip](https://pypi.org/p/pip/) package installer:
 
 ```bash
 pip install apytypes

--- a/lib/apytypes/__init__.pyi
+++ b/lib/apytypes/__init__.pyi
@@ -13,8 +13,7 @@ from apytypes._apytypes import get_float_quantization_mode
 from apytypes._apytypes import get_float_quantization_seed
 from apytypes._apytypes import set_float_quantization_mode
 from apytypes._apytypes import set_float_quantization_seed
-from . import _apytypes
-from . import _version
+from apytypes._version import version as __version__
 
 __all__: list = [
     "APyFixed",
@@ -33,4 +32,3 @@ __all__: list = [
     "get_float_quantization_seed",
     "set_float_quantization_seed",
 ]
-__version__: str = "0.0.1.dev0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -77,4 +77,7 @@ default.extend-words = { NDArray = "NDArray" }
 default.extend-identifiers = { NDArray = "NDArray" }
 
 [tool.cibuildwheel]
-skip = "pp*"  # APyTypes currently can not be build for PyPy
+skip = [
+    "pp*",      # APyTypes currently can not be build for PyPy ...
+    "*-win32",  # ... nor can it be build for 32-bit Windows systems
+]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -75,3 +75,6 @@ markers = [
 files.extend-exclude = ["extern", "docs/Doxyfile"]
 default.extend-words = { NDArray = "NDArray" }
 default.extend-identifiers = { NDArray = "NDArray" }
+
+[tool.cibuildwheel]
+skip = "pp*"  # APyTypes currently can not be build for PyPy

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,9 +10,12 @@ description = "Python package for custom fixed-point and floating-point formats"
 readme = "README.md"
 requires-python = ">=3.9"
 classifiers = [
-    "Programming Language :: Python :: 3",
+    "Development Status :: 3 - Alpha",
+    "Intended Audience :: Science/Research",
     "License :: OSI Approved :: MIT License",
     "Operating System :: OS Independent",
+    "Programming Language :: Python :: 3",
+    "Topic :: Scientific/Engineering :: Electronic Design Automation (EDA)",
 ]
 
 [project.urls]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -81,3 +81,7 @@ skip = [
     "pp*",      # APyTypes currently can not be build for PyPy ...
     "*-win32",  # ... nor can it be build for 32-bit Windows systems
 ]
+
+[tool.cibuildwheel.macos.environment]
+# MacOS 10.14 is the first MacOS release with full support for C++17
+MACOSX_DEPLOYMENT_TARGET = "10.14"

--- a/src/apyfixed.cc
+++ b/src/apyfixed.cc
@@ -611,7 +611,7 @@ void APyFixed::set_from_string_dec(const std::string& str)
     std::size_t binary_point_dec = str_trimmed.find('.');
     binary_point_dec = (binary_point_dec == std::string::npos) ? 0 : binary_point_dec;
     str_trimmed.erase(
-        std::remove(str_trimmed.begin(), str_trimmed.end(), '.'), str_trimmed.cend()
+        std::remove(str_trimmed.begin(), str_trimmed.end(), '.'), str_trimmed.end()
     );
 
     // Copy characters (from back) of the trimmed string into a BCD list


### PR DESCRIPTION
This workflow automizes the publishing of APyTypes:

* Publish to [test.pypi.org](test.pypi.org) on pushes to main
* Publish to [pypi.org](pypi.org) on new tags
* GitHub release on new tags

### TODO:
* [X] Register project name `apytypes` on [test.pypi.org](https://test.pypi.org) and [pypi.org](https://pypi.org)
* [X] First publication on [test.pypi.org/project/apytypes](https://test.pypi.org/project/apytypes/) 🎉
* [ ] Get the apytypes organization accepted on [pypi.org](pypi.org) and [test.pypi.org](test.pypi.org)
* [ ] Transfer project name `apytypes` to the public PyPi apytypes organization 
* [x] Update README install instruction to `pip install apytypes`
* [x] Fix the build wheel step for `windows-latest`
* [x] Fix the build wheel step for `macos-12`