### PR TITLE
src: add APyFixed.leading_* methods

### DIFF
--- a/lib/apytypes/_apytypes.pyi
+++ b/lib/apytypes/_apytypes.pyi
@@ -271,6 +271,15 @@ class APyFixed:
         :class:`int`
         """
 
+    def leading_ones(self) -> int:
+        """
+        Retrieve the number of leading ones.
+
+        Returns
+        -------
+        :class:`int`
+        """
+
     def leading_signs(self) -> int:
         """
         Retrieve the number of leading signs.

--- a/lib/apytypes/_apytypes.pyi
+++ b/lib/apytypes/_apytypes.pyi
@@ -262,6 +262,33 @@ class APyFixed:
             assert not(fx_a.is_identical(fx_b))
         """
 
+    def leading_fractional_zeros(self) -> int:
+        """
+        Retrieve the number of leading zeros after the binary fixed-point.
+
+        Returns
+        -------
+        :class:`int`
+        """
+
+    def leading_sign(self) -> int:
+        """
+        Retrieve the number of leading signs, minus one.
+
+        Returns
+        -------
+        :class:`int`
+        """
+
+    def leading_zeros(self) -> int:
+        """
+        Retrieve the number of leading zeros.
+
+        Returns
+        -------
+        :class:`int`
+        """
+
     def resize(
         self,
         bits: int | None = None,

--- a/lib/apytypes/_apytypes.pyi
+++ b/lib/apytypes/_apytypes.pyi
@@ -271,9 +271,9 @@ class APyFixed:
         :class:`int`
         """
 
-    def leading_sign(self) -> int:
+    def leading_signs(self) -> int:
         """
-        Retrieve the number of leading signs, minus one.
+        Retrieve the number of leading signs.
 
         Returns
         -------

--- a/lib/test/apyfixed/test_arithmetic.py
+++ b/lib/test/apyfixed/test_arithmetic.py
@@ -272,3 +272,37 @@ def test_issue_198():
             int_bits=321,
         )
     )
+
+
+def test_leading_zeros():
+    # Less than full-limb test
+    assert APyFixed(0x000, bits=12, int_bits=0).leading_zeros() == 12
+    assert APyFixed(0x001, bits=12, int_bits=0).leading_zeros() == 11
+    assert APyFixed(0x002, bits=12, int_bits=0).leading_zeros() == 10
+    assert APyFixed(0x003, bits=12, int_bits=0).leading_zeros() == 10
+    assert APyFixed(0x004, bits=12, int_bits=0).leading_zeros() == 9
+    assert APyFixed(0x7FF, bits=12, int_bits=0).leading_zeros() == 1
+    assert APyFixed(0x800, bits=12, int_bits=0).leading_zeros() == 0
+    assert APyFixed(0xFFF, bits=12, int_bits=0).leading_zeros() == 0
+
+    # Full-limb test
+    assert APyFixed(0x0000000000000000, bits=64, int_bits=0).leading_zeros() == 64
+    assert APyFixed(0x0000000000000001, bits=64, int_bits=0).leading_zeros() == 63
+    assert APyFixed(0x0000000000000002, bits=64, int_bits=0).leading_zeros() == 62
+    assert APyFixed(0x0000000000000003, bits=64, int_bits=0).leading_zeros() == 62
+    assert APyFixed(0x0000000000000004, bits=64, int_bits=0).leading_zeros() == 61
+    assert APyFixed(0x1000000000000000, bits=64, int_bits=0).leading_zeros() == 3
+    assert APyFixed(0x2000000000000000, bits=64, int_bits=0).leading_zeros() == 2
+    assert APyFixed(0x4000000000000000, bits=64, int_bits=0).leading_zeros() == 1
+    assert APyFixed(0x8000000000000000, bits=64, int_bits=0).leading_zeros() == 0
+    assert APyFixed(0xFFFFFFFFFFFFFFFF, bits=64, int_bits=0).leading_zeros() == 0
+
+    # Two-limb test
+    assert APyFixed(0x000000000000000000, bits=72, int_bits=0).leading_zeros() == 72
+    assert APyFixed(0x000000000000000001, bits=72, int_bits=0).leading_zeros() == 71
+    assert APyFixed(0x000000000000000002, bits=72, int_bits=0).leading_zeros() == 70
+    assert APyFixed(0x000000000000000003, bits=72, int_bits=0).leading_zeros() == 70
+    assert APyFixed(0x000000000000000004, bits=72, int_bits=0).leading_zeros() == 69
+    assert APyFixed(0x00FFFFFFFFFFFFFFFF, bits=72, int_bits=0).leading_zeros() == 8
+    assert APyFixed(0x01FFFFFFFFFFFFFFFF, bits=72, int_bits=0).leading_zeros() == 7
+    assert APyFixed(0xFFFFFFFFFFFFFFFFFF, bits=72, int_bits=0).leading_zeros() == 0

--- a/lib/test/apyfixed/test_arithmetic.py
+++ b/lib/test/apyfixed/test_arithmetic.py
@@ -345,3 +345,51 @@ def test_leading_signs():
     assert APyFixed(0x01FFFFFFFFFFFFFFFF, bits=72, int_bits=0).leading_signs() == 7
     assert APyFixed(0xFFFFFFFFFFFFFFFFFF, bits=72, int_bits=0).leading_signs() == 72
     assert APyFixed(0xFFFFFFFFFFFFFFFFF0, bits=72, int_bits=0).leading_signs() == 68
+
+
+def test_leading_fractional_zeros():
+    # Less than full-limb test
+    assert APyFixed(0xFF_F, bits=12, frac_bits=4).leading_fractional_zeros() == 0
+    assert APyFixed(0xFF_7, bits=12, frac_bits=4).leading_fractional_zeros() == 1
+    assert APyFixed(0x00_3, bits=12, frac_bits=4).leading_fractional_zeros() == 2
+    assert APyFixed(0x0F_1, bits=12, frac_bits=4).leading_fractional_zeros() == 3
+    assert APyFixed(0xFF_0, bits=12, frac_bits=4).leading_fractional_zeros() == 4
+    assert APyFixed(0x00_0, bits=12, frac_bits=4).leading_fractional_zeros() == 4
+
+    # Multi-limb boundary test
+    assert (
+        APyFixed(0x0_0000000000000000, bits=68, frac_bits=64).leading_fractional_zeros()
+        == 64
+    )
+    assert (
+        APyFixed(0x1_0000000000000001, bits=68, frac_bits=64).leading_fractional_zeros()
+        == 63
+    )
+    assert (
+        APyFixed(0x2_0000000000000002, bits=68, frac_bits=64).leading_fractional_zeros()
+        == 62
+    )
+    assert (
+        APyFixed(0x3_0000000000000003, bits=68, frac_bits=64).leading_fractional_zeros()
+        == 62
+    )
+    assert (
+        APyFixed(0x0_1FFFFFFFFFFFFFFF, bits=68, frac_bits=64).leading_fractional_zeros()
+        == 3
+    )
+    assert (
+        APyFixed(0x1_200FF00FF00FF00F, bits=68, frac_bits=64).leading_fractional_zeros()
+        == 2
+    )
+    assert (
+        APyFixed(0x1_300FF00FF00FF00F, bits=68, frac_bits=64).leading_fractional_zeros()
+        == 2
+    )
+    assert (
+        APyFixed(0xF_400FF00FF00FF00F, bits=68, frac_bits=64).leading_fractional_zeros()
+        == 1
+    )
+    assert (
+        APyFixed(0xE_800FF00FF00FF00F, bits=68, frac_bits=64).leading_fractional_zeros()
+        == 0
+    )

--- a/lib/test/apyfixed/test_arithmetic.py
+++ b/lib/test/apyfixed/test_arithmetic.py
@@ -348,6 +348,10 @@ def test_leading_signs():
 
 
 def test_leading_fractional_zeros():
+
+    # Code coverage test
+    assert APyFixed(0x00, bits=8, frac_bits=0).leading_fractional_zeros() == 0
+
     # Less than full-limb test
     assert APyFixed(0xFF_F, bits=12, frac_bits=4).leading_fractional_zeros() == 0
     assert APyFixed(0xFF_7, bits=12, frac_bits=4).leading_fractional_zeros() == 1

--- a/lib/test/apyfixed/test_arithmetic.py
+++ b/lib/test/apyfixed/test_arithmetic.py
@@ -306,3 +306,42 @@ def test_leading_zeros():
     assert APyFixed(0x00FFFFFFFFFFFFFFFF, bits=72, int_bits=0).leading_zeros() == 8
     assert APyFixed(0x01FFFFFFFFFFFFFFFF, bits=72, int_bits=0).leading_zeros() == 7
     assert APyFixed(0xFFFFFFFFFFFFFFFFFF, bits=72, int_bits=0).leading_zeros() == 0
+
+
+def test_leading_signs():
+    # Less than full-limb test
+    assert APyFixed(0xFF0, bits=12, int_bits=0).leading_signs() == 8
+    assert APyFixed(0x000, bits=12, int_bits=0).leading_signs() == 12
+    assert APyFixed(0x001, bits=12, int_bits=0).leading_signs() == 11
+    assert APyFixed(0x002, bits=12, int_bits=0).leading_signs() == 10
+    assert APyFixed(0x003, bits=12, int_bits=0).leading_signs() == 10
+    assert APyFixed(0x004, bits=12, int_bits=0).leading_signs() == 9
+    assert APyFixed(0x7FF, bits=12, int_bits=0).leading_signs() == 1
+    assert APyFixed(0x800, bits=12, int_bits=0).leading_signs() == 1
+    assert APyFixed(0xFF0, bits=12, int_bits=0).leading_signs() == 8
+    assert APyFixed(0xFFF, bits=12, int_bits=0).leading_signs() == 12
+
+    # Full-limb test
+    assert APyFixed(0x0000000000000000, bits=64, int_bits=0).leading_signs() == 64
+    assert APyFixed(0x0000000000000001, bits=64, int_bits=0).leading_signs() == 63
+    assert APyFixed(0x0000000000000002, bits=64, int_bits=0).leading_signs() == 62
+    assert APyFixed(0x0000000000000003, bits=64, int_bits=0).leading_signs() == 62
+    assert APyFixed(0x0000000000000004, bits=64, int_bits=0).leading_signs() == 61
+    assert APyFixed(0x1000000000000000, bits=64, int_bits=0).leading_signs() == 3
+    assert APyFixed(0x2000000000000000, bits=64, int_bits=0).leading_signs() == 2
+    assert APyFixed(0x4000000000000000, bits=64, int_bits=0).leading_signs() == 1
+    assert APyFixed(0x8000000000000000, bits=64, int_bits=0).leading_signs() == 1
+    assert APyFixed(0xC000000000000000, bits=64, int_bits=0).leading_signs() == 2
+    assert APyFixed(0xFFFFFFFFFFFFFF00, bits=64, int_bits=0).leading_signs() == 56
+    assert APyFixed(0xFFFFFFFFFFFFFFFF, bits=64, int_bits=0).leading_signs() == 64
+
+    # Two-limb test
+    assert APyFixed(0x000000000000000000, bits=72, int_bits=0).leading_signs() == 72
+    assert APyFixed(0x000000000000000001, bits=72, int_bits=0).leading_signs() == 71
+    assert APyFixed(0x000000000000000002, bits=72, int_bits=0).leading_signs() == 70
+    assert APyFixed(0x000000000000000003, bits=72, int_bits=0).leading_signs() == 70
+    assert APyFixed(0x000000000000000004, bits=72, int_bits=0).leading_signs() == 69
+    assert APyFixed(0x00FFFFFFFFFFFFFFFF, bits=72, int_bits=0).leading_signs() == 8
+    assert APyFixed(0x01FFFFFFFFFFFFFFFF, bits=72, int_bits=0).leading_signs() == 7
+    assert APyFixed(0xFFFFFFFFFFFFFFFFFF, bits=72, int_bits=0).leading_signs() == 72
+    assert APyFixed(0xFFFFFFFFFFFFFFFFF0, bits=72, int_bits=0).leading_signs() == 68

--- a/src/apyfixed.cc
+++ b/src/apyfixed.cc
@@ -3,6 +3,7 @@
  */
 
 // Python object access through Pybind
+#include <iostream>
 #include <nanobind/nanobind.h>
 namespace nb = nanobind;
 
@@ -830,12 +831,30 @@ std::size_t APyFixed::leading_zeros() const
     }
 }
 
+std::size_t APyFixed::leading_ones() const
+{
+    std::size_t leading_ones = limb_vector_leading_ones(_data.begin(), _data.end());
+    if (leading_ones == 0) {
+        return 0;
+    } else {
+        std::size_t utilized_bits_last_limb = ((bits() - 1) % _LIMB_SIZE_BITS) + 1;
+        return leading_ones - (_LIMB_SIZE_BITS - utilized_bits_last_limb);
+    }
+}
+
 std::size_t APyFixed::leading_fractional_zeros() const
 {
     throw NotImplementedException();
 }
 
-std::size_t APyFixed::leading_sign() const { throw NotImplementedException(); }
+std::size_t APyFixed::leading_signs() const
+{
+    if (is_negative()) {
+        return leading_ones();
+    } else {
+        return leading_zeros();
+    }
+}
 
 /* ********************************************************************************** *
  * *                           Static member functions                              * *

--- a/src/apyfixed.cc
+++ b/src/apyfixed.cc
@@ -819,6 +819,24 @@ bool APyFixed::is_identical(const APyFixed& other) const
     return bits() == other.bits() && int_bits() == other.int_bits() && *this == other;
 }
 
+std::size_t APyFixed::leading_zeros() const
+{
+    std::size_t leading_zeros = limb_vector_leading_zeros(_data.begin(), _data.end());
+    if (leading_zeros == 0) {
+        return 0;
+    } else {
+        std::size_t utilized_bits_last_limb = ((bits() - 1) % _LIMB_SIZE_BITS) + 1;
+        return leading_zeros - (_LIMB_SIZE_BITS - utilized_bits_last_limb);
+    }
+}
+
+std::size_t APyFixed::leading_fractional_zeros() const
+{
+    throw NotImplementedException();
+}
+
+std::size_t APyFixed::leading_sign() const { throw NotImplementedException(); }
+
 /* ********************************************************************************** *
  * *                           Static member functions                              * *
  * ********************************************************************************** */

--- a/src/apyfixed.cc
+++ b/src/apyfixed.cc
@@ -3,7 +3,6 @@
  */
 
 // Python object access through Pybind
-#include <iostream>
 #include <nanobind/nanobind.h>
 namespace nb = nanobind;
 
@@ -851,9 +850,6 @@ std::size_t APyFixed::leading_fractional_zeros() const
 
     std::size_t utilized_full_frac_limbs = frac_bits / _LIMB_SIZE_BITS;
     std::size_t utilized_frac_bits_last_limb = frac_bits % _LIMB_SIZE_BITS;
-    std::cout << "Utilized full frac limbs: " << utilized_full_frac_limbs << std::endl;
-    std::cout << "Utilized frac bits last limb: " << utilized_frac_bits_last_limb
-              << std::endl;
 
     std::size_t leading_frac_bits_full_limbs = limb_vector_leading_zeros(
         _data.begin(), _data.begin() + utilized_full_frac_limbs
@@ -867,11 +863,6 @@ std::size_t APyFixed::leading_fractional_zeros() const
         leading_frac_bits_last_limb
             = ::leading_zeros(limb) - (_LIMB_SIZE_BITS - utilized_frac_bits_last_limb);
     }
-
-    std::cout << "leading_frac_bits_full_limbs: " << leading_frac_bits_full_limbs
-              << std::endl;
-    std::cout << "leading_frac_bits_last_limb: " << leading_frac_bits_last_limb
-              << std::endl;
 
     if (leading_frac_bits_last_limb != utilized_frac_bits_last_limb) {
         return leading_frac_bits_last_limb;

--- a/src/apyfixed.h
+++ b/src/apyfixed.h
@@ -184,11 +184,14 @@ public:
     //! Retrieve leading zeros
     std::size_t leading_zeros() const;
 
+    //! Retrieve leading ones
+    std::size_t leading_ones() const;
+
     //! Retrieve leading fractional zeros
     std::size_t leading_fractional_zeros() const;
 
-    //! Retrieve leading sign
-    std::size_t leading_sign() const;
+    //! Retrieve leading signs
+    std::size_t leading_signs() const;
 
     /* ****************************************************************************** *
      *                           Conversion to other types                            *

--- a/src/apyfixed.h
+++ b/src/apyfixed.h
@@ -181,6 +181,15 @@ public:
     //! same number of integer bits, and the same number of fractional bits
     bool is_identical(const APyFixed& other) const;
 
+    //! Retrieve leading zeros
+    std::size_t leading_zeros() const;
+
+    //! Retrieve leading fractional zeros
+    std::size_t leading_fractional_zeros() const;
+
+    //! Retrieve leading sign
+    std::size_t leading_sign() const;
+
     /* ****************************************************************************** *
      *                           Conversion to other types                            *
      * ****************************************************************************** */
@@ -390,8 +399,8 @@ private:
         OverflowMode overflow
     ) const;
 
-    // Perform two's complement overflowing. This method sign-extends any bits outside
-    // of the APyFixed range.
+    //! Perform two's complement overflowing. This method sign-extends any bits outside
+    //! of the APyFixed range.
     template <class RANDOM_ACCESS_ITERATOR>
     void _twos_complement_overflow(
         RANDOM_ACCESS_ITERATOR it_begin,

--- a/src/apyfixed_wrapper.cc
+++ b/src/apyfixed_wrapper.cc
@@ -255,8 +255,8 @@ void bind_fixed(nb::module_& m)
             )pbdoc"
         )
         .def(
-            "leading_sign",
-            &APyFixed::leading_sign,
+            "leading_signs",
+            &APyFixed::leading_signs,
             R"pbdoc(
             Retrieve the number of leading signs.
 

--- a/src/apyfixed_wrapper.cc
+++ b/src/apyfixed_wrapper.cc
@@ -232,6 +232,39 @@ void bind_fixed(nb::module_& m)
         )
         .def_prop_ro("_vector_size", &APyFixed::vector_size)
         .def("_repr_latex_", &APyFixed::latex)
+        .def(
+            "leading_zeros",
+            &APyFixed::leading_zeros,
+            R"pbdoc(
+            Retrieve the number of leading zeros.
+
+            Returns
+            -------
+            :class:`int`
+            )pbdoc"
+        )
+        .def(
+            "leading_fractional_zeros",
+            &APyFixed::leading_fractional_zeros,
+            R"pbdoc(
+            Retrieve the number of leading zeros after the binary fixed-point.
+
+            Returns
+            -------
+            :class:`int`
+            )pbdoc"
+        )
+        .def(
+            "leading_sign",
+            &APyFixed::leading_sign,
+            R"pbdoc(
+            Retrieve the number of leading signs.
+
+            Returns
+            -------
+            :class:`int`
+            )pbdoc"
+        )
 
         /*
          * Dunder methods

--- a/src/apyfixed_wrapper.cc
+++ b/src/apyfixed_wrapper.cc
@@ -233,6 +233,17 @@ void bind_fixed(nb::module_& m)
         .def_prop_ro("_vector_size", &APyFixed::vector_size)
         .def("_repr_latex_", &APyFixed::latex)
         .def(
+            "leading_ones",
+            &APyFixed::leading_ones,
+            R"pbdoc(
+            Retrieve the number of leading ones.
+
+            Returns
+            -------
+            :class:`int`
+            )pbdoc"
+        )
+        .def(
             "leading_zeros",
             &APyFixed::leading_zeros,
             R"pbdoc(

--- a/src/apytypes_util.h
+++ b/src/apytypes_util.h
@@ -5,7 +5,6 @@
 #ifndef _APYTYPES_UTIL_H
 #define _APYTYPES_UTIL_H
 
-#include <iostream>
 #include <nanobind/nanobind.h>
 #include <nanobind/stl/string.h>
 
@@ -97,7 +96,6 @@ significant_limbs(RANDOM_ACCESS_ITERATOR begin, RANDOM_ACCESS_ITERATOR end)
 //! Compute the number of leading zeros in a single limb
 [[maybe_unused, nodiscard]] static APY_INLINE std::size_t leading_zeros(mp_limb_t n)
 {
-    std::cout << "leading_zeros of: " << n << std::endl;
     if (n == 0) {
         return _LIMB_SIZE_BITS;
     } else {
@@ -113,7 +111,6 @@ significant_limbs(RANDOM_ACCESS_ITERATOR begin, RANDOM_ACCESS_ITERATOR end)
 //! Compute the number of leading ones in a single limb
 [[maybe_unused, nodiscard]] static APY_INLINE std::size_t leading_ones(mp_limb_t n)
 {
-    std::cout << "leading_ones of: " << n << std::endl;
     if (n == 0) {
         return 0;
     } else {
@@ -124,12 +121,6 @@ significant_limbs(RANDOM_ACCESS_ITERATOR begin, RANDOM_ACCESS_ITERATOR end)
         }
         return ones;
     }
-}
-
-//! Compute the number of leading signs in a single limb
-[[maybe_unused, nodiscard]] static APY_INLINE std::size_t leading_signs(mp_limb_t n)
-{
-    return mp_limb_signed_t(n) < 0 ? leading_ones(n) : leading_zeros(n);
 }
 
 //! Retrieve the number of leading zeros of a limb vector
@@ -147,7 +138,6 @@ limb_vector_leading_zeros(RANDOM_ACCESS_ITERATOR begin, RANDOM_ACCESS_ITERATOR e
         return _LIMB_SIZE_BITS * zero_limbs;
     } else {
         // Some of the limbs is non-zero
-        // return _LIMB_SIZE_BITS * (zero_limbs + 1) - bit_width(*rev_non_zero_it);
         return _LIMB_SIZE_BITS * zero_limbs + leading_zeros(*rev_non_zero_it);
     }
 }

--- a/src/apytypes_util.h
+++ b/src/apytypes_util.h
@@ -109,6 +109,13 @@ limb_vector_leading_zeros(RANDOM_ACCESS_ITERATOR begin, RANDOM_ACCESS_ITERATOR e
     }
 }
 
+template <class RANDOM_ACCESS_ITERATOR>
+[[maybe_unused, nodiscard]] static APY_INLINE std::size_t
+limb_vector_leading_sign(RANDOM_ACCESS_ITERATOR begin, RANDOM_ACCESS_ITERATOR end)
+{
+    throw NotImplementedException();
+}
+
 //! Quickly count the number of nibbles in an unsigned `mp_limb_t`
 [[maybe_unused, nodiscard]] static APY_INLINE std::size_t nibble_width(mp_limb_t x)
 {


### PR DESCRIPTION
This PR adds the following methods to `APyFixed`:

* `APyFixed.leading_zeros() -> int`
* `APyFixed.leading_ones() -> int`
* `APyFixed.leading_signs() -> int`
* `APyFixed.leading_fractional_zeros() -> int` 