### PR TITLE
Small fix in long floating-point multiplication / division

### DIFF
--- a/lib/test/apyfloat/test_arithmetic.py
+++ b/lib/test/apyfloat/test_arithmetic.py
@@ -608,6 +608,16 @@ def test_long_mul():
     res = x * y
     assert res.is_identical(APyFloat(sign=0, exp=2047, man=0, exp_bits=11, man_bits=60))
 
+    # Subnormal becoming normal after quantization
+    x = APyFloat(
+        sign=0, exp=0, man=4503599627370495, exp_bits=11, man_bits=52
+    )  # (2.22507e-308)
+    y = APyFloat(
+        sign=0, exp=1023, man=1, exp_bits=11, man_bits=52
+    )  # Slightly larger than 1
+    res = x * y
+    assert res.is_identical(APyFloat(sign=0, exp=1, man=0, exp_bits=11, man_bits=52))
+
 
 @pytest.mark.float_div
 @pytest.mark.parametrize("exp", list(perm(["5", "8"], 2)))
@@ -695,6 +705,21 @@ def test_subnormal_div():
     assert res.is_identical(x)
 
     # More test cases to be added
+
+
+@pytest.mark.float_div
+def test_subnormal_quant_div():
+    """Subnormal becoming normal after quantization."""
+    res = APyFloat(sign=0, exp=1, man=1023, exp_bits=5, man_bits=10) / APyFloat(
+        sign=0, exp=16, man=0, exp_bits=5, man_bits=10
+    )
+    assert res.is_identical(APyFloat(sign=0, exp=1, man=0, exp_bits=5, man_bits=10))
+
+    # -2 / -8.98847e+307
+    res = APyFloat(
+        sign=1, exp=1023, man=4503599627370495, exp_bits=11, man_bits=52
+    ) / APyFloat(sign=1, exp=2046, man=0, exp_bits=11, man_bits=52)
+    assert res.is_identical(APyFloat(sign=0, exp=1, man=0, exp_bits=11, man_bits=52))
 
 
 @pytest.mark.float_div

--- a/lib/test/apyfloatarray/test_arithmetic.py
+++ b/lib/test/apyfloatarray/test_arithmetic.py
@@ -474,6 +474,16 @@ def test_array_mul():
     res = a * b
     assert res.is_identical(APyFloatArray([1], [0], [986], 5, 10))
 
+    # Subnormal becoming normal after quantization
+    x = APyFloatArray(
+        [0], [0], [4503599627370495], exp_bits=11, man_bits=52
+    )  # (2.22507e-308)
+    y = APyFloatArray(
+        [0], [1023], [1], exp_bits=11, man_bits=52
+    )  # Slightly larger than 1
+    res = x * y
+    assert res.is_identical(APyFloatArray([0], [1], [0], exp_bits=11, man_bits=52))
+
 
 @pytest.mark.float_array
 def test_array_mul_scalar():
@@ -624,6 +634,14 @@ def test_array_mul_scalar():
     res = a * b
     assert res.is_identical(APyFloatArray([1], [0], [986], 5, 10))
 
+    # Subnormal becoming normal after quantization
+    x = APyFloatArray(
+        [0], [0], [4503599627370495], exp_bits=11, man_bits=52
+    )  # (2.22507e-308)
+    y = APyFloat(0, 1023, 1, exp_bits=11, man_bits=52)  # Slightly larger than 1
+    res = x * y
+    assert res.is_identical(APyFloatArray([0], [1], [0], exp_bits=11, man_bits=52))
+
 
 @pytest.mark.float_array
 def test_array_mul_int_float():
@@ -667,12 +685,34 @@ def test_array_div():
     )
     assert (a / b).is_identical(ans)
 
+    res = APyFloatArray([0], [1], [1023], exp_bits=5, man_bits=10) / APyFloatArray(
+        [0], [16], [0], exp_bits=5, man_bits=10
+    )
+    assert res.is_identical(APyFloatArray([0], [1], [0], exp_bits=5, man_bits=10))
+
+    # -2 / -8.98847e+307
+    res = APyFloatArray(
+        [1], [1023], [4503599627370495], exp_bits=11, man_bits=52
+    ) / APyFloatArray([1], [2046], [0], exp_bits=11, man_bits=52)
+    assert res.is_identical(APyFloatArray([0], [1], [0], exp_bits=11, man_bits=52))
+
 
 @pytest.mark.float_array
 def test_array_div_scalar():
     a = APyFloatArray.from_float([4, 12, 40], 9, 10)
     b = APyFloat.from_float(8, 9, 8)
     assert (a / b).is_identical(APyFloatArray.from_float([0.5, 1.5, 5], 9, 10))
+
+    res = APyFloatArray([0], [1], [1023], exp_bits=5, man_bits=10) / APyFloat(
+        0, 16, 0, exp_bits=5, man_bits=10
+    )
+    assert res.is_identical(APyFloatArray([0], [1], [0], exp_bits=5, man_bits=10))
+
+    # -2 / -8.98847e+307
+    res = APyFloatArray(
+        [1], [1023], [4503599627370495], exp_bits=11, man_bits=52
+    ) / APyFloat(1, 2046, 0, exp_bits=11, man_bits=52)
+    assert res.is_identical(APyFloatArray([0], [1], [0], exp_bits=11, man_bits=52))
 
 
 @pytest.mark.float_array

--- a/src/apyfloat.cc
+++ b/src/apyfloat.cc
@@ -1050,6 +1050,12 @@ APyFloat APyFloat::operator*(const APyFloat& y) const
 
         if (apy_res.positive_greater_than_equal_pow2(0)) { // Remove leading one
             apy_res = apy_res - fx_one;
+
+            // If a leading one is present while the exponent is zero,
+            // then it 'acts like a carry' and creates a normal number
+            if (new_exp == 0) {
+                new_exp = 1;
+            }
         }
         apy_res <<= res.man_bits;
         res.man = (man_t)(apy_res).to_double();
@@ -1131,6 +1137,12 @@ APyFloat APyFloat::operator/(const APyFloat& y) const
     // Remove leading one
     if (apy_man_res.positive_greater_than_equal_pow2(0)) {
         apy_man_res = apy_man_res - fx_one;
+
+        // If a leading one is present while the exponent is zero,
+        // then it 'acts like a carry' and creates a normal number
+        if (new_exp == 0) {
+            new_exp = 1;
+        }
     }
     apy_man_res <<= res.man_bits;
     res.man = (man_t)(apy_man_res).to_double();


### PR DESCRIPTION
Setting the exponent to '1' for a certain case was missing in two places: division, and multiplication with long formats. 