### PR TITLE
Faster floating-point matrix multiplication

### DIFF
--- a/src/apyfloatarray.h
+++ b/src/apyfloatarray.h
@@ -188,7 +188,7 @@ private:
      * multiplication.
      */
     APyFloatArray checked_2d_matmul(const APyFloatArray& rhs) const;
-    APyFloat vector_sum() const;
+    APyFloat vector_sum(const QuantizationMode quantization) const;
 };
 
 #endif


### PR DESCRIPTION
Closes #368 

(Doing it in steps instead...)

Remains:

- [ ] Only set/reset quantization mode in one location for the accumulation context (and inline actual multiplication + vector sum)
- [ ] Cast matrix rather than re-cast vectors all the time