### PR TITLE
src: equally many limb-optimize APyFixedArray::operator+/-()

### DIFF
--- a/src/apyfixedarray.h
+++ b/src/apyfixedarray.h
@@ -238,7 +238,9 @@ private:
         std::optional<AccumulatorOption> mode // optional accumulation mode
     ) const;
 
-    APyFixedArray _cast_correct_wl(int new_bits, int new_int_bits) const;
+    void _cast_correct_wl(
+        std::vector<mp_limb_t>::iterator output_it, int new_bits, int new_int_bits
+    ) const;
 
     /*!
      * The internal cast method used to place cast data onto a pair of iterators.

--- a/src/apytypes_util.h
+++ b/src/apytypes_util.h
@@ -804,7 +804,7 @@ template <class RANDOM_ACCESS_ITERATOR>
 )
 {
     (void)cbegin_it;
-    return mp_limb_signed_t(*--cend_it) < 0;
+    return mp_limb_signed_t(*std::prev(cend_it)) < 0;
 }
 
 //! Reduce the first `n` bits in a limb vector over bitwise `or`. Returns bool.


### PR DESCRIPTION
### Benchmark:

```Python
from apytypes import *
from time import time
import numpy as np


a = APyFixedArray.from_float(np.random.rand(200, 200) - 0.5, 200, 1)
b = APyFixedArray.from_float(np.random.rand(200, 200) - 0.5, 200, 1)

t1 = time()
for i in range(10000):
    a + b
t2 = time()
print(f'[200 x 200] 200-bit addition: {(t2 - t1)*1e6 / 10000} us per addition')

t1 = time()
for i in range(10000):
    a - b 
t2 = time()
print(f'[200 x 200] 200-bit subtraction: {(t2 - t1)*1e6 / 10000} us per subtraction')
```

### Before (b01c1ad):

```
[200 x 200] 200-bit addition: 1035.451579093933 us per addition
[200 x 200] 200-bit subtraction: 986.5080833435059 us per subtraction
```

### After:

```
[200 x 200] 200-bit addition: 148.31440448760986 us per addition
[200 x 200] 200-bit subtraction: 162.70325183868408 us per subtraction
```