### PR TITLE
Update version management to use setuptools_scm

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -10,6 +10,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - uses: actions/setup-python@v5
         with:
           python-version: "3.10"

--- a/.github/workflows/run_coverage.yml
+++ b/.github/workflows/run_coverage.yml
@@ -17,6 +17,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v5
       with:
@@ -25,9 +27,10 @@ jobs:
       run: |
         sudo apt-get install -yy lcov
         python -m pip install --upgrade pip
-        python -m pip install pytest-cov gcovr ninja meson-python numpy
+        python -m pip install pytest-cov gcovr ninja meson-python numpy setuptools_scm
     - name: Install APyTypes
       run: |
+        git fetch --tags
         export CPPFLAGS='-O0 --coverage -fprofile-abs-path'
         python -m pip install --no-deps --no-build-isolation -v --editable .
         unset CPPFLAGS

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -25,6 +25,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
     - uses: ilammy/msvc-dev-cmd@v1  # Active MSVC environment on Windows virtual env
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v5
@@ -35,6 +37,7 @@ jobs:
         python -m pip install --upgrade pip
     - name: Install APyTypes
       run: |
+        git fetch --tags
         python -m pip install .[test] -v
     - name: Test with pytest
       run: |

--- a/meson.build
+++ b/meson.build
@@ -1,8 +1,8 @@
 project(
     'apytypes',
     'cpp', 'c',
-    default_options : ['cpp_std=c++17', 'c_std=c17'],
-    version : '0.0.1.dev0',
+    default_options : ['cpp_std=c++17', 'c_std=c17', 'b_lto=true'],
+    version : run_command(find_program('python3'), '-m', 'setuptools_scm', check: true).stdout().strip(),
 )
 
 # Python module incudes

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,3 @@
-[build-system]
-build-backend = 'mesonpy'
-requires = ['meson-python']
-
 [project]
 name = "apytypes"
 dynamic = ['version']
@@ -20,11 +16,9 @@ classifiers = [
 ]
 
 [project.urls]
-Homepage = "https://apytypes.github.io/"
+Homepage = "https://github.com/apytypes/apytypes/"
 Issues = "https://github.com/apytypes/apytypes/issues"
-
-[tool.meson-python.args]
-install = ['--skip-subprojects']
+Documentation = "https://apytypes.github.io/apytypes/"
 
 [project.optional-dependencies]
 docs = [
@@ -48,6 +42,20 @@ comparison = [
     "numpy",
     "matplotlib",
 ]
+
+[build-system]
+build-backend = 'mesonpy'
+requires = ['meson-python', 'setuptools_scm>=7']
+
+[tool.meson-python.args]
+install = ['--skip-subprojects']
+
+[tool.setuptools_scm]
+version_scheme = "release-branch-semver"
+local_scheme = "node-and-date"
+write_to = "lib/apytypes/_version.py"
+parentdir_prefix_version = "apytypes-"
+fallback_version = "0.0+UNKNOWN"
 
 [tool.pytest.ini_options]
 markers = [


### PR DESCRIPTION
Now it should be enough to tag a version and it will be used when building. Later dev-versions will automatically be one minor version higher.

Also enables lto, so about 300 k smaller library.