### PR TITLE
Add fast path for floating-point addition

### DIFF
--- a/lib/test/apyfloat/test_arithmetic.py
+++ b/lib/test/apyfloat/test_arithmetic.py
@@ -119,36 +119,35 @@ def test_add_representable(exp, man, sign, lhs, rhs):
 def test_add_overflow():
     """Test that an addition can overflow."""
     # To positive infinity
-    assert (APyFloat(0, 30, 3, 5, 2) + APyFloat(0, 30, 3, 5, 2)).is_inf
+    res = APyFloat(0, 30, 3, 5, 2) + APyFloat(0, 30, 3, 5, 2)
+    assert res.is_inf
 
     # To negative infinity
-    assert (APyFloat(1, 30, 3, 5, 2) + APyFloat(1, 30, 3, 5, 2)).is_inf
+    res = APyFloat(1, 30, 3, 5, 2) + APyFloat(1, 30, 3, 5, 2)
+    assert res.is_inf
 
     # Overflow to infinity after quantization
-    assert (APyFloat(0, 30, 3, 5, 2) + APyFloat(0, 27, 0, 5, 2)).is_inf
+    res = APyFloat(0, 30, 3, 5, 2) + APyFloat(0, 27, 0, 5, 2)
+    assert res.is_inf
 
 
 @pytest.mark.float_add
 def test_add_subnormals():
     # Add two subnormal numbers
-    assert (APyFloat(0, 0, 1, 5, 3) + APyFloat(0, 0, 2, 5, 3)).is_identical(
-        APyFloat(0, 0, 3, 5, 3)
-    )
+    res = APyFloat(0, 0, 1, 5, 3) + APyFloat(0, 0, 2, 5, 3)
+    assert res.is_identical(APyFloat(0, 0, 3, 5, 3))
 
     # Addition of subnormal numbers resulting in normal number
-    assert (APyFloat(0, 0, 7, 5, 3) + APyFloat(0, 0, 1, 5, 3)).is_identical(
-        APyFloat(0, 1, 0, 5, 3)
-    )
+    res = APyFloat(0, 0, 7, 5, 3) + APyFloat(0, 0, 1, 5, 3)
+    assert res.is_identical(APyFloat(0, 1, 0, 5, 3))
 
     # Add subnormal to normal number
-    assert (APyFloat(0, 0, 1, 4, 3) + APyFloat(0, 1, 0, 4, 3)).is_identical(
-        APyFloat(0, 1, 1, 4, 3)
-    )
+    res = APyFloat(0, 0, 1, 4, 3) + APyFloat(0, 1, 0, 4, 3)
+    assert res.is_identical(APyFloat(0, 1, 1, 4, 3))
 
     # Add subnormal to big normal number
-    assert (APyFloat(0, 0, 1, 4, 3) + APyFloat(0, 7, 0, 4, 3)).is_identical(
-        APyFloat(0, 7, 0, 4, 3)
-    )
+    res = APyFloat(0, 0, 1, 4, 3) + APyFloat(0, 7, 0, 4, 3)
+    assert res.is_identical(APyFloat(0, 7, 0, 4, 3))
 
 
 @pytest.mark.float_add
@@ -188,8 +187,8 @@ def test_add_inf_nan():
 
 
 @pytest.mark.float_add
-def test_long_add():
-    """Some tests for sanity checking addition with long formats."""
+def test_add_double():
+    """Some tests for sanity checking addition with binary64. This uses the faster path."""
 
     # 2.5 + 24.5 = 27.0
     x = APyFloat(sign=0, exp=1024, man=0x4000000000000, exp_bits=11, man_bits=52)
@@ -219,6 +218,12 @@ def test_long_add():
     y = APyFloat(0, 1025, 0x4DA8D64D7F0ED, 11, 52)
     res = x + y
     assert res.is_identical(APyFloat(0, 1025, 0x9CA80064A9CDC, 11, 52))
+
+
+@pytest.mark.float_add
+def test_long_add():
+    """TODO: some tests for sanity checking addition with longer formats."""
+    pass
 
 
 # Subtraction
@@ -281,24 +286,20 @@ def test_sub_overflow():
 @pytest.mark.float_add
 def test_sub_subnormals():
     # Subtract two subnormal numbers
-    assert (APyFloat(0, 0, 1, 5, 3) - APyFloat(0, 0, 2, 5, 3)).is_identical(
-        APyFloat(1, 0, 1, 5, 3)
-    )
+    res = APyFloat(0, 0, 1, 5, 3) - APyFloat(0, 0, 2, 5, 3)
+    assert res.is_identical(APyFloat(1, 0, 1, 5, 3))
 
     # Subtraction of subnormal numbers resulting in normal number
-    assert (APyFloat(1, 0, 7, 5, 3) - APyFloat(0, 0, 1, 5, 3)).is_identical(
-        APyFloat(1, 1, 0, 5, 3)
-    )
+    res = APyFloat(1, 0, 7, 5, 3) - APyFloat(0, 0, 1, 5, 3)
+    assert res.is_identical(APyFloat(1, 1, 0, 5, 3))
 
     # Subtract subnormal from normal number
-    assert (APyFloat(0, 1, 0, 4, 3) - APyFloat(0, 0, 1, 4, 3)).is_identical(
-        APyFloat(0, 0, 7, 4, 3)
-    )
+    res = APyFloat(0, 1, 0, 4, 3) - APyFloat(0, 0, 1, 4, 3)
+    assert res.is_identical(APyFloat(0, 0, 7, 4, 3))
 
     # Subtract subnormal from big normal number
-    assert (APyFloat(0, 7, 0, 4, 3) - APyFloat(0, 0, 1, 4, 3)).is_identical(
-        APyFloat(0, 7, 0, 4, 3)
-    )
+    res = APyFloat(0, 7, 0, 4, 3) - APyFloat(0, 0, 1, 4, 3)
+    assert res.is_identical(APyFloat(0, 7, 0, 4, 3))
 
 
 @pytest.mark.float_sub

--- a/lib/test/apyfloat/test_arithmetic.py
+++ b/lib/test/apyfloat/test_arithmetic.py
@@ -237,6 +237,12 @@ def test_long_add():
     res = x + y
     assert res.is_identical(APyFloat(sign=0, exp=0, man=94, exp_bits=11, man_bits=61))
 
+    # Add two subnormals that becomes a normal number
+    x = APyFloat(sign=0, exp=0, man=(1 << 61) - 1, exp_bits=11, man_bits=61)
+    y = APyFloat(sign=0, exp=0, man=1, exp_bits=11, man_bits=61)
+    res = x + y
+    assert res.is_identical(APyFloat(sign=0, exp=1, man=0, exp_bits=11, man_bits=61))
+
     # Mixed formats. 1.75 + (-5) = -3.25
     x = APyFloat(sign=0, exp=7, man=6, exp_bits=4, man_bits=3)
     y = APyFloat(sign=1, exp=1025, man=0x4000000000000 << 8, exp_bits=11, man_bits=60)
@@ -251,6 +257,29 @@ def test_long_add():
     y = APyFloat(0, 1025, 0x4DA8D64D7F0ED << 8, 11, 60)
     res = x + y
     assert res.is_identical(APyFloat(0, 1025, 0x9CA80064A9CDC << 8, 11, 60))
+
+    # Test carry from addition of mantissas
+    x = APyFloat(0, 1023, 1 << 59, 11, 60)
+    res = x + x
+    assert res.is_identical(APyFloat(0, 1024, 1 << 59, 11, 60))
+
+    # Test carry from addition of mantissas can overflow to infinity
+    x = APyFloat(0, 2046, 1 << 59, 11, 60)
+    y = APyFloat(0, 2046, 1 << 59, 11, 60)
+    res = x + y
+    assert res.is_identical(APyFloat(0, 2047, 0, 11, 60))
+
+    # Test carry from quantization
+    x = APyFloat(0, 1023, (1 << 60) - 1, 11, 60)
+    y = APyFloat(0, 1023 - 61, 0, 11, 60)  # Tie break
+    res = x + y
+    assert res.is_identical(APyFloat(0, 1024, 0, 11, 60))
+
+    # Test carry from quantization can overflow to infinity
+    x = APyFloat(0, 2046, (1 << 60) - 1, 11, 60)
+    y = APyFloat(0, 2046 - 61, 0, 11, 60)  # Tie break
+    res = x + y
+    assert res.is_identical(APyFloat(0, 2047, 0, 11, 60))
 
 
 # Subtraction

--- a/lib/test/apyfloat/test_arithmetic.py
+++ b/lib/test/apyfloat/test_arithmetic.py
@@ -222,8 +222,35 @@ def test_add_double():
 
 @pytest.mark.float_add
 def test_long_add():
-    """TODO: some tests for sanity checking addition with longer formats."""
-    pass
+    """Some tests for sanity checking addition with longer formats."""
+    # 2.5 + 24.5 = 27.0
+    x = APyFloat(sign=0, exp=1024, man=0x4000000000000 << 8, exp_bits=11, man_bits=60)
+    y = APyFloat(sign=0, exp=1027, man=0x8400000000000 << 8, exp_bits=11, man_bits=60)
+    res = x + y
+    assert res.is_identical(
+        APyFloat(sign=0, exp=1027, man=0xAC00000000000 << 8, exp_bits=11, man_bits=60)
+    )
+
+    # Add two subnormals
+    x = APyFloat(sign=0, exp=0, man=23, exp_bits=11, man_bits=61)
+    y = APyFloat(sign=0, exp=0, man=71, exp_bits=11, man_bits=61)
+    res = x + y
+    assert res.is_identical(APyFloat(sign=0, exp=0, man=94, exp_bits=11, man_bits=61))
+
+    # Mixed formats. 1.75 + (-5) = -3.25
+    x = APyFloat(sign=0, exp=7, man=6, exp_bits=4, man_bits=3)
+    y = APyFloat(sign=1, exp=1025, man=0x4000000000000 << 8, exp_bits=11, man_bits=60)
+    res = x + y
+    assert res.is_identical(
+        APyFloat(sign=1, exp=1024, man=0xA000000000000 << 8, exp_bits=11, man_bits=60)
+    )
+
+    # 1.234324 + 5.21343 = 6.447754
+    # These numbers cannot be represented exactly but should be performed as the following
+    x = APyFloat(0, 1023, 0x3BFCA85CAAFBC << 8, 11, 60)
+    y = APyFloat(0, 1025, 0x4DA8D64D7F0ED << 8, 11, 60)
+    res = x + y
+    assert res.is_identical(APyFloat(0, 1025, 0x9CA80064A9CDC << 8, 11, 60))
 
 
 # Subtraction

--- a/src/apyfloat.cc
+++ b/src/apyfloat.cc
@@ -785,7 +785,8 @@ APyFloat APyFloat::operator+(APyFloat y) const
     // A tighter bound would sometimes be sufficient, but checking that is probably not
     // worth it
     const unsigned int max_man_bits = res.man_bits + 5;
-    if (max_man_bits <= _MAN_T_SIZE_BITS) {
+    if ((max_man_bits <= _MAN_T_SIZE_BITS)
+        && (quantization != QuantizationMode::STOCH_WEIGHTED)) {
         // Align mantissa based on format, also add room for guard bits
         const int man_bits_delta = x.man_bits - y.man_bits;
         if (man_bits_delta > 0) {


### PR DESCRIPTION
Use integer operations when the intermediate result can fit within one `man_t` (64-bits). This is related to #124.

Note that the test for floating-point addition with long formats uses binary64, as these will now use the fast path this test must be re-written as well. 