### PR TITLE
Refactor mantissa quantization to its own method

### DIFF
--- a/lib/test/apyfloat/test_arithmetic.py
+++ b/lib/test/apyfloat/test_arithmetic.py
@@ -414,13 +414,15 @@ def test_mul_mixed(exp, man, sign, lhs, rhs):
 @pytest.mark.float_mul
 def test_mul_overflow():
     """Test that a multiplication can overflow to infinity."""
-    assert (APyFloat(0, 0b11110, 1, 5, 2) * APyFloat(0, 0b11110, 3, 5, 3)).is_inf
+    res = APyFloat(0, 0b11110, 1, 5, 2) * APyFloat(0, 0b11110, 3, 5, 3)
+    assert res.is_inf
 
 
 @pytest.mark.float_mul
 def test_mul_underflow():
     """Test that a multiplication can underflow to zero."""
-    assert (APyFloat(0, 1, 1, 5, 2) * APyFloat(0, 1, 3, 5, 3)) == 0
+    res = APyFloat(0, 1, 1, 5, 2) * APyFloat(0, 1, 3, 5, 3)
+    assert res == 0
 
 
 @pytest.mark.float_mul

--- a/src/apyfloat.h
+++ b/src/apyfloat.h
@@ -121,6 +121,10 @@ public:
         QuantizationMode quantization
     ) const;
 
+    //! Change the number of mantissa bits. The number is assumed not be NaN or Inf.
+    //! The exponent is updated in case of carry.
+    void cast_mantissa(std::uint8_t man_bits, QuantizationMode quantization);
+
     APyFloat cast_no_quant(
         std::uint8_t exp_bits,
         std::uint8_t man_bits,


### PR DESCRIPTION
Makes the `_cast` method not as big, and will hopefully improve the performance of floating-point addition.