### PR TITLE
Handle infinity according to quantization mode

### DIFF
--- a/lib/test/apyfloat/run_berkeley_cases.py
+++ b/lib/test/apyfloat/run_berkeley_cases.py
@@ -290,7 +290,7 @@ def print_summary(summary, output_file: str, seed: int, level: int) -> None:
 
     success_rate = (1 - float(failed_tests) / total_tests) * 100
     print(
-        f"Ran {total_tests} tests in total whereof {failed_tests} failed, giving a {success_rate:.2f}% overall success rate."
+        f"Ran {total_tests} tests in total whereof {failed_tests} failed, giving an overall success rate of {success_rate:.2f}%."
     )
 
 

--- a/lib/test/apyfloat/run_berkeley_cases.py
+++ b/lib/test/apyfloat/run_berkeley_cases.py
@@ -115,22 +115,23 @@ def run_berkeley_test(
 
     if "to" in operation:
         to_exp_bits, to_man_bits = parse_format(args[2])
-        with open(output_file, "a") as f:
-            for test in test_cases:
-                tests_total += 1
-                lhs = APyFloat.from_bits(test[0], exp_bits, man_bits)
-                ref = APyFloat.from_bits(test[1], to_exp_bits, to_man_bits)
-                try:
-                    res = func_under_test(lhs, to_exp_bits, to_man_bits)
-                except Exception as e:
-                    f.write(f"lhs: {lhs!r}, ref: {ref!r}, res: {res!r}\n")
-                    f.write(f"Exception: {e}")
-                else:
-                    if (ref.is_nan and not res.is_nan) or (
-                        not ref.is_nan and not res.is_identical(ref)
-                    ):
+        with APyFloatQuantizationContext(quantization):
+            with open(output_file, "a") as f:
+                for test in test_cases:
+                    tests_total += 1
+                    lhs = APyFloat.from_bits(test[0], exp_bits, man_bits)
+                    ref = APyFloat.from_bits(test[1], to_exp_bits, to_man_bits)
+                    try:
+                        res = func_under_test(lhs, to_exp_bits, to_man_bits)
+                    except Exception as e:
                         f.write(f"lhs: {lhs!r}, ref: {ref!r}, res: {res!r}\n")
-                        tests_failed += 1
+                        f.write(f"Exception: {e}")
+                    else:
+                        if (ref.is_nan and not res.is_nan) or (
+                            not ref.is_nan and not res.is_identical(ref)
+                        ):
+                            f.write(f"lhs: {lhs!r}, ref: {ref!r}, res: {res!r}\n")
+                            tests_failed += 1
     else:
         with APyFloatQuantizationContext(quantization):
             with open(output_file, "a") as f:

--- a/lib/test/apyfloat/test_rounding.py
+++ b/lib/test/apyfloat/test_rounding.py
@@ -40,6 +40,14 @@ class TestAPyFloatQuantizationAddSub:
             res = APyFloat(1, 15, 2, 5, 2) + APyFloat(0, 1, 0, 5, 2)
             assert res.is_identical(APyFloat(1, 15, 1, 5, 2))
 
+            # Two big positive numbers should become infinity
+            res = APyFloat(0, 30, 3, 5, 2) + APyFloat(0, 30, 3, 5, 2)
+            assert res.is_identical(APyFloat(0, 31, 0, 5, 2))
+
+            # Two big negative numbers should saturate
+            res = APyFloat(1, 30, 3, 5, 2) + APyFloat(1, 30, 3, 5, 2)
+            assert res.is_identical(APyFloat(1, 30, 3, 5, 2))
+
     def test_to_neg(self):
         with APyFloatQuantizationContext(QuantizationMode.TO_NEG):
             # 1.5 + very small number should quantize to 1.5
@@ -49,6 +57,14 @@ class TestAPyFloatQuantizationAddSub:
             # -1.5 + very small number should quantize to 1.5
             res = APyFloat(1, 15, 2, 5, 2) + APyFloat(0, 1, 0, 5, 2)
             assert res.is_identical(APyFloat(1, 15, 2, 5, 2))
+
+            # Two big positive numbers should saturate
+            res = APyFloat(0, 30, 3, 5, 2) + APyFloat(0, 30, 3, 5, 2)
+            assert res.is_identical(APyFloat(0, 30, 3, 5, 2))
+
+            # Two big negative numbers should become infinity
+            res = APyFloat(1, 30, 3, 5, 2) + APyFloat(1, 30, 3, 5, 2)
+            assert res.is_identical(APyFloat(1, 31, 0, 5, 2))
 
     def test_to_zero(self):
         with APyFloatQuantizationContext(QuantizationMode.TO_ZERO):
@@ -63,6 +79,14 @@ class TestAPyFloatQuantizationAddSub:
                 sign=1, exp=12, man=3, exp_bits=5, man_bits=2
             )
             assert res.is_identical(APyFloat(1, 15, 2, 5, 2))
