### PR TITLE
Increase test coverage in APyFloat

### DIFF
--- a/lib/test/apyfloat/test_methods.py
+++ b/lib/test/apyfloat/test_methods.py
@@ -1,6 +1,21 @@
 from itertools import permutations as perm
 import pytest
-from apytypes import APyFloat, APyFixed
+from apytypes import APyFloat
+
+
+def test_scalar_constructor_raises():
+    # Too many exponent bits
+    with pytest.raises(ValueError, match=".*exponent"):
+        APyFloat(0, 0, 0, 100, 5)
+    # Too many mantissa bits
+    with pytest.raises(ValueError, match=".*mantissa"):
+        APyFloat(0, 0, 0, 5, 100)
+
+
+def test_scalar_depricated_raises():
+    # The method 'resize' was depricated and changed to 'cast'
+    with pytest.warns(DeprecationWarning, match=".*cast"):
+        APyFloat(0, 0, 0, 7, 10).resize(10, 43)
 
 
 @pytest.mark.float_special
@@ -105,17 +120,21 @@ def test_properties():
     assert a.man == 4
     assert a.true_man == 68
     assert a.exp == 3
+    assert a.bias == 7
     assert a.true_exp == -4
     assert a.sign == False
     assert a.true_sign == 1
+    assert a.bits == 11
 
     a = APyFloat(1, 0, 4, 4, 6)
     assert a.man == 4
     assert a.true_man == 4
     assert a.exp == 0
+    assert a.bias == 7
     assert a.true_exp == -6
     assert a.sign == True
     assert a.true_sign == -1
+    assert a.bits == 11
 
     # Subnormal number
     a = APyFloat(0, 0, 1, 5, 2)

--- a/lib/test/apyfloat/test_methods.py
+++ b/lib/test/apyfloat/test_methods.py
@@ -115,6 +115,35 @@ def test_from_float():
     b.is_identical(a)
 
 
+def test_casting_special_numbers():
+    # Cast -0 to -0
+    a = APyFloat(1, 0, 0, 5, 7)
+    a = a.cast(10, 34)
+    assert a.is_identical(APyFloat(1, 0, 0, 10, 34))
+
+    # Cast -inf to -inf
+    a = APyFloat(1, 31, 0, 5, 7)
+    a = a.cast(11, 34)
+    assert a.is_identical(APyFloat(1, 2047, 0, 11, 34))
+
+    # Cast NaN to NaN
+    a = APyFloat(0, 31, 123, 5, 7)
+    a = a.cast(11, 34)
+    assert a.is_nan
+    assert a.exp_bits == 11
+    assert a.man_bits == 34
+
+    # Cast subnormal to normal
+    a = APyFloat(0, 0, 1, 4, 3)
+    a = a.cast(5, 3)
+    assert a.is_identical(APyFloat(0, 6, 0, 5, 3))
+
+    # Cast normal to subnormal
+    a = APyFloat(0, 6, 0, 5, 3)
+    a = a.cast(4, 3)
+    assert a.is_identical(APyFloat(0, 0, 1, 4, 3))
+
+
 def test_properties():
     a = APyFloat(0, 3, 4, 4, 6)
     assert a.man == 4


### PR DESCRIPTION
Increase test coverage for miscellaneous things, such as constructor raises and warnings for deprecated functions, in APyFloat.