### PR TITLE
Improve support for non IEEE-like biases

### DIFF
--- a/lib/test/apyfloat/test_arithmetic.py
+++ b/lib/test/apyfloat/test_arithmetic.py
@@ -862,6 +862,52 @@ def test_long_div():
     assert res.is_identical(APyFloat(sign=0, exp=0, man=2, exp_bits=14, man_bits=59))
 
 
+@pytest.mark.float_div
+def test_div_mixed_bias():
+    # Test that the implementation doesn't do "x.cast() / y.cast()"
+    x = APyFloat(sign=0, exp=30, man=0, exp_bits=5, man_bits=2, bias=4)
+    y = APyFloat(sign=0, exp=30, man=0, exp_bits=5, man_bits=2, bias=8)
+    assert (_ := x / y).is_identical(
+        APyFloat(sign=0, exp=10, man=0, exp_bits=5, man_bits=2, bias=6)
+    )
+
+
+@pytest.mark.float_mul
+def test_div_mixed_bias_overflow():
+    """Test that a result can overflow to infinity due to a change in bias."""
+    x = APyFloat(sign=0, exp=21, man=0, exp_bits=5, man_bits=2, bias=5)
+    y = APyFloat(sign=0, exp=25, man=0, exp_bits=5, man_bits=2, bias=25)
+
+    # Divide with one
+    assert (_ := x / y).is_identical(
+        APyFloat(sign=0, exp=31, man=0, exp_bits=5, man_bits=2, bias=15)
+    )
+
+    # Divide with one but with larger bias difference
+    y = APyFloat(sign=0, exp=27, man=0, exp_bits=5, man_bits=2, bias=27)
+    assert (_ := x / y).is_identical(
+        APyFloat(sign=0, exp=31, man=0, exp_bits=5, man_bits=2, bias=16)
+    )
+
+
+@pytest.mark.float_add
+def test_div_mixed_bias_underflow():
+    """Test that a result can become zero due to a change in bias."""
+    x = APyFloat(sign=0, exp=1, man=1, exp_bits=5, man_bits=2, bias=25)
+    y = APyFloat(sign=0, exp=5, man=0, exp_bits=5, man_bits=2, bias=5)
+
+    # Divide with one
+    assert (_ := x / y).is_identical(
+        APyFloat(sign=0, exp=0, man=0, exp_bits=5, man_bits=2, bias=15)
+    )
+
+    # Divide with one but with larger bias difference
+    x = APyFloat(sign=0, exp=1, man=1, exp_bits=5, man_bits=2, bias=30)
+    assert (_ := x / y).is_identical(
+        APyFloat(sign=0, exp=0, man=0, exp_bits=5, man_bits=2, bias=17)
+    )
+
+
 # Power
 @pytest.mark.float_pow
 def test_issue_253():

--- a/lib/test/apyfloat/test_arithmetic.py
+++ b/lib/test/apyfloat/test_arithmetic.py
@@ -180,30 +180,6 @@ def test_add_mixed_bias_overflow():
 
 
 @pytest.mark.float_add
-def test_add_mixed_bias_underflow():
-    """Test that a result can become zero due to a change in bias."""
-    x = APyFloat(sign=0, exp=0, man=0, exp_bits=5, man_bits=2, bias=5)
-    y = APyFloat(sign=0, exp=1, man=1, exp_bits=5, man_bits=2, bias=25)
-
-    # Add with zero
-    assert (_ := x + y).is_identical(
-        APyFloat(sign=0, exp=0, man=0, exp_bits=5, man_bits=2, bias=15)
-    )
-
-    # Add with zero but with larger bias difference
-    y = APyFloat(sign=0, exp=1, man=1, exp_bits=5, man_bits=2, bias=27)
-    assert (_ := x + y).is_identical(
-        APyFloat(sign=0, exp=0, man=0, exp_bits=5, man_bits=2, bias=16)
-    )
-
-    # Add with subnormal number
-    y = APyFloat(sign=0, exp=0, man=1, exp_bits=5, man_bits=2, bias=28)
-    assert (_ := x + y).is_identical(
-        APyFloat(sign=0, exp=0, man=0, exp_bits=5, man_bits=2, bias=16)
-    )
-
-
-@pytest.mark.float_add
 def test_add_double():
     """Some tests for sanity checking addition with binary64. This uses the faster path."""
 

--- a/lib/test/apyfloat/test_comparisons.py
+++ b/lib/test/apyfloat/test_comparisons.py
@@ -208,3 +208,98 @@ def test_signed_zero_comparison():
     assert b >= a
     assert not (b < a)
     assert b <= a
+
+
+@pytest.mark.float_comp
+def test_mixed_bias_comparisons():
+    """Comparisons where all fields are different."""
+    # x and y are equal
+    x = APyFloat(sign=0, exp=5, man=1, exp_bits=5, man_bits=2, bias=5)
+    y = APyFloat(sign=0, exp=25, man=1, exp_bits=5, man_bits=2, bias=25)
+    assert x == y
+    assert x >= y
+    assert x <= y
+    assert not x > y
+    assert not x < y
+    assert not x != y
+
+    # Two normal numbers but y is smaller
+    y = APyFloat(sign=0, exp=5, man=1, exp_bits=5, man_bits=2, bias=6)
+    assert not x == y
+    assert x >= y
+    assert not x <= y
+    assert x > y
+    assert not x < y
+    assert x != y
+
+    # Two equal subnormal numbers
+    x = APyFloat(sign=0, exp=0, man=1, exp_bits=5, man_bits=2, bias=5)
+    y = APyFloat(sign=0, exp=0, man=2, exp_bits=5, man_bits=2, bias=6)
+    assert x == y
+    assert x >= y
+    assert x <= y
+    assert not x > y
+    assert not x < y
+    assert not x != y
+
+    # Two subnormal numbers but y is slightly larger
+    y = APyFloat(sign=0, exp=0, man=3, exp_bits=5, man_bits=2, bias=6)
+    assert not x == y
+    assert not x >= y
+    assert x <= y
+    assert not x > y
+    assert x < y
+    assert x != y
+
+    # Subnormal number equal to normal number
+    x = APyFloat(sign=0, exp=0, man=1, exp_bits=5, man_bits=2, bias=5)
+    y = APyFloat(sign=0, exp=1, man=0, exp_bits=5, man_bits=2, bias=7)
+    assert x == y
+    assert x >= y
+    assert x <= y
+    assert not x > y
+    assert not x < y
+    assert not x != y
+
+
+@pytest.mark.float_comp
+def test_mixed_format_comparisons():
+    """Comparisons with mixed formats."""
+    # x and y are equal
+    x = APyFloat(sign=0, exp=5, man=2, exp_bits=4, man_bits=3, bias=5)
+    y = APyFloat(sign=0, exp=25, man=1, exp_bits=5, man_bits=2, bias=25)
+    assert x == y
+    assert x >= y
+    assert x <= y
+    assert not x > y
+    assert not x < y
+    assert not x != y
+
+    # Two normal numbers but y is smaller
+    y = APyFloat(sign=0, exp=7, man=3, exp_bits=5, man_bits=5, bias=8)
+    assert not x == y
+    assert x >= y
+    assert not x <= y
+    assert x > y
+    assert not x < y
+    assert x != y
+
+    # Two equal subnormal numbers
+    x = APyFloat(sign=0, exp=0, man=1, exp_bits=5, man_bits=2, bias=5)
+    y = APyFloat(sign=0, exp=0, man=4, exp_bits=4, man_bits=3, bias=6)
+    assert x == y
+    assert x >= y
+    assert x <= y
+    assert not x > y
+    assert not x < y
+    assert not x != y
+
+    # Two subnormal numbers but y is slightly larger
+    x = APyFloat(sign=0, exp=0, man=1, exp_bits=5, man_bits=2, bias=5)
+    y = APyFloat(sign=0, exp=0, man=5, exp_bits=4, man_bits=3, bias=6)
+    assert not x == y
+    assert not x >= y
+    assert x <= y
+    assert not x > y
+    assert x < y
+    assert x != y

--- a/lib/test/apyfloatarray/test_arithmetic.py
+++ b/lib/test/apyfloatarray/test_arithmetic.py
@@ -869,6 +869,93 @@ def test_array_infinity_saturation_mul():
         assert res.is_identical(APyFloatArray([1], [30], [3], 5, 2))
 
 
+@pytest.mark.float_mul
+@pytest.mark.parametrize("with_scalar", [False, True])
+def test_array_mul_mixed_bias(with_scalar):
+    # Test that the implementation doesn't do "x.cast() * y.cast()"
+    x = APyFloatArray([0], [30], [0], exp_bits=5, man_bits=2, bias=14)
+
+    if with_scalar:
+        y = APyFloat(sign=0, exp=15, man=0, exp_bits=5, man_bits=2, bias=16)
+    else:
+        y = APyFloatArray([0], [15], [0], exp_bits=5, man_bits=2, bias=16)
+    assert (_ := x * y).is_identical(
+        APyFloatArray([0], [30], [0], exp_bits=5, man_bits=2, bias=15)
+    )
+
+    # Multiply two one's but with different formats
+    x = APyFloatArray([0], [14], [0], exp_bits=5, man_bits=2, bias=14)
+
+    if with_scalar:
+        y = APyFloat(sign=0, exp=21, man=0, exp_bits=5, man_bits=2, bias=21)
+    else:
+        y = APyFloatArray([0], [21], [0], exp_bits=5, man_bits=2, bias=21)
+    assert (_ := x * y).is_identical(
+        APyFloatArray([0], [17], [0], exp_bits=5, man_bits=2, bias=17)
+    )
+
+
+@pytest.mark.float_mul
+@pytest.mark.parametrize("with_scalar", [False, True])
+def test_array_mul_mixed_bias_overflow(with_scalar):
+    """Test that a result can overflow to infinity due to a change in bias."""
+    x = APyFloatArray([0], [21], [0], exp_bits=5, man_bits=2, bias=5)
+
+    if with_scalar:
+        y = APyFloat(sign=0, exp=25, man=0, exp_bits=5, man_bits=2, bias=25)
+    else:
+        y = APyFloatArray([0], [25], [0], exp_bits=5, man_bits=2, bias=25)
+
+    # Multiply with one
+    assert (_ := x * y).is_identical(
+        APyFloatArray([0], [31], [0], exp_bits=5, man_bits=2, bias=15)
+    )
+
+    # Multiply with one but with larger bias difference
+    if with_scalar:
+        y = APyFloat(sign=0, exp=27, man=0, exp_bits=5, man_bits=2, bias=27)
+    else:
+        y = APyFloatArray([0], [27], [0], exp_bits=5, man_bits=2, bias=27)
+    assert (_ := x * y).is_identical(
+        APyFloatArray([0], [31], [0], exp_bits=5, man_bits=2, bias=16)
+    )
+
+    # Should become one
+    x = APyFloatArray([0], [30], [0], exp_bits=5, man_bits=2, bias=3)
+
+    if with_scalar:
+        y = APyFloat(sign=0, exp=1, man=0, exp_bits=5, man_bits=2, bias=28)
+    else:
+        y = APyFloatArray([0], [1], [0], exp_bits=5, man_bits=2, bias=28)
+    assert (_ := x * y).is_identical(
+        APyFloatArray([0], [15], [0], exp_bits=5, man_bits=2)
+    )
+
+
+@pytest.mark.float_add
+def test_add_mixed_bias_underflow():
+    """Test that a result can become zero due to a change in bias."""
+    x = APyFloat(sign=0, exp=0, man=0, exp_bits=5, man_bits=2, bias=5)
+    y = APyFloat(sign=0, exp=1, man=1, exp_bits=5, man_bits=2, bias=25)
+
+    # Add with zero
+    assert (_ := x + y).is_identical(
+        APyFloat(sign=0, exp=0, man=0, exp_bits=5, man_bits=2, bias=15)
+    )
+
+    # Add with zero but with larger bias difference
+    y = APyFloat(sign=0, exp=1, man=1, exp_bits=5, man_bits=2, bias=27)
+    assert (_ := x + y).is_identical(
+        APyFloat(sign=0, exp=0, man=0, exp_bits=5, man_bits=2, bias=16)
+    )
+
+    # Add with subnormal number
+    y = APyFloat(sign=0, exp=0, man=1, exp_bits=5, man_bits=2, bias=28)
+    assert (_ := x + y).is_identical(
+        APyFloat(sign=0, exp=0, man=0, exp_bits=5, man_bits=2, bias=16)
+    )
+
+
 @pytest.mark.float_add
 @pytest.mark.float_sub
 @pytest.mark.float_array

--- a/lib/test/apyfloatarray/test_constructors.py
+++ b/lib/test/apyfloatarray/test_constructors.py
@@ -27,8 +27,6 @@ def test_constructor_raises():
         match="Non <type>/sequence found when walking: '<class 'apytypes._apytypes.APyFloatArray'>'",
     ):
         APyFloatArray([True], [4], [APyFloatArray], 10, 10)
-    with pytest.raises(ValueError, match="Not.*implemented.*bias"):
-        APyFloatArray.from_float([1, 5], 10, 10, 12)
 
 
 @pytest.mark.float_array

--- a/lib/test/apyfloatarray/test_constructors.py
+++ b/lib/test/apyfloatarray/test_constructors.py
@@ -8,8 +8,6 @@ def test_constructor_raises():
         APyFloatArray([1], [5, 2], [4], 10, 10)
     with pytest.raises(ValueError, match="Inhomogeneous sequence"):
         APyFloatArray([1, 2], [5, 2], [4, "str"], 10, 10)
-    with pytest.raises(ValueError, match="Not.*implemented.*bias"):
-        APyFloatArray([1], [5], [4], 10, 10, 12)
     with pytest.raises(ValueError, match="python_sequence_extract_shape"):
         APyFloatArray(["foo"], [5], [4], 10, 10)
     with pytest.raises(ValueError, match="python_sequence_extract_shape"):

--- a/src/apyfloat.cc
+++ b/src/apyfloat.cc
@@ -732,7 +732,8 @@ APyFloat APyFloat::operator+(const APyFloat& rhs) const
     } else {
         std::uint8_t res_exp_bits = std::max(exp_bits, rhs.exp_bits);
         std::uint8_t res_man_bits = std::max(man_bits, rhs.man_bits);
-        exp_t res_bias = APyFloat::ieee_bias(res_exp_bits);
+        exp_t res_bias
+            = calc_bias(res_exp_bits, exp_bits, bias, rhs.exp_bits, rhs.bias);
         // Cast once to resulting word length to get faster comparisons later
         x = cast_no_quant(res_exp_bits, res_man_bits, res_bias);
         y = rhs.cast_no_quant(res_exp_bits, res_man_bits, res_bias);
@@ -1053,9 +1054,10 @@ APyFloat& APyFloat::operator+=(const APyFloat& rhs)
 
 APyFloat APyFloat::operator*(const APyFloat& y) const
 {
-    auto res_exp_bits = std::max(exp_bits, y.exp_bits);
-    auto res_man_bits = std::max(man_bits, y.man_bits);
-    APyFloat res(res_exp_bits, res_man_bits);
+    const auto res_exp_bits = std::max(exp_bits, y.exp_bits);
+    const auto res_man_bits = std::max(man_bits, y.man_bits);
+    const auto res_bias = calc_bias(res_exp_bits, exp_bits, bias, y.exp_bits, y.bias);
+    APyFloat res(res_exp_bits, res_man_bits, res_bias);
 
     // Calculate sign
     res.sign = sign ^ y.sign;
@@ -1209,7 +1211,10 @@ APyFloat APyFloat::operator*(const APyFloat& y) const
 
 APyFloat APyFloat::operator/(const APyFloat& y) const
 {
-    APyFloat res(std::max(exp_bits, y.exp_bits), std::max(man_bits, y.man_bits));
+    const auto res_exp_bits = std::max(exp_bits, y.exp_bits);
+    const auto res_man_bits = std::max(man_bits, y.man_bits);
+    const auto res_bias = calc_bias(res_exp_bits, exp_bits, bias, y.exp_bits, y.bias);
+    APyFloat res(res_exp_bits, res_man_bits, res_bias);
 
     // Calculate sign
     res.sign = sign ^ y.sign;

--- a/src/apyfloat_util.cc
+++ b/src/apyfloat_util.cc
@@ -1,4 +1,5 @@
 #include "apyfloat_util.h"
+#include <math.h>
 
 /* Helper functions */
 man_t ipow(man_t base, unsigned int n)
@@ -21,6 +22,16 @@ man_t ipow(man_t base, unsigned int n)
     }
 
     return result;
+}
+
+exp_t calc_bias_general(
+    int new_exp_bits, int exp_bits1, exp_t bias1, int exp_bits2, exp_t bias2
+)
+{
+    return ((double)(bias1 + 1) / (1 << exp_bits1)
+            + (double)(bias2 + 1) / (1 << exp_bits2))
+        * (1 << (new_exp_bits - 1))
+        - 1;
 }
 
 void quantize_apymantissa(

--- a/src/apyfloat_util.h
+++ b/src/apyfloat_util.h
@@ -29,7 +29,7 @@ bool APY_INLINE do_infinity(QuantizationMode mode, bool sign)
     }
 }
 
-//! Calculate new bias
+//! Calculate new bias. Assumes new_exp_bits is larger than exp_bits1 and exp_bits2.
 exp_t APY_INLINE
 calc_bias(int new_exp_bits, int exp_bits1, exp_t bias1, int exp_bits2, exp_t bias2)
 {
@@ -38,6 +38,12 @@ calc_bias(int new_exp_bits, int exp_bits1, exp_t bias1, int exp_bits2, exp_t bia
             >> 1)
         - 1;
 }
+
+//! General calculation of new bias. Should only be used if new_exp_bits can be strictly
+//! less than exp_bits1 or exp_bits2.
+exp_t calc_bias_general(
+    int new_exp_bits, int exp_bits1, exp_t bias1, int exp_bits2, exp_t bias2
+);
 
 //! Quantize mantissa
 void APY_INLINE quantize_mantissa(

--- a/src/apyfloat_util.h
+++ b/src/apyfloat_util.h
@@ -29,6 +29,18 @@ bool APY_INLINE do_infinity(QuantizationMode mode, bool sign)
     }
 }
 
+//! Calculate new bias
+exp_t APY_INLINE
+calc_bias(int new_exp_bits, int exp_bits1, exp_t bias1, int exp_bits2, exp_t bias2)
+{
+    return ((((bias1 + 1) << (new_exp_bits - exp_bits1))
+             + ((bias2 + 1) << (new_exp_bits - exp_bits2)))
+            >> 1)
+        - 1;
+    // return std::min(((bias1 + 1) << (new_exp_bits - exp_bits1)), ((bias2 + 1) <<
+    // (new_exp_bits - exp_bits2))) - 1;
+}
+
 //! Quantize mantissa
 void APY_INLINE quantize_mantissa(
     man_t& man,

--- a/src/apyfloat_util.h
+++ b/src/apyfloat_util.h
@@ -37,8 +37,6 @@ calc_bias(int new_exp_bits, int exp_bits1, exp_t bias1, int exp_bits2, exp_t bia
              + ((bias2 + 1) << (new_exp_bits - exp_bits2)))
             >> 1)
         - 1;
-    // return std::min(((bias1 + 1) << (new_exp_bits - exp_bits1)), ((bias2 + 1) <<
-    // (new_exp_bits - exp_bits2))) - 1;
 }
 
 //! Quantize mantissa

--- a/src/apyfloatarray.cc
+++ b/src/apyfloatarray.cc
@@ -1521,7 +1521,8 @@ APyFloatArray APyFloatArray::checked_2d_matmul(const APyFloatArray& rhs) const
         : std::vector<std::size_t> { shape[0] };              // rhs is 1-D
     const std::uint8_t max_exp_bits = std::max(exp_bits, rhs.exp_bits);
     const std::uint8_t max_man_bits = std::max(man_bits, rhs.man_bits);
-    const auto res_bias = APyFloat::ieee_bias(max_exp_bits);
+    const auto res_bias
+        = calc_bias(max_exp_bits, exp_bits, bias, rhs.exp_bits, rhs.bias);
     const auto res_cols = rhs.shape.size() > 1 ? rhs.shape[1] : 1;
 
     auto accumulator_mode = get_accumulator_mode_float();

--- a/src/apyfloatarray.cc
+++ b/src/apyfloatarray.cc
@@ -25,12 +25,7 @@ APyFloatArray::APyFloatArray(
     : exp_bits(exp_bits)
     , man_bits(man_bits)
 {
-    this->bias = APyFloat::ieee_bias(exp_bits);
-    if (bias.value_or(this->bias) != this->bias) {
-        throw NotImplementedException(
-            "Not implemented: APyFloatArray with non IEEE-like bias"
-        );
-    }
+    this->bias = bias.value_or(APyFloat::ieee_bias(exp_bits));
 
     const auto signs_shape = python_sequence_extract_shape(sign_seq);
     const auto exps_shape = python_sequence_extract_shape(exp_seq);

--- a/src/apytypes_common.cc
+++ b/src/apytypes_common.cc
@@ -191,7 +191,7 @@ APyFloatAccumulatorContext::APyFloatAccumulatorContext(
 
     new_mode.exp_bits = exp_bits.value();
     new_mode.man_bits = man_bits.value();
-    new_mode.bias = bias.value_or(APyFloat::ieee_bias(new_mode.exp_bits));
+    new_mode.bias = bias;
     new_mode.quantization = quantization.value_or(get_float_quantization_mode());
 
     // Set the current mode

--- a/src/apytypes_common.h
+++ b/src/apytypes_common.h
@@ -177,7 +177,7 @@ std::optional<APyFixedAccumulatorOption> get_accumulator_mode_fixed();
 struct APyFloatAccumulatorOption {
     std::uint8_t exp_bits;
     std::uint8_t man_bits;
-    exp_t bias;
+    std::optional<exp_t> bias;
     QuantizationMode quantization;
 };
 


### PR DESCRIPTION
Support floating-point arithmetic with mixed biases, closes #322. The new bias is calculated by taking the "average".

### TODOs:
* [x] Update code to not assume IEEE-like biases
* [x] Write test cases for scalars:
    * [x] Addition / subtraction
    * [x] Multiplication
    * [x] Division
    * [x] Comparisons
* [x] Write test cases for arrays

Also added two test cases marked xfail related to the accumulator context quantizing too early, related to #422.