+
+            # Two big positive numbers should saturate
+            res = APyFloat(0, 30, 3, 5, 2) + APyFloat(0, 30, 3, 5, 2)
+            assert res.is_identical(APyFloat(0, 30, 3, 5, 2))
+
+            # Two big negative numbers should saturate
+            res = APyFloat(1, 30, 3, 5, 2) + APyFloat(1, 30, 3, 5, 2)
+            assert res.is_identical(APyFloat(1, 30, 3, 5, 2))
 
     def test_to_ties_even(self):
         with APyFloatQuantizationContext(QuantizationMode.TIES_EVEN):
@@ -102,6 +126,14 @@ class TestAPyFloatQuantizationAddSub:
             res = APyFloat(1, 15, 3, 5, 2) + APyFloat(1, 12, 0, 5, 2)
             assert res.is_identical(APyFloat(1, 16, 0, 5, 2))
 
+            # Two big positive numbers should become infinity
+            res = APyFloat(0, 30, 3, 5, 2) + APyFloat(0, 30, 3, 5, 2)
+            assert res.is_identical(APyFloat(0, 31, 0, 5, 2))
+
+            # Two big negative numbers should become infinity
+            res = APyFloat(1, 30, 3, 5, 2) + APyFloat(1, 30, 3, 5, 2)
+            assert res.is_identical(APyFloat(1, 31, 0, 5, 2))
+
     def test_to_ties_away(self):
         with APyFloatQuantizationContext(QuantizationMode.TIES_EVEN):
             # 1.5 + relatively big number (0.21875) should quantize to 1.75
@@ -140,6 +172,14 @@ class TestAPyFloatQuantizationAddSub:
             res = APyFloat(1, 15, 3, 5, 2) + APyFloat(1, 12, 0, 5, 2)
             assert res.is_identical(APyFloat(1, 16, 0, 5, 2))
 
+            # Two big positive numbers should become infinity
+            res = APyFloat(0, 30, 3, 5, 2) + APyFloat(0, 30, 3, 5, 2)
+            assert res.is_identical(APyFloat(0, 31, 0, 5, 2))
+
+            # Two big negative numbers should become infinity
+            res = APyFloat(1, 30, 3, 5, 2) + APyFloat(1, 30, 3, 5, 2)
+            assert res.is_identical(APyFloat(1, 31, 0, 5, 2))
+
     def test_jam(self):
         with APyFloatQuantizationContext(QuantizationMode.JAM):
             # 1.5 + very small number should quantize to 1.75
@@ -153,6 +193,14 @@ class TestAPyFloatQuantizationAddSub:
             # 1.0 + 1.0 should become 2.5
             res = APyFloat(0, 15, 0, 5, 2) + APyFloat(0, 15, 0, 5, 2)
             assert res.is_identical(APyFloat(0, 16, 1, 5, 2))
+
+            # Two big positive numbers should saturate
+            res = APyFloat(0, 30, 3, 5, 2) + APyFloat(0, 30, 3, 5, 2)
+            assert res.is_identical(APyFloat(0, 30, 3, 5, 2))
+
+            # Two big negative numbers should saturate
+            res = APyFloat(1, 30, 3, 5, 2) + APyFloat(1, 30, 3, 5, 2)
+            assert res.is_identical(APyFloat(1, 30, 3, 5, 2))
 
     def test_stoch_weighted(self):
         with APyFloatQuantizationContext(QuantizationMode.STOCH_WEIGHTED):
@@ -216,6 +264,14 @@ class TestAPyFloatQuantizationMul:
             res = APyFloat(1, 0, 1, 4, 3) * APyFloat(0, 0, 1, 4, 3)
             assert res.is_identical(APyFloat(1, 0, 0, 4, 3))
 
+            # Big positive number should become infinity
+            res = APyFloat(0, 30, 3, 5, 2) * APyFloat(0, 30, 3, 5, 2)
+            assert res.is_identical(APyFloat(0, 31, 0, 5, 2))
+
+            # Big negative number should saturate
+            res = APyFloat(1, 30, 3, 5, 2) * APyFloat(0, 30, 3, 5, 2)
+            assert res.is_identical(APyFloat(1, 30, 3, 5, 2))
+
     def test_to_neg(self):
         with APyFloatQuantizationContext(QuantizationMode.TO_NEG):
             # Should round down
@@ -241,6 +297,14 @@ class TestAPyFloatQuantizationMul:
             res = APyFloat(1, 0, 1, 4, 3) * APyFloat(0, 0, 1, 4, 3)
             assert res.is_identical(APyFloat(1, 0, 1, 4, 3))
 
+            # Big positive number should saturate
+            res = APyFloat(0, 30, 3, 5, 2) * APyFloat(0, 30, 3, 5, 2)
+            assert res.is_identical(APyFloat(0, 30, 3, 5, 2))
+
+            # Big negative number should become infinity
+            res = APyFloat(1, 30, 3, 5, 2) * APyFloat(0, 30, 3, 5, 2)
+            assert res.is_identical(APyFloat(1, 31, 0, 5, 2))
+
 
 @pytest.mark.float_div
 class TestAPyFloatQuantizationDiv:
@@ -258,6 +322,14 @@ class TestAPyFloatQuantizationDiv:
             res = APyFloat(1, 15, 2, 5, 2) / APyFloat(0, 15, 1, 5, 2)
             assert res.is_identical(APyFloat(1, 15, 0, 5, 2))
 
+            # Should become infinity
+            res = APyFloat(0, 30, 3, 5, 2) / APyFloat(0, 0, 3, 5, 2)
+            assert res.is_identical(APyFloat(0, 31, 0, 5, 2))
+
+            # Should saturate
+            res = APyFloat(0, 30, 3, 5, 2) / APyFloat(1, 0, 3, 5, 2)
+            assert res.is_identical(APyFloat(1, 30, 3, 5, 2))
+
     def test_to_neg(self):
         with APyFloatQuantizationContext(QuantizationMode.TO_NEG):
             # 1.5 / 1.25 (=1.2) should quantize to 1.0
@@ -268,6 +340,14 @@ class TestAPyFloatQuantizationDiv:
             res = APyFloat(1, 15, 2, 5, 2) / APyFloat(0, 15, 1, 5, 2)
             assert res.is_identical(APyFloat(1, 15, 1, 5, 2))
 
+            # Should saturate
+            res = APyFloat(0, 30, 3, 5, 2) / APyFloat(0, 0, 3, 5, 2)
+            assert res.is_identical(APyFloat(0, 30, 3, 5, 2))
+
+            # Should become infinity
+            res = APyFloat(0, 30, 3, 5, 2) / APyFloat(1, 0, 3, 5, 2)
+            assert res.is_identical(APyFloat(1, 31, 0, 5, 2))
+
     def test_to_zero(self):
         with APyFloatQuantizationContext(QuantizationMode.TO_ZERO):
             # 1.25 / 1.5 should quantize to 0.75
@@ -277,6 +357,14 @@ class TestAPyFloatQuantizationDiv:
             # -1.25 / 1.5 should quantize to -0.75
             res = APyFloat(1, 15, 1, 5, 2) / APyFloat(0, 15, 2, 5, 2)
             assert res.is_identical(APyFloat(1, 14, 2, 5, 2))
+
+            # Should saturate
+            res = APyFloat(0, 30, 3, 5, 2) / APyFloat(0, 0, 3, 5, 2)
+            assert res.is_identical(APyFloat(0, 30, 3, 5, 2))
+
+            # Should saturate
+            res = APyFloat(0, 30, 3, 5, 2) / APyFloat(1, 0, 3, 5, 2)
+            assert res.is_identical(APyFloat(1, 30, 3, 5, 2))
 
     def test_to_ties_even(self):
         with APyFloatQuantizationContext(QuantizationMode.TIES_EVEN):
@@ -312,6 +400,14 @@ class TestAPyFloatQuantizationDiv:
             res = APyFloat(1, 0, 3, 5, 2) / APyFloat(0, 16, 0, 5, 2)
             assert res.is_identical(APyFloat(1, 0, 2, 5, 2))
 
+            # Should become infinity
+            res = APyFloat(0, 30, 3, 5, 2) / APyFloat(0, 0, 3, 5, 2)
+            assert res.is_identical(APyFloat(0, 31, 0, 5, 2))
+
+            # Should become infinity
+            res = APyFloat(0, 30, 3, 5, 2) / APyFloat(1, 0, 3, 5, 2)
+            assert res.is_identical(APyFloat(1, 31, 0, 5, 2))
+
     def test_to_ties_away(self):
         with APyFloatQuantizationContext(QuantizationMode.TIES_AWAY):
             # 1.25 / 1.5 should quantize to closes which is 0.875
@@ -346,6 +442,14 @@ class TestAPyFloatQuantizationDiv:
             res = APyFloat(1, 0, 3, 5, 2) / APyFloat(0, 16, 0, 5, 2)
             assert res.is_identical(APyFloat(1, 0, 2, 5, 2))
 
+            # Should become infinity
+            res = APyFloat(0, 30, 3, 5, 2) / APyFloat(0, 0, 3, 5, 2)
+            assert res.is_identical(APyFloat(0, 31, 0, 5, 2))
+
+            # Should become infinity
+            res = APyFloat(0, 30, 3, 5, 2) / APyFloat(1, 0, 3, 5, 2)
+            assert res.is_identical(APyFloat(1, 31, 0, 5, 2))
+
     def test_jam(self):
         with APyFloatQuantizationContext(QuantizationMode.JAM):
             # 1.5 / 1.25 (=1.2) should quantize to 1.25
@@ -359,6 +463,14 @@ class TestAPyFloatQuantizationDiv:
             # 4 / 2 (=2) should quantize to 2.25
             res = APyFloat(0, 17, 0, 5, 2) / APyFloat(0, 16, 0, 5, 2)
             assert res.is_identical(APyFloat(0, 16, 1, 5, 2))
+
+            # Should saturate
+            res = APyFloat(0, 30, 3, 5, 2) / APyFloat(0, 0, 3, 5, 2)
+            assert res.is_identical(APyFloat(0, 30, 3, 5, 2))
+
+            # Should saturate
+            res = APyFloat(0, 30, 3, 5, 2) / APyFloat(1, 0, 3, 5, 2)
+            assert res.is_identical(APyFloat(1, 30, 3, 5, 2))
 
     def test_stoch_weighted(self):
         with APyFloatQuantizationContext(QuantizationMode.STOCH_WEIGHTED):
@@ -519,6 +631,15 @@ class TestAPyFloatQuantization:
             .is_identical(APyFloat(1, 5, 0b101, 5, 3))
         )  # Round down
 
+        # Test handling of infinities
+        assert (
+            APyFloat(0, 30, 0, 5, 5).cast(4, 3).is_identical(APyFloat(0, 15, 0, 4, 3))
+        )  # Should become infinity
+
+        assert (
+            APyFloat(1, 30, 0, 5, 5).cast(4, 3).is_identical(APyFloat(1, 14, 7, 4, 3))
+        )  # Should saturate
+
     def test_quantization_to_neg(self):
         apytypes.set_float_quantization_mode(QuantizationMode.TO_NEG)
         # Quantization from 0.xx
@@ -608,6 +729,15 @@ class TestAPyFloatQuantization:
             .cast(5, 3)
             .is_identical(APyFloat(1, 5, 0b110, 5, 3))
         )  # Round up
+
+        # Test handling of infinities
+        assert (
+            APyFloat(0, 30, 0, 5, 5).cast(4, 3).is_identical(APyFloat(0, 14, 7, 4, 3))
+        )  # Should saturate
+
+        assert (
+            APyFloat(1, 30, 0, 5, 5).cast(4, 3).is_identical(APyFloat(1, 15, 0, 4, 3))
+        )  # Should become infinity
 
     def test_quantization_to_away(self):
         apytypes.set_float_quantization_mode(QuantizationMode.TO_AWAY)
@@ -699,6 +829,15 @@ class TestAPyFloatQuantization:
             .is_identical(APyFloat(1, 5, 0b110, 5, 3))
         )  # Round down
 
+        # Test handling of infinities
+        assert (
+            APyFloat(0, 30, 0, 5, 5).cast(4, 3).is_identical(APyFloat(0, 15, 0, 4, 3))
+        )  # Should become infinity
+
+        assert (
+            APyFloat(1, 30, 0, 5, 5).cast(4, 3).is_identical(APyFloat(1, 15, 0, 4, 3))
+        )  # Should become infinity
+
     def test_quantization_to_zero(self):
         apytypes.set_float_quantization_mode(QuantizationMode.TO_ZERO)
         # Quantization from 0.xx
@@ -788,6 +927,15 @@ class TestAPyFloatQuantization:
             .cast(5, 3)
             .is_identical(APyFloat(1, 5, 0b101, 5, 3))
         )  # Round down
+
+        # Test handling of infinities
+        assert (
+            APyFloat(0, 30, 0, 5, 5).cast(4, 3).is_identical(APyFloat(0, 14, 7, 4, 3))
+        )  # Should saturate
+
+        assert (
+            APyFloat(1, 30, 0, 5, 5).cast(4, 3).is_identical(APyFloat(1, 14, 7, 4, 3))
+        )  # Should saturate
 
     def test_quantization_ties_even(self):
         apytypes.set_float_quantization_mode(QuantizationMode.TIES_EVEN)
@@ -879,6 +1027,15 @@ class TestAPyFloatQuantization:
             .is_identical(APyFloat(1, 5, 0b110, 5, 3))
         )  # Round up
 
+        # Test handling of infinities
+        assert (
+            APyFloat(0, 30, 0, 5, 5).cast(4, 3).is_identical(APyFloat(0, 15, 0, 4, 3))
+        )  # Should become infinity
+
+        assert (
+            APyFloat(1, 30, 0, 5, 5).cast(4, 3).is_identical(APyFloat(1, 15, 0, 4, 3))
+        )  # Should become infinity
+
     def test_quantization_ties_odd(self):
         apytypes.set_float_quantization_mode(QuantizationMode.TIES_ODD)
         # Quantization from 0.xx
@@ -968,6 +1125,15 @@ class TestAPyFloatQuantization:
             .cast(5, 3)
             .is_identical(APyFloat(1, 5, 0b110, 5, 3))
         )  # Round up
+
+        # Test handling of infinities
+        assert (
+            APyFloat(0, 30, 0, 5, 5).cast(4, 3).is_identical(APyFloat(0, 15, 0, 4, 3))
+        )  # Should become infinity
+
+        assert (
+            APyFloat(1, 30, 0, 5, 5).cast(4, 3).is_identical(APyFloat(1, 15, 0, 4, 3))
+        )  # Should become infinity
 
     def test_quantization_ties_pos(self):
         apytypes.set_float_quantization_mode(QuantizationMode.TIES_POS)
@@ -1059,6 +1225,15 @@ class TestAPyFloatQuantization:
             .is_identical(APyFloat(1, 5, 0b110, 5, 3))
         )  # Round up
 
+        # Test handling of infinities
+        assert (
+            APyFloat(0, 30, 0, 5, 5).cast(4, 3).is_identical(APyFloat(0, 15, 0, 4, 3))
+        )  # Should become infinity
+
+        assert (
+            APyFloat(1, 30, 0, 5, 5).cast(4, 3).is_identical(APyFloat(1, 15, 0, 4, 3))
+        )  # Should become infinity
+
     def test_quantization_ties_neg(self):
         apytypes.set_float_quantization_mode(QuantizationMode.TIES_NEG)
         # Quantization from 0.xx
@@ -1148,6 +1323,15 @@ class TestAPyFloatQuantization:
             .cast(5, 3)
             .is_identical(APyFloat(1, 5, 0b110, 5, 3))
         )  # Round up
+
+        # Test handling of infinities
+        assert (
+            APyFloat(0, 30, 0, 5, 5).cast(4, 3).is_identical(APyFloat(0, 15, 0, 4, 3))
+        )  # Should become infinity
+
+        assert (
+            APyFloat(1, 30, 0, 5, 5).cast(4, 3).is_identical(APyFloat(1, 15, 0, 4, 3))
+        )  # Should become infinity
 
     def test_quantization_ties_away(self):
         apytypes.set_float_quantization_mode(QuantizationMode.TIES_AWAY)
@@ -1239,6 +1423,15 @@ class TestAPyFloatQuantization:
             .is_identical(APyFloat(1, 5, 0b110, 5, 3))
         )  # Round up
 
+        # Test handling of infinities
+        assert (
+            APyFloat(0, 30, 0, 5, 5).cast(4, 3).is_identical(APyFloat(0, 15, 0, 4, 3))
+        )  # Should become infinity
+
+        assert (
+            APyFloat(1, 30, 0, 5, 5).cast(4, 3).is_identical(APyFloat(1, 15, 0, 4, 3))
+        )  # Should become infinity
+
     def test_quantization_ties_to_zero(self):
         apytypes.set_float_quantization_mode(QuantizationMode.TIES_ZERO)
         # Quantization from 0.xx
@@ -1328,6 +1521,15 @@ class TestAPyFloatQuantization:
             .cast(5, 3)
             .is_identical(APyFloat(1, 5, 0b110, 5, 3))
         )  # Round up
+
+        # Test handling of infinities
+        assert (
+            APyFloat(0, 30, 0, 5, 5).cast(4, 3).is_identical(APyFloat(0, 15, 0, 4, 3))
+        )  # Should become infinity
+
+        assert (
+            APyFloat(1, 30, 0, 5, 5).cast(4, 3).is_identical(APyFloat(1, 15, 0, 4, 3))
+        )  # Should become infinity
 
     def test_quantization_jamming(self):
         apytypes.set_float_quantization_mode(QuantizationMode.JAM)
@@ -1419,6 +1621,15 @@ class TestAPyFloatQuantization:
             .is_identical(APyFloat(1, 5, 0b101, 5, 3))
         )
 
+        # Test handling of infinities
+        assert (
+            APyFloat(0, 30, 0, 5, 5).cast(4, 3).is_identical(APyFloat(0, 14, 7, 4, 3))
+        )  # Should saturate
+
+        assert (
+            APyFloat(1, 30, 0, 5, 5).cast(4, 3).is_identical(APyFloat(1, 14, 7, 4, 3))
+        )  # Should saturate
+
     def test_quantization_unbiased_jamming(self):
         apytypes.set_float_quantization_mode(QuantizationMode.JAM_UNBIASED)
         # Quantization from 0.xx
@@ -1444,6 +1655,15 @@ class TestAPyFloatQuantization:
             .cast(5, 3)
             .is_identical(APyFloat(0, 5, 0b101, 5, 3))
         )
+
+        # Test handling of infinities
+        assert (
+            APyFloat(0, 30, 0, 5, 5).cast(4, 3).is_identical(APyFloat(0, 14, 7, 4, 3))
+        )  # Should saturate
+
+        assert (
+            APyFloat(1, 30, 0, 5, 5).cast(4, 3).is_identical(APyFloat(1, 14, 7, 4, 3))
+        )  # Should saturate
 
     def test_quantization_magnitude_truncation(self):
         # Shouldn't be used for floating-point
@@ -1535,6 +1755,15 @@ class TestAPyFloatQuantization:
             .cast(5, 3)
             .is_identical(APyFloat(1, 5, 0b110, 5, 3))
         )
+
+        # Test handling of infinities
+        assert (
+            APyFloat(0, 30, 0, 5, 5).cast(4, 3).is_identical(APyFloat(0, 15, 0, 4, 3))
+        )  # Should become infinity
+
+        assert (
+            APyFloat(1, 30, 0, 5, 5).cast(4, 3).is_identical(APyFloat(1, 15, 0, 4, 3))
+        )  # Should become infinity
 
     def test_quantization_stochastic_weighted(self):
         """

--- a/lib/test/apyfloatarray/test_arithmetic.py
+++ b/lib/test/apyfloatarray/test_arithmetic.py
@@ -1,5 +1,10 @@
 import pytest
-from apytypes import APyFloat, APyFloatArray
+from apytypes import (
+    APyFloat,
+    APyFloatArray,
+    APyFloatQuantizationContext,
+    QuantizationMode,
+)
 
 
 @pytest.mark.float_array
@@ -804,3 +809,139 @@ def test_scalar_array_mul_with_one():
             res = a * b
             assert res.is_identical(b)
             assert (b * a).is_identical(b)
+
+
+def test_array_infinity_saturation_cast():
+    # Big positive number should become infinity
+    res = APyFloatArray([0], [30], [2], 5, 2).cast(4, 2)
+    assert res.is_identical(APyFloatArray([0], [15], [0], 4, 2))
+
+    # Big negative number should become infinity
+    res = APyFloatArray([1], [30], [2], 5, 2).cast(4, 2)
+    assert res.is_identical(APyFloatArray([1], [15], [0], 4, 2))
+
+    with APyFloatQuantizationContext(QuantizationMode.TO_ZERO):
+        # Big positive number should saturate
+        res = APyFloatArray([0], [30], [2], 5, 2).cast(4, 2)
+        assert res.is_identical(APyFloatArray([0], [14], [3], 4, 2))
+
+        # Big negative number should saturate
+        res = APyFloatArray([1], [30], [2], 5, 2).cast(4, 2)
+        assert res.is_identical(APyFloatArray([1], [14], [3], 4, 2))
+
+
+@pytest.mark.float_mul
+def test_array_infinity_saturation_mul():
+    # Array x Scalar
+    # Big positive number should become infinity
+    res = APyFloatArray([0], [30], [2], 5, 2) * APyFloat(0, 30, 3, 5, 2)
+    assert res.is_identical(APyFloatArray([0], [31], [0], 5, 2))
+
+    # Big negative number should become infinity
+    res = APyFloatArray([1], [30], [2], 5, 2) * APyFloat(0, 30, 3, 5, 2)
+    assert res.is_identical(APyFloatArray([1], [31], [0], 5, 2))
+
+    with APyFloatQuantizationContext(QuantizationMode.TO_ZERO):
+        # Big positive number should saturate
+        res = APyFloatArray([0], [30], [2], 5, 2) * APyFloat(0, 30, 3, 5, 2)
+        assert res.is_identical(APyFloatArray([0], [30], [3], 5, 2))
+
+        # Big negative number should saturate
+        res = APyFloatArray([1], [30], [2], 5, 2) * APyFloat(0, 30, 3, 5, 2)
+        assert res.is_identical(APyFloatArray([1], [30], [3], 5, 2))
+
+    # Array x Array
+    # Big positive number should become infinity
+    res = APyFloatArray([0], [30], [2], 5, 2) * APyFloatArray([0], [30], [2], 5, 2)
+    assert res.is_identical(APyFloatArray([0], [31], [0], 5, 2))
+
+    # Big negative number should become infinity
+    res = APyFloatArray([1], [30], [2], 5, 2) * APyFloatArray([0], [30], [2], 5, 2)
+    assert res.is_identical(APyFloatArray([1], [31], [0], 5, 2))
+
+    with APyFloatQuantizationContext(QuantizationMode.TO_ZERO):
+        # Big positive number should saturate
+        res = APyFloatArray([0], [30], [2], 5, 2) * APyFloatArray([0], [30], [2], 5, 2)
+        assert res.is_identical(APyFloatArray([0], [30], [3], 5, 2))
+
+        # Big negative number should saturate
+        res = APyFloatArray([1], [30], [2], 5, 2) * APyFloatArray([0], [30], [2], 5, 2)
+        assert res.is_identical(APyFloatArray([1], [30], [3], 5, 2))
+
+
+@pytest.mark.float_add
+def test_array_infinity_saturation_add():
+    # Array x Scalar
+    # Big positive number should become infinity
+    res = APyFloatArray([0], [30], [2], 5, 2) + APyFloat(0, 30, 3, 5, 2)
+    assert res.is_identical(APyFloatArray([0], [31], [0], 5, 2))
+
+    # Big negative number should become infinity
+    res = APyFloatArray([1], [30], [2], 5, 2) + APyFloat(1, 30, 3, 5, 2)
+    assert res.is_identical(APyFloatArray([1], [31], [0], 5, 2))
+
+    with APyFloatQuantizationContext(QuantizationMode.TO_ZERO):
+        # Big positive number should saturate
+        res = APyFloatArray([0], [30], [2], 5, 2) + APyFloat(0, 30, 3, 5, 2)
+        assert res.is_identical(APyFloatArray([0], [30], [3], 5, 2))
+
+        # Big negative number should saturate
+        res = APyFloatArray([1], [30], [2], 5, 2) + APyFloat(1, 30, 3, 5, 2)
+        assert res.is_identical(APyFloatArray([1], [30], [3], 5, 2))
+
+    # Array x Array
+    # Big positive number should become infinity
+    res = APyFloatArray([0], [30], [2], 5, 2) + APyFloatArray([0], [30], [2], 5, 2)
+    assert res.is_identical(APyFloatArray([0], [31], [0], 5, 2))
+
+    # Big negative number should become infinity
+    res = APyFloatArray([1], [30], [2], 5, 2) + APyFloatArray([1], [30], [2], 5, 2)
+    assert res.is_identical(APyFloatArray([1], [31], [0], 5, 2))
+
+    with APyFloatQuantizationContext(QuantizationMode.TO_ZERO):
+        # Big positive number should saturate
+        res = APyFloatArray([0], [30], [2], 5, 2) + APyFloatArray([0], [30], [2], 5, 2)
+        assert res.is_identical(APyFloatArray([0], [30], [3], 5, 2))
+
+        # Big negative number should saturate
+        res = APyFloatArray([1], [30], [2], 5, 2) + APyFloatArray([1], [30], [2], 5, 2)
+        assert res.is_identical(APyFloatArray([1], [30], [3], 5, 2))
+
+
+@pytest.mark.float_div
+def test_array_infinity_saturation_div():
+    # Array x Scalar
+    # Big positive number should become infinity
+    res = APyFloatArray([0], [30], [2], 5, 2) / APyFloat(0, 1, 3, 5, 2)
+    assert res.is_identical(APyFloatArray([0], [31], [0], 5, 2))
+
+    # Big negative number should become infinity
+    res = APyFloatArray([1], [30], [2], 5, 2) / APyFloat(0, 1, 3, 5, 2)
+    assert res.is_identical(APyFloatArray([1], [31], [0], 5, 2))
+
+    with APyFloatQuantizationContext(QuantizationMode.TO_ZERO):
+        # Big positive number should saturate
+        res = APyFloatArray([0], [30], [2], 5, 2) / APyFloat(0, 1, 3, 5, 2)
+        assert res.is_identical(APyFloatArray([0], [30], [3], 5, 2))
+
+        # Big negative number should saturate
+        res = APyFloatArray([1], [30], [2], 5, 2) / APyFloat(0, 1, 3, 5, 2)
+        assert res.is_identical(APyFloatArray([1], [30], [3], 5, 2))
+
+    # Array x Array
+    # Big positive number should become infinity
+    res = APyFloatArray([0], [30], [2], 5, 2) / APyFloatArray([0], [1], [2], 5, 2)
+    assert res.is_identical(APyFloatArray([0], [31], [0], 5, 2))
+
+    # Big negative number should become infinity
+    res = APyFloatArray([1], [30], [2], 5, 2) / APyFloatArray([0], [1], [2], 5, 2)
+    assert res.is_identical(APyFloatArray([1], [31], [0], 5, 2))
+
+    with APyFloatQuantizationContext(QuantizationMode.TO_ZERO):
+        # Big positive number should saturate
+        res = APyFloatArray([0], [30], [2], 5, 2) / APyFloatArray([0], [1], [2], 5, 2)
+        assert res.is_identical(APyFloatArray([0], [30], [3], 5, 2))
+
+        # Big negative number should saturate
+        res = APyFloatArray([1], [30], [2], 5, 2) / APyFloatArray([0], [1], [2], 5, 2)
+        assert res.is_identical(APyFloatArray([1], [30], [3], 5, 2))

--- a/src/apyfloat.cc
+++ b/src/apyfloat.cc
@@ -256,8 +256,13 @@ void APyFloat::cast_mantissa(std::uint8_t new_man_bits, QuantizationMode quantiz
     // Check if only zeros should be added
     if (man_bits_delta <= 0) {
         if (exp >= max_exp) {
-            exp = max_exp;
-            man = 0;
+            if (do_infinity(quantization, sign)) {
+                exp = max_exp;
+                man = 0;
+            } else {
+                exp = max_exp - 1;
+                man = leading_one() - 1;
+            }
         } else {
             man <<= -man_bits_delta;
         }
@@ -990,8 +995,15 @@ APyFloat& APyFloat::operator+=(const APyFloat& rhs)
     }
 
     // Check for overflow
-    if (exp >= max_exponent()) {
-        set_to_inf();
+    const exp_t max_exp = max_exponent();
+    if (exp >= max_exp) {
+        if (do_infinity(quantization, sign)) {
+            exp = max_exp;
+            man = 0;
+        } else {
+            exp = max_exp - 1;
+            man = leading_one() - 1;
+        }
         return *this;
     }
 

--- a/src/apyfloat_util.h
+++ b/src/apyfloat_util.h
@@ -129,6 +129,23 @@ void APY_INLINE quantize_mantissa(
     );
 }
 
+//! Check if one should saturate to infinity or maximum normal number
+bool APY_INLINE do_infinity(QuantizationMode mode, bool sign)
+{
+    switch (mode) {
+    case QuantizationMode::TRN_ZERO:     // TO_ZERO
+    case QuantizationMode::JAM:          // JAM
+    case QuantizationMode::JAM_UNBIASED: // JAM_UNBIASED
+        return false;
+    case QuantizationMode::TRN: // TO_NEG
+        return sign;
+    case QuantizationMode::TRN_INF: // TO_POS
+        return !sign;
+    default:
+        return true;
+    }
+}
+
 //! Fast integer power by squaring.
 man_t ipow(man_t base, unsigned int n);
 

--- a/src/apyfloatarray.cc
+++ b/src/apyfloatarray.cc
@@ -223,8 +223,13 @@ APyFloatArray APyFloatArray::operator+(const APyFloatArray& rhs) const
 
             // Check for overflow
             if (new_exp >= res_max_exponent) {
-                new_exp = res_max_exponent;
-                new_man = 0;
+                if (do_infinity(quantization, x.sign)) {
+                    new_exp = res_max_exponent;
+                    new_man = 0;
+                } else {
+                    new_exp = res_max_exponent - 1;
+                    new_man = man_mask;
+                }
             }
             res.data[i]
                 = { x.sign, static_cast<exp_t>(new_exp), static_cast<man_t>(new_man) };
@@ -410,8 +415,13 @@ APyFloatArray APyFloatArray::operator+(const APyFloat& rhs) const
 
             // Check for overflow
             if (new_exp >= res_max_exponent) {
-                new_exp = res_max_exponent;
-                new_man = 0;
+                if (do_infinity(quantization, res_sign)) {
+                    new_exp = res_max_exponent;
+                    new_man = 0;
+                } else {
+                    new_exp = res_max_exponent - 1;
+                    new_man = man_mask;
+                }
             }
             res.data[i] = { res_sign,
                             static_cast<exp_t>(new_exp),
@@ -521,6 +531,7 @@ void APyFloatArray::hadamard_multiplication(
         const man_t two_before = two >> 1;
         const man_t one_before = 1ULL << sum_man_bits;
         const man_t two_res = 1 << res.man_bits;
+        const man_t max_man = one_before - 1;
         const man_t mask_two = two - 1;
         const uint8_t man_bits_delta = new_man_bits - res.man_bits;
         const uint8_t man_bits_delta_dec = man_bits_delta - 1;
@@ -625,8 +636,13 @@ void APyFloatArray::hadamard_multiplication(
 
             // Check for overflow
             if (new_exp >= res_max_exponent) {
-                new_exp = res_max_exponent;
-                new_man = 0;
+                if (do_infinity(quantization, res_sign)) {
+                    new_exp = res_max_exponent;
+                    new_man = 0;
+                } else {
+                    new_exp = res_max_exponent - 1;
+                    new_man = max_man;
+                }
             }
             res.data[i] = { res_sign,
                             static_cast<exp_t>(new_exp),
@@ -731,6 +747,7 @@ APyFloatArray APyFloatArray::operator*(const APyFloat& rhs) const
         const man_t two_before = two >> 1;
         const man_t one_before = 1ULL << sum_man_bits;
         const man_t two_res = 1 << res_man_bits;
+        const man_t max_man = two_res - 1;
         const auto mask_two = two - 1;
         const auto man_bits_delta = new_man_bits - res_man_bits;
         const auto man_bits_delta_dec = man_bits_delta - 1;
@@ -821,8 +838,13 @@ APyFloatArray APyFloatArray::operator*(const APyFloat& rhs) const
 
             // Check for overflow
             if (new_exp >= res_max_exponent) {
-                new_exp = res_max_exponent;
-                new_man = 0;
+                if (do_infinity(quantization, res_sign)) {
+                    new_exp = res_max_exponent;
+                    new_man = 0;
+                } else {
+                    new_exp = res_max_exponent - 1;
+                    new_man = max_man;
+                }
             }
             res.data[i] = { res_sign,
                             static_cast<exp_t>(new_exp),


### PR DESCRIPTION
Floating-point results should sometimes quantize to infinity and at other times to the maximum normal number depending on the quantization mode. Related to  #406. This will probably take a toll on the performance unfortunately.