### PR TITLE
More test cases and add overflow detection in APyFloat cast

### DIFF
--- a/lib/test/apyfloat/test_arithmetic.py
+++ b/lib/test/apyfloat/test_arithmetic.py
@@ -656,6 +656,10 @@ def test_power():
     a = APyFloat(sign=0, exp=511, man=1116352409, exp_bits=10, man_bits=32)
     (a**3).is_identical(APyFloat(sign=0, exp=512, man=0, exp_bits=10, man_bits=32))
 
+    # Test identity
+    a = APyFloat(sign=0, exp=511, man=1116352409, exp_bits=10, man_bits=32)
+    (a**1).is_identical(a)
+
 
 @pytest.mark.float_pow
 def test_power_subnormal_res():
@@ -707,6 +711,21 @@ def test_long_power():
     res = APyFloat.from_float(1.75, 11, 52) ** 3
     assert res.is_identical(APyFloat.from_float(1.75**3, 11, 52))
 
+    # Test overflow
+    # Related to https://github.com/apytypes/apytypes/issues/288
+    res = APyFloat(0, 30, 1, 5, 60) ** 2
+    assert res.is_identical(APyFloat(0, 31, 0, 5, 60))
+    res = APyFloat(0, 30, 1, 5, 60) ** 1000
+    assert res.is_identical(APyFloat(0, 31, 0, 5, 60))
+
+    # Test underflow
+    res = APyFloat(1, 0, 1, 5, 60) ** 1000
+    assert res.is_identical(APyFloat(0, 0, 0, 5, 60))
+
+    # Test identity
+    a = APyFloat(sign=0, exp=511, man=1116352409, exp_bits=20, man_bits=61)
+    (a**1).is_identical(a)
+
 
 @pytest.mark.xfail()
 @pytest.mark.float_pow
@@ -726,16 +745,18 @@ def test_negative_long_power():
 @pytest.mark.float_pow
 def test_power_overflow():
     """Test that the power function can overflow to infinity."""
-    assert float(APyFloat(0, 0b11110, 1, 5, 2) ** 2) == float("inf")
-    assert float(APyFloat(1, 0b11110, 1, 5, 2) ** 3) == float("-inf")
+    res = APyFloat(0, 30, 1, 5, 4) ** 2
+    assert res.is_identical(APyFloat(0, 31, 0, 5, 4))
+    # Related to https://github.com/apytypes/apytypes/issues/288
+    res = APyFloat(1, 30, 1, 5, 4) ** 1001
+    assert res.is_identical(APyFloat(1, 31, 0, 5, 4))
 
 
 @pytest.mark.float_pow
 def test_power_underflow():
     """Test that the power function can underflow to zero."""
-    res = APyFloat(0, 1, 1, 5, 2) ** 3
-    assert res.is_identical(APyFloat(0, 0, 0, 5, 2))
-
+    res = APyFloat(1, 1, 1, 5, 2) ** 3
+    assert res.is_identical(APyFloat(1, 0, 0, 5, 2))
     res = APyFloat(0, 0, 1, 5, 2) ** 2
     assert res.is_identical(APyFloat(0, 0, 0, 5, 2))
 

--- a/lib/test/apyfloat/test_methods.py
+++ b/lib/test/apyfloat/test_methods.py
@@ -115,6 +115,28 @@ def test_from_float():
     b.is_identical(a)
 
 
+def test_cast_special_cases():
+    # Only change the number of exponent bits
+    a = APyFloat(1, 15, 4, 5, 3)
+    a = a.cast(4, 3)
+    assert a.is_identical(APyFloat(1, 7, 4, 4, 3))
+
+    # Only change the number of mantissa bits
+    a = APyFloat(1, 15, 4, 5, 3)
+    a = a.cast(4, 2)
+    assert a.is_identical(APyFloat(1, 7, 2, 4, 2))
+
+    # Cast from big number becomes infinity
+    a = APyFloat(1, 30, 4, 5, 3)
+    a = a.cast(4, 3)
+    assert a.is_identical(APyFloat(1, 15, 0, 4, 3))
+
+    # Cast from small number becomes zero (for TIES_EVEN)
+    a = APyFloat(0, 0, 1, 5, 3)
+    a = a.cast(4, 3)
+    assert a.is_identical(APyFloat(0, 0, 0, 4, 3))
+
+
 def test_casting_special_numbers():
     # Cast -0 to -0
     a = APyFloat(1, 0, 0, 5, 7)

--- a/src/apyfloat.cc
+++ b/src/apyfloat.cc
@@ -241,6 +241,8 @@ APyFloat APyFloat::_cast(
 
     if (new_exp <= -static_cast<std::int64_t>(res.man_bits)) { // Exponent too small
         return res.construct_zero();
+    } else if (new_exp >= res.max_exponent()) {
+        return res.construct_inf();
     }
 
     // Check if the number will be converted to a subnormal
@@ -1131,7 +1133,7 @@ APyFloat APyFloat::pow(const APyFloat& x, const APyFloat& y)
 APyFloat APyFloat::pown(const APyFloat& x, int n)
 {
     // Handling of special cases based on the 754-2019 standard
-    if (x.is_nan()) {
+    if (x.is_nan() || (n == 1)) {
         return x;
     }
 


### PR DESCRIPTION
Fixes #288. 

The method `_cast` did not check whether the exponent was within range when casting to a format with more mantissa bits. This was probably introduced in PR #277. 

This PR also adds an early exit when the power is 1, and also some more test cases related to casting.