### PR TITLE
Handle sign of zero correctly in floating-point addition and subtraction

### DIFF
--- a/lib/test/apyfloat/run_berkeley_cases.py
+++ b/lib/test/apyfloat/run_berkeley_cases.py
@@ -14,6 +14,7 @@ from apytypes import (
     APyFloatQuantizationContext,
 )
 import itertools
+import math
 import os
 import random
 import subprocess
@@ -324,9 +325,10 @@ def print_summary(summary, output_file: str, seed: int, level: int) -> None:
                 )
                 failed_tests += summary[op][quant][0]
 
-    success_rate = (1 - float(failed_tests) / total_tests) * 100
+    # Round percentage down so it doesn't show 100% success even if something failed
+    success_rate = math.floor((1 - float(failed_tests) / total_tests) * 10000) / 100.0
     print(
-        f"Ran {total_tests} tests in total whereof {failed_tests} failed, giving an overall success rate of {success_rate:.2f}%."
+        f"Ran {total_tests} tests in total whereof {failed_tests} failed, giving an overall success rate of {success_rate}%."
     )
 
 

--- a/lib/test/apyfloat/test_arithmetic.py
+++ b/lib/test/apyfloat/test_arithmetic.py
@@ -4,70 +4,6 @@ import pytest
 from apytypes import APyFloat
 
 
-# Exhaustive tests, long running
-# These should be replaced by testing against a third-party tool
-# @pytest.mark.slow
-# @pytest.mark.float_add
-# @pytest.mark.parametrize("x_bits", range(0, 2**8))
-# @pytest.mark.parametrize("y_bits", range(0, 2**8))
-# def test_add_all(x_bits, y_bits):
-#    y = APyFloat.from_bits(y_bits, 4, 3)
-#    x = APyFloat.from_bits(x_bits, 4, 3)
-#    ans = x + y
-#    ref = APyFloat.from_float(float(x) + float(y), 4, 3)
-#    print(f'{float(x)} + {float(y)} = {float(ref)} != {float(ans)}')
-#    print(f'{x!r} + {y!r} = {ref!r} != {ans!r}')
-#    assert ans == ref or (ans.is_nan and ref.is_nan) or (ans == 0 and ref == 0)
-
-
-# @pytest.mark.slow
-# @pytest.mark.float_sub
-# @pytest.mark.parametrize("x_bits", range(0, 2**8))
-# @pytest.mark.parametrize("y_bits", range(0, 2**8))
-# def test_sub_all(x_bits, y_bits):
-#    y = APyFloat.from_bits(y_bits, 4, 3)
-#    x = APyFloat.from_bits(x_bits, 4, 3)
-#    ans = x - y
-#    ref = APyFloat.from_float(float(x) - float(y), 4, 3)
-#    print(f'{float(x)} - {float(y)} = {float(ref)} != {float(ans)}')
-#    print(f'{x!r} - {y!r} = {ref!r} != {ans!r}')
-#    assert ans == ref or (ans.is_nan and ref.is_nan) or (ans == 0 and ref == 0)
-
-
-# @pytest.mark.slow
-# @pytest.mark.float_mul
-# @pytest.mark.parametrize("x_bits", range(0, 2**8))
-# @pytest.mark.parametrize("y_bits", range(0, 2**8))
-# def test_mul_all(x_bits, y_bits):
-#    y = APyFloat.from_bits(y_bits, 4, 3)
-#    x = APyFloat.from_bits(x_bits, 4, 3)
-#    ans = x * y
-#    prod = float(x) * float(y)
-#    ref = APyFloat.from_float(prod, 4, 3)
-#    print(f'{float(x)} * {float(y)} = {float(ref)}({prod}) != {float(ans)}')
-#    print(f'{x!r} * {y!r} = {ref!r} != {ans!r}')
-#    assert ans.is_identical(ref) or (ans.is_nan and ref.is_nan) or (ans == 0 and ref == 0)
-
-
-# @pytest.mark.slow
-# @pytest.mark.float_div
-# @pytest.mark.parametrize("x_bits", range(0, 2 * 8))
-# @pytest.mark.parametrize("y_bits", range(0, 2**8))
-# def test_div_all(x_bits, y_bits):
-#     y = APyFloat.from_bits(y_bits, 4, 3)
-#     if y != 0:
-#         x = APyFloat.from_bits(x_bits, 4, 3)
-#         ans = x / y
-#         ref = APyFloat.from_float(float(x) / float(y), 4, 3)
-#         print(f"{float(x)} / {float(y)} = {float(ref)} != {float(ans)}")
-#         print(f"{x!r} / {y!r} = (ref){ref!r} != (ans){ans!r}")
-#         assert (
-#             ans.is_identical(ref)
-#             or (ans.is_nan and ref.is_nan)
-#             or (ans == 0 and ref == 0)
-#         )
-
-
 # Negation
 @pytest.mark.parametrize("sign", ["-", ""])
 @pytest.mark.parametrize(
@@ -301,7 +237,7 @@ def test_long_add():
     x = APyFloat(0, 1046, 1232143, 11, 60)
     y = APyFloat(1, 1046, 1232143, 11, 60)
     res = x + y
-    assert res.is_identical(APyFloat(1, 0, 0, 11, 60))
+    assert res.is_identical(APyFloat(0, 0, 0, 11, 60))
 
 
 # Subtraction
@@ -355,11 +291,11 @@ def test_sub_diff_sign():
 def test_sub_res_zero():
     # 12 - 12, same format
     res = APyFloat(0, 258, 8, 9, 4) - APyFloat(0, 258, 8, 9, 4)
-    assert res.is_identical(APyFloat(1, 0, 0, 9, 4))
+    assert res.is_identical(APyFloat(0, 0, 0, 9, 4))
 
     # 12 - 12, different format
     res = APyFloat(0, 258, 4, 9, 3) - APyFloat(0, 258, 8, 9, 4)
-    assert res.is_identical(APyFloat(1, 0, 0, 9, 4))
+    assert res.is_identical(APyFloat(0, 0, 0, 9, 4))
 
 
 @pytest.mark.float_sub

--- a/lib/test/apyfloatarray/test_arithmetic.py
+++ b/lib/test/apyfloatarray/test_arithmetic.py
@@ -870,6 +870,73 @@ def test_array_infinity_saturation_mul():
 
 
 @pytest.mark.float_add
+@pytest.mark.float_sub
+@pytest.mark.float_array
+@pytest.mark.parametrize("man", [10, 60])
+@pytest.mark.parametrize("with_scalar", [False, True])
+def test_array_add_sub_zero_sign(man, with_scalar):
+    pos_zero = APyFloatArray([0], [0], [0], 5, 10)
+    neg_zero = APyFloatArray([1], [0], [0], 5, man)
+    non_zero = APyFloatArray.from_float([1.0], 5, man)
+
+    # Scalar equivalents
+    pos_zero_scal = APyFloat(0, 0, 0, 5, 10)
+    neg_zero_scal = APyFloat(1, 0, 0, 5, man)
+    non_zero_scal = APyFloat.from_float(1.0, 5, man)
+
+    modes = (
+        QuantizationMode.TIES_EVEN,
+        QuantizationMode.TO_ZERO,
+        QuantizationMode.TO_POS,
+    )
+
+    for mode in modes:
+        with APyFloatQuantizationContext(mode):
+            rhs = pos_zero_scal if with_scalar else pos_zero
+            assert (_ := pos_zero + rhs)[0].sign == False
+            rhs = neg_zero_scal if with_scalar else neg_zero
+            assert (_ := pos_zero + rhs)[0].sign == False
+            rhs = pos_zero_scal if with_scalar else pos_zero
+            assert (_ := neg_zero + rhs)[0].sign == False
+            rhs = neg_zero_scal if with_scalar else neg_zero
+            assert (_ := neg_zero + rhs)[0].sign == True
+
+            rhs = pos_zero_scal if with_scalar else pos_zero
+            assert (_ := pos_zero - rhs)[0].sign == False
+            rhs = neg_zero_scal if with_scalar else neg_zero
+            assert (_ := pos_zero - rhs)[0].sign == False
+            rhs = pos_zero_scal if with_scalar else pos_zero
+            assert (_ := neg_zero - rhs)[0].sign == True
+            rhs = neg_zero_scal if with_scalar else neg_zero
+            assert (_ := neg_zero - rhs)[0].sign == False
+
+            rhs = non_zero_scal if with_scalar else non_zero
+            assert (_ := non_zero + (-rhs))[0].sign == False
+
+    with APyFloatQuantizationContext(QuantizationMode.TO_NEG):
+        rhs = pos_zero_scal if with_scalar else pos_zero
+        assert (_ := pos_zero + rhs)[0].sign == False
+        rhs = neg_zero_scal if with_scalar else neg_zero
+        assert (_ := pos_zero + rhs)[0].sign == True
+        rhs = pos_zero_scal if with_scalar else pos_zero
+        assert (_ := neg_zero + rhs)[0].sign == True
+        rhs = neg_zero_scal if with_scalar else neg_zero
+        assert (_ := neg_zero + rhs)[0].sign == True
+
+        rhs = pos_zero_scal if with_scalar else pos_zero
+        assert (_ := pos_zero - pos_zero)[0].sign == True
+        rhs = neg_zero_scal if with_scalar else neg_zero
+        assert (_ := pos_zero - rhs)[0].sign == False
+        rhs = pos_zero_scal if with_scalar else pos_zero
+        assert (_ := neg_zero - rhs)[0].sign == True
+        rhs = neg_zero_scal if with_scalar else neg_zero
+        assert (_ := neg_zero - rhs)[0].sign == True
+
+        rhs = non_zero_scal if with_scalar else non_zero
+        assert (_ := non_zero - rhs)[0].sign == True
+
+
+@pytest.mark.float_add
 def test_array_infinity_saturation_add():
     # Array x Scalar
     # Big positive number should become infinity

--- a/lib/test/apyfloatarray/test_arithmetic.py
+++ b/lib/test/apyfloatarray/test_arithmetic.py
@@ -48,7 +48,7 @@ def test_array_add():
     ans = APyFloatArray.from_float(
         [
             [7.0, 4.5, 10.5],
-            [-8.0, 15.0, -0.0],
+            [-8.0, 15.0, 0.0],
         ],
         exp_bits=8,
         man_bits=8,
@@ -246,7 +246,7 @@ def test_array_sub():
     ans = APyFloatArray.from_float(
         [
             [-5, -0.5, -4.5],
-            [-0.0, -25.0, -12.0],
+            [0.0, -25.0, -12.0],
         ],
         exp_bits=8,
         man_bits=8,

--- a/src/apyfloatarray.cc
+++ b/src/apyfloatarray.cc
@@ -162,7 +162,9 @@ APyFloatArray APyFloatArray::operator+(const APyFloatArray& rhs) const
                 std::swap(x_is_zero_exponent, y_is_zero_exponent);
             } else if (x.sign != y.sign && x.exp == y.exp && x.man == y.man) {
                 // Set to zero
-                res.data[i] = { true, static_cast<exp_t>(0), static_cast<man_t>(0) };
+                res.data[i] = { quantization == QuantizationMode::TRN,
+                                static_cast<exp_t>(0),
+                                static_cast<man_t>(0) };
                 continue;
             }
 


### PR DESCRIPTION
Related to #406. 

Todo:
* [x] Correct sign of zeros for scalars.
* [x] Correct sign of zeros for arrays.