### PR TITLE
Rewrite APyFloat operators

### DIFF
--- a/docs/api/quantizationoverflow.rst
+++ b/docs/api/quantizationoverflow.rst
@@ -5,7 +5,7 @@ Quantization and overflow handling
    :members:
    :undoc-members:
 
-.. image:: _static/quantization.png
+.. image:: ../_static/quantization.png
    :alt: Illustration of the different quantization modes
 
 .. autoclass:: apytypes.OverflowMode

--- a/lib/test/apyfloat/test_arithmetic.py
+++ b/lib/test/apyfloat/test_arithmetic.py
@@ -467,6 +467,18 @@ def test_power():
     assert APyFloat.from_float(-8.125, 8, 10) ** 4 == APyFloat.from_float(
         (-8.125) ** 4, 8, 10
     )
+    # Sqrt(2) (triggers carry)
+    a = APyFloat(sign=0, exp=510, man=27146, exp_bits=10, man_bits=16)
+    # Wrong
+    # (a**2).is_identical(APyFloat(sign=0, exp=510, man=0, exp_bits=10, man_bits=16))
+    (a**4).is_identical(APyFloat(sign=0, exp=509, man=0, exp_bits=10, man_bits=16))
+
+    a = APyFloat(sign=0, exp=511, man=1865452045155277, exp_bits=10, man_bits=52)
+    (a**2).is_identical(APyFloat(sign=0, exp=512, man=1, exp_bits=10, man_bits=52))
+
+    # Cube root of three
+    a = APyFloat(sign=0, exp=511, man=1116352409, exp_bits=10, man_bits=32)
+    (a**3).is_identical(APyFloat(sign=0, exp=512, man=0, exp_bits=10, man_bits=32))
 
 
 @pytest.mark.xfail()

--- a/lib/test/apyfloat/test_rounding.py
+++ b/lib/test/apyfloat/test_rounding.py
@@ -3,13 +3,24 @@ from apytypes import APyFloat, QuantizationMode, QuantizationContext
 import pytest
 
 
-@pytest.mark.xfail()
 def test_issue_245():
-    # Smoke test for jamming rounding when adding with zero
+    # Test that jamming bit is not applied when result is zero
     # https://github.com/apytypes/apytypes/issues/245
     with QuantizationContext(QuantizationMode.JAM):
         res = APyFloat(0, 15, 0, 5, 2) + APyFloat(0, 0, 0, 5, 2)
-        assert res.is_identical(APyFloat(0, 15, 1, 5, 2))
+        assert res.is_identical(APyFloat(0, 15, 0, 5, 2))
+
+    with QuantizationContext(QuantizationMode.JAM):
+        res = APyFloat(0, 15, 0, 5, 2) - APyFloat(0, 0, 0, 5, 2)
+        assert res.is_identical(APyFloat(0, 15, 0, 5, 2))
+
+    with QuantizationContext(QuantizationMode.JAM):
+        res = APyFloat(0, 15, 0, 5, 2) * APyFloat(0, 0, 0, 5, 2)
+        assert res.is_identical(APyFloat(0, 0, 0, 5, 2))
+
+    with QuantizationContext(QuantizationMode.JAM):
+        res = APyFloat(0, 0, 0, 5, 2) / APyFloat(0, 15, 0, 5, 2)
+        assert res.is_identical(APyFloat(0, 0, 0, 5, 2))
 
 
 @pytest.mark.float_add

--- a/lib/test/apyfloatarray/test_constructors.py
+++ b/lib/test/apyfloatarray/test_constructors.py
@@ -21,7 +21,9 @@ def test_explicit_constructor():
     assert arr.man_bits == 5
     assert arr.bias == 7  # Default when using 4 exponent bits
 
-    arr2d = APyFloatArray([[0, 1], [0, 1]], [[2, 3], [2, 3]], [[4, 5], [4, 5]], 6, 7)
+    arr2d = APyFloatArray(
+        [[False, 1], [0, True]], [[2, 3], [2, 3]], [[4, 5], [4, 5]], 6, 7
+    )
     assert len(arr2d) == 2
     assert arr2d.shape == (2, 2)
     assert arr2d.exp_bits == 6

--- a/src/apyfloat.h
+++ b/src/apyfloat.h
@@ -217,7 +217,7 @@ public:
         man = data.man;
     }
 
-    static inline exp_t ieee_bias(std::uint8_t exp_bits)
+    APY_INLINE static exp_t ieee_bias(std::uint8_t exp_bits)
     {
         return (1ULL << (exp_bits - 1)) - 1;
     }
@@ -260,30 +260,27 @@ private:
     APyFloat
     construct_nan(std::optional<bool> new_sign = std::nullopt, man_t payload = 1) const;
 
-    inline exp_t exp_mask() const { return ((1ULL << exp_bits) - 1); }
-    inline exp_t max_exponent() const
+    APY_INLINE exp_t exp_mask() const { return ((1ULL << exp_bits) - 1); }
+    APY_INLINE exp_t max_exponent() const
     {
         return ((1ULL << exp_bits) - 1);
     } // Max exponent with bias
-    inline exp_t ieee_bias() const { return ieee_bias(exp_bits); }
-    inline man_t man_mask() const { return (1ULL << man_bits) - 1; }
-    inline man_t leading_one() const { return (1ULL << man_bits); }
-    inline man_t leading_bit() const
+    APY_INLINE exp_t ieee_bias() const { return ieee_bias(exp_bits); }
+    APY_INLINE man_t man_mask() const { return (1ULL << man_bits) - 1; }
+    APY_INLINE man_t leading_one() const { return (1ULL << man_bits); }
+    APY_INLINE man_t leading_bit() const
     {
         return (static_cast<man_t>(is_normal()) << man_bits);
     }
 
     APyFloat normalized() const;
     static void quantize_apymantissa(
-        APyFixed& apyman,
-        bool sign,
-        int bits,
-        std::optional<QuantizationMode> quantization = std::nullopt
+        APyFixed& apyman, bool sign, int bits, QuantizationMode quantization
     );
     static QuantizationMode
     translate_quantization_mode(QuantizationMode quantization, bool sign);
 
-    int leading_zeros_apyfixed(APyFixed fx) const;
+    APY_INLINE int leading_zeros_apyfixed(APyFixed fx) const;
     APY_INLINE bool same_type_as(APyFloat other) const;
 };
 


### PR DESCRIPTION
Also refactors addition slightly as a step towards special casing for single limb computations.

We should discuss how to deal with jamming for some cases. I'm still a bit doubtful if we actually should jam for adding/subtracting with zero. The argument is probably more for multiplying with zero, which will need to decide which exponent the jammed bit should have. That probably leads to that we should not jam for multiplication with zero (or division of zero by a non-zero value), so I actually doubt that we should jam for adding/subtracting by zero. By the way, I think that some operations suffer from double rounding. Not sure if it ever will affect any actual result though.