### PR TITLE
Sanity check APyFloat format in Python interface

### DIFF
--- a/src/apyfloat.cc
+++ b/src/apyfloat.cc
@@ -41,6 +41,33 @@ static constexpr std::size_t _EXP_LIMIT_BITS = _EXP_T_SIZE_BITS - 2;
  * **********************************************************************************
  */
 
+void APyFloat::create_in_place(
+    APyFloat* apyfloat,
+    int sign,
+    exp_t exp,
+    man_t man,
+    std::uint8_t exp_bits,
+    std::uint8_t man_bits,
+    std::optional<exp_t> bias
+)
+{
+    const exp_t ieee_bias = APyFloat::ieee_bias(exp_bits);
+    if (bias.has_value() && bias.value() != ieee_bias) {
+        print_warning("non 'ieee-like' biases are not sure to work yet.\n");
+    }
+
+    if (exp_bits > _EXP_LIMIT_BITS) {
+        throw nb::value_error("Too many bits for the exponent field.");
+    }
+
+    if (man_bits > _MAN_LIMIT_BITS) {
+        throw nb::value_error("Too many bits for the mantissa field.");
+    }
+
+    new (apyfloat)
+        APyFloat(sign, exp, man, exp_bits, man_bits, bias.value_or(ieee_bias));
+}
+
 APyFloat::APyFloat(
     bool sign,
     exp_t exp,
@@ -55,21 +82,6 @@ APyFloat::APyFloat(
     , sign(sign)
     , exp(exp)
     , man(man)
-{
-    if (bias.has_value() && bias.value() != ieee_bias()) {
-        print_warning("non 'ieee-like' biases are not sure to work yet.\n");
-    }
-}
-
-APyFloat::APyFloat(
-    int sign,
-    exp_t exp,
-    man_t man,
-    std::uint8_t exp_bits,
-    std::uint8_t man_bits,
-    std::optional<exp_t> bias
-)
-    : APyFloat(bool(sign), exp, man, exp_bits, man_bits, bias)
 {
 }
 

--- a/src/apyfloat.h
+++ b/src/apyfloat.h
@@ -25,6 +25,7 @@ public:
      * ******************************************************************************
      */
 
+    // These constructors are not exposed to Python
     explicit APyFloat(
         bool sign,
         exp_t exp,
@@ -33,16 +34,6 @@ public:
         std::uint8_t man_bits,
         std::optional<exp_t> bias = std::nullopt
     );
-    explicit APyFloat(
-        int sign,
-        exp_t exp,
-        man_t man,
-        std::uint8_t exp_bits,
-        std::uint8_t man_bits,
-        std::optional<exp_t> bias = std::nullopt
-    );
-
-    // These constructors are not exposed to Python
     APyFloat(
         const APyFloatData& data,
         std::uint8_t exp_bits,
@@ -59,6 +50,16 @@ public:
      * * Methods for conversions                                                    *
      * ******************************************************************************
      */
+    // Factory function for Python interface
+    static void create_in_place(
+        APyFloat* apyfloat,
+        int sign,
+        exp_t exp,
+        man_t man,
+        std::uint8_t exp_bits,
+        std::uint8_t man_bits,
+        std::optional<exp_t> bias = std::nullopt
+    );
 
     static APyFloat from_double(
         double value,

--- a/src/apyfloat_wrapper.cc
+++ b/src/apyfloat_wrapper.cc
@@ -9,31 +9,11 @@ void bind_float(nb::module_& m)
 {
     nb::class_<APyFloat>(m, "APyFloat")
         /*
-         * Constructors
+         * Constructor
          */
         .def(
-            nb::init<
-                bool,
-                exp_t,
-                man_t,
-                std::uint8_t,
-                std::uint8_t,
-                std::optional<exp_t>>(),
-            nb::arg("sign"),
-            nb::arg("exp"),
-            nb::arg("man"),
-            nb::arg("exp_bits"),
-            nb::arg("man_bits"),
-            nb::arg("bias") = nb::none()
-        )
-        .def(
-            nb::init<
-                int,
-                exp_t,
-                man_t,
-                std::uint8_t,
-                std::uint8_t,
-                std::optional<exp_t>>(),
+            "__init__",
+            &APyFloat::create_in_place,
             nb::arg("sign"),
             nb::arg("exp"),
             nb::arg("man"),


### PR DESCRIPTION
This PR introduces a factory function for the Python interface such that the range check for bits is not performed in the C++ code.