### PR TITLE
More exception handling of formats in APyFloat

### DIFF
--- a/lib/test/apyfloat/test_arithmetic.py
+++ b/lib/test/apyfloat/test_arithmetic.py
@@ -1087,6 +1087,11 @@ def test_power_underflow():
 )
 def test_power_special_cases(x, n, test_exp):
     """Test the special cases for the power function."""
+    if n[0] == "-":
+        pytest.skip(
+            "Skip tests with negative powers as the function currently throws, see https://github.com/apytypes/apytypes/issues/191."
+        )
+
     if str(test_exp) == "nan":
         assert eval(f"(APyFloat.from_float(float({x}), 9, 7)**{n}).is_nan")
     else:

--- a/lib/test/apyfloat/test_methods.py
+++ b/lib/test/apyfloat/test_methods.py
@@ -5,10 +5,14 @@ from apytypes import APyFloat
 
 def test_scalar_constructor_raises():
     # Too many exponent bits
-    with pytest.raises(ValueError, match=".*exponent"):
+    with pytest.raises(
+        ValueError, match="Exponent bits can at most be .. but 100 was given"
+    ):
         APyFloat(0, 0, 0, 100, 5)
     # Too many mantissa bits
-    with pytest.raises(ValueError, match=".*mantissa"):
+    with pytest.raises(
+        ValueError, match="Mantissa bits can at most be .. but 100 was given"
+    ):
         APyFloat(0, 0, 0, 5, 100)
 
 

--- a/lib/test/apyfloat/test_methods.py
+++ b/lib/test/apyfloat/test_methods.py
@@ -42,6 +42,19 @@ def test_scalar_from_bits_raises():
         APyFloat.from_bits(0, 5, 100)
 
 
+def test_scalar_cast_raises():
+    # Too many exponent bits
+    with pytest.raises(
+        ValueError, match="Exponent bits can at most be .. but 100 was given"
+    ):
+        APyFloat(0, 0, 0, 5, 5).cast(100, 5)
+    # Too many mantissa bits
+    with pytest.raises(
+        ValueError, match="Mantissa bits can at most be .. but 100 was given"
+    ):
+        APyFloat(0, 0, 0, 5, 5).cast(5, 100)
+
+
 @pytest.mark.float_special
 @pytest.mark.parametrize("float_s", ["nan", "inf", "-inf", "0.0", "-0.0"])
 def test_special_conversions(float_s):

--- a/lib/test/apyfloat/test_methods.py
+++ b/lib/test/apyfloat/test_methods.py
@@ -16,6 +16,32 @@ def test_scalar_constructor_raises():
         APyFloat(0, 0, 0, 5, 100)
 
 
+def test_scalar_from_float_raises():
+    # Too many exponent bits
+    with pytest.raises(
+        ValueError, match="Exponent bits can at most be .. but 100 was given"
+    ):
+        APyFloat.from_float(0, 100, 5)
+    # Too many mantissa bits
+    with pytest.raises(
+        ValueError, match="Mantissa bits can at most be .. but 100 was given"
+    ):
+        APyFloat.from_float(0, 5, 100)
+
+
+def test_scalar_from_bits_raises():
+    # Too many exponent bits
+    with pytest.raises(
+        ValueError, match="Exponent bits can at most be .. but 100 was given"
+    ):
+        APyFloat.from_bits(0, 100, 5)
+    # Too many mantissa bits
+    with pytest.raises(
+        ValueError, match="Mantissa bits can at most be .. but 100 was given"
+    ):
+        APyFloat.from_bits(0, 5, 100)
+
+
 @pytest.mark.float_special
 @pytest.mark.parametrize("float_s", ["nan", "inf", "-inf", "0.0", "-0.0"])
 def test_special_conversions(float_s):

--- a/lib/test/apyfloatarray/test_constructors.py
+++ b/lib/test/apyfloatarray/test_constructors.py
@@ -27,6 +27,15 @@ def test_constructor_raises():
         match="Non <type>/sequence found when walking: '<class 'apytypes._apytypes.APyFloatArray'>'",
     ):
         APyFloatArray([True], [4], [APyFloatArray], 10, 10)
+    with pytest.raises(
+        ValueError, match="Exponent bits can at most be .. but 100 was given"
+    ):
+        APyFloatArray([0], [0], [0], 100, 5)
+    # Too many mantissa bits
+    with pytest.raises(
+        ValueError, match="Mantissa bits can at most be .. but 100 was given"
+    ):
+        APyFloatArray([0], [0], [0], 5, 100)
 
 
 @pytest.mark.float_array

--- a/lib/test/apyfloatarray/test_matmul.py
+++ b/lib/test/apyfloatarray/test_matmul.py
@@ -259,10 +259,10 @@ def test_inner_product_with_inf_from_summation_long():
 
 @pytest.mark.float_array
 def test_inner_product_long():
-    a = APyFloatArray.from_float([1, 2, 3, 4, 5, 6, 7, 8], exp_bits=5, man_bits=62)
-    b = APyFloatArray.from_float([9, 8, 7, 6, 5, 4, 3, 2], exp_bits=6, man_bits=62)
+    a = APyFloatArray.from_float([1, 2, 3, 4, 5, 6, 7, 8], exp_bits=5, man_bits=61)
+    b = APyFloatArray.from_float([9, 8, 7, 6, 5, 4, 3, 2], exp_bits=6, man_bits=61)
     assert (a @ b).is_identical(b @ a)
-    assert (b @ a).is_identical(APyFloat.from_float(156, exp_bits=6, man_bits=62))
+    assert (b @ a).is_identical(APyFloat.from_float(156, exp_bits=6, man_bits=61))
 
 
 @pytest.mark.float_array

--- a/lib/test/apyfloatarray/test_methods.py
+++ b/lib/test/apyfloatarray/test_methods.py
@@ -29,6 +29,19 @@ def test_array_from_float_raises():
         APyFloatArray.from_float([0], 5, 100)
 
 
+def test_array_cast_raises():
+    # Too many exponent bits
+    with pytest.raises(
+        ValueError, match="Exponent bits can at most be .. but 100 was given"
+    ):
+        APyFloatArray([0], [0], [0], 5, 5).cast(100, 5)
+    # Too many mantissa bits
+    with pytest.raises(
+        ValueError, match="Mantissa bits can at most be .. but 100 was given"
+    ):
+        APyFloatArray([0], [0], [0], 5, 5).cast(5, 100)
+
+
 @pytest.mark.float_array
 def test_to_numpy():
     # Skip this test if `NumPy` is not present on the machine

--- a/lib/test/apyfloatarray/test_methods.py
+++ b/lib/test/apyfloatarray/test_methods.py
@@ -16,6 +16,20 @@ def test_is_identical():
 
 
 @pytest.mark.float_array
+def test_array_from_float_raises():
+    # Too many exponent bits
+    with pytest.raises(
+        ValueError, match="Exponent bits can at most be .. but 100 was given"
+    ):
+        APyFloatArray.from_float([0], 100, 5)
+    # Too many mantissa bits
+    with pytest.raises(
+        ValueError, match="Mantissa bits can at most be .. but 100 was given"
+    ):
+        APyFloatArray.from_float([0], 5, 100)
+
+
+@pytest.mark.float_array
 def test_to_numpy():
     # Skip this test if `NumPy` is not present on the machine
     np = pytest.importorskip("numpy")

--- a/src/apyfloat.cc
+++ b/src/apyfloat.cc
@@ -32,13 +32,10 @@ void APyFloat::create_in_place(
     std::optional<exp_t> bias
 )
 {
-    const exp_t ieee_bias = APyFloat::ieee_bias(exp_bits);
-
     check_exponent_format(exp_bits);
     check_mantissa_format(man_bits);
 
-    new (apyfloat)
-        APyFloat(sign, exp, man, exp_bits, man_bits, bias.value_or(ieee_bias));
+    new (apyfloat) APyFloat(sign, exp, man, exp_bits, man_bits, bias);
 }
 
 APyFloat::APyFloat(

--- a/src/apyfloat.cc
+++ b/src/apyfloat.cc
@@ -140,9 +140,14 @@ APyFloat APyFloat::cast(
 ) const
 {
     const auto actual_exp_bits = new_exp_bits.value_or(exp_bits);
+    const auto actual_man_bits = new_man_bits.value_or(man_bits);
+
+    check_exponent_format(actual_exp_bits);
+    check_mantissa_format(actual_man_bits);
+
     return _cast(
         actual_exp_bits,
-        new_man_bits.value_or(man_bits),
+        actual_man_bits,
         new_bias.value_or(APyFloat::ieee_bias(actual_exp_bits)),
         quantization.value_or(get_float_quantization_mode())
     );
@@ -727,10 +732,10 @@ APyFloat APyFloat::operator+(const APyFloat& rhs) const
                 res.set_to_zero(new_sign);
                 return res;
             }
-            return rhs.cast(res_exp_bits, res_man_bits, res_bias);
+            return rhs._cast(res_exp_bits, res_man_bits, res_bias);
         }
         if (rhs.is_zero()) {
-            return cast(res_exp_bits, res_man_bits, res_bias);
+            return _cast(res_exp_bits, res_man_bits, res_bias);
         }
         // Handle the NaN and inf cases
         if (is_max_exponent() || rhs.is_max_exponent()) {

--- a/src/apyfloat.cc
+++ b/src/apyfloat.cc
@@ -1323,6 +1323,10 @@ APyFloat APyFloat::pow(const APyFloat& x, const APyFloat& y)
 
 APyFloat APyFloat::pown(const APyFloat& x, int n)
 {
+    if (n < 0) {
+        throw NotImplementedException("Not implemented: power with negative integers.");
+    }
+
     // Handling of special cases based on the 754-2019 standard
     if (x.is_nan() || (n == 1)) {
         return x;

--- a/src/apyfloat.cc
+++ b/src/apyfloat.cc
@@ -5,7 +5,6 @@ namespace nb = nanobind;
 #include <cassert>
 #include <climits>
 #include <cmath>
-#include <iostream>
 
 #include <fmt/format.h>
 
@@ -24,15 +23,6 @@ namespace nb = nanobind;
 static constexpr std::size_t _MAN_LIMIT_BITS = _MAN_T_SIZE_BITS - 3;
 static constexpr std::size_t _EXP_LIMIT_BITS = _EXP_T_SIZE_BITS - 2;
 
-constexpr bool PRINT_WARNINGS = false;
-
-void print_warning(const std::string msg)
-{
-    if constexpr (PRINT_WARNINGS) {
-        std::cerr << "Warning: " << msg;
-    }
-}
-
 /* **********************************************************************************
  * * Constructors                                                                   *
  * **********************************************************************************
@@ -49,16 +39,23 @@ void APyFloat::create_in_place(
 )
 {
     const exp_t ieee_bias = APyFloat::ieee_bias(exp_bits);
-    if (bias.has_value() && bias.value() != ieee_bias) {
-        print_warning("non 'ieee-like' biases are not sure to work yet.\n");
-    }
 
     if (exp_bits > _EXP_LIMIT_BITS) {
-        throw nb::value_error("Too many bits for the exponent field.");
+        throw nb::value_error(fmt::format(
+                                  "Exponent bits can at most be {} but {} was given",
+                                  _EXP_LIMIT_BITS,
+                                  (unsigned int)exp_bits
+        )
+                                  .c_str());
     }
 
     if (man_bits > _MAN_LIMIT_BITS) {
-        throw nb::value_error("Too many bits for the mantissa field.");
+        throw nb::value_error(fmt::format(
+                                  "Mantissa bits can at most be {} but {} was given",
+                                  _MAN_LIMIT_BITS,
+                                  (unsigned int)man_bits
+        )
+                                  .c_str());
     }
 
     new (apyfloat)

--- a/src/apyfloat.cc
+++ b/src/apyfloat.cc
@@ -17,12 +17,6 @@ namespace nb = nanobind;
 
 #include "ieee754.h"
 
-/*!
- * APyFloat word length limits.
- */
-static constexpr std::size_t _MAN_LIMIT_BITS = _MAN_T_SIZE_BITS - 3;
-static constexpr std::size_t _EXP_LIMIT_BITS = _EXP_T_SIZE_BITS - 2;
-
 /* **********************************************************************************
  * * Constructors                                                                   *
  * **********************************************************************************
@@ -40,23 +34,8 @@ void APyFloat::create_in_place(
 {
     const exp_t ieee_bias = APyFloat::ieee_bias(exp_bits);
 
-    if (exp_bits > _EXP_LIMIT_BITS) {
-        throw nb::value_error(fmt::format(
-                                  "Exponent bits can at most be {} but {} was given",
-                                  _EXP_LIMIT_BITS,
-                                  (unsigned int)exp_bits
-        )
-                                  .c_str());
-    }
-
-    if (man_bits > _MAN_LIMIT_BITS) {
-        throw nb::value_error(fmt::format(
-                                  "Mantissa bits can at most be {} but {} was given",
-                                  _MAN_LIMIT_BITS,
-                                  (unsigned int)man_bits
-        )
-                                  .c_str());
-    }
+    check_exponent_format(exp_bits);
+    check_mantissa_format(man_bits);
 
     new (apyfloat)
         APyFloat(sign, exp, man, exp_bits, man_bits, bias.value_or(ieee_bias));
@@ -142,6 +121,9 @@ APyFloat APyFloat::from_double(
     std::optional<exp_t> bias
 )
 {
+    check_exponent_format(exp_bits);
+    check_mantissa_format(man_bits);
+
     APyFloat apytypes_double(
         sign_of_double(value), exp_of_double(value), man_of_double(value), 11, 52, 1023
     );
@@ -566,6 +548,9 @@ APyFloat APyFloat::from_bits(
     std::optional<exp_t> bias
 )
 {
+    check_exponent_format(exp_bits);
+    check_mantissa_format(man_bits);
+
     APyFloat f(exp_bits, man_bits, bias);
     return f.update_from_bits(python_long_int_bit_pattern);
 }

--- a/src/apyfloat_util.cc
+++ b/src/apyfloat_util.cc
@@ -1,5 +1,9 @@
 #include "apyfloat_util.h"
+#include <fmt/format.h>
 #include <math.h>
+#include <nanobind/nanobind.h>
+
+namespace nb = nanobind;
 
 /* Helper functions */
 man_t ipow(man_t base, unsigned int n)
@@ -68,5 +72,29 @@ QuantizationMode translate_quantization_mode(QuantizationMode quantization, bool
         return sign ? QuantizationMode::RND : QuantizationMode::RND_ZERO;
     default:
         return quantization;
+    }
+}
+
+void check_exponent_format(std::uint8_t exp_bits)
+{
+    if (exp_bits > _EXP_LIMIT_BITS) {
+        throw nb::value_error(fmt::format(
+                                  "Exponent bits can at most be {} but {} was given",
+                                  _EXP_LIMIT_BITS,
+                                  (unsigned int)exp_bits
+        )
+                                  .c_str());
+    }
+}
+
+void check_mantissa_format(std::uint8_t man_bits)
+{
+    if (man_bits > _MAN_LIMIT_BITS) {
+        throw nb::value_error(fmt::format(
+                                  "Mantissa bits can at most be {} but {} was given",
+                                  _MAN_LIMIT_BITS,
+                                  (unsigned int)man_bits
+        )
+                                  .c_str());
     }
 }

--- a/src/apyfloat_util.h
+++ b/src/apyfloat_util.h
@@ -12,6 +12,12 @@ static constexpr std::size_t _MAN_T_SIZE_BITS = 8 * _MAN_T_SIZE_BYTES;
 static constexpr std::size_t _EXP_T_SIZE_BYTES = sizeof(exp_t);
 static constexpr std::size_t _EXP_T_SIZE_BITS = 8 * _EXP_T_SIZE_BYTES;
 
+/*!
+ * APyFloat word length limits.
+ */
+static constexpr std::size_t _MAN_LIMIT_BITS = _MAN_T_SIZE_BITS - 3;
+static constexpr std::size_t _EXP_LIMIT_BITS = _EXP_T_SIZE_BITS - 2;
+
 //! Check if one should saturate to infinity or maximum normal number
 bool APY_INLINE do_infinity(QuantizationMode mode, bool sign)
 {
@@ -207,4 +213,9 @@ void quantize_apymantissa(
 );
 QuantizationMode translate_quantization_mode(QuantizationMode quantization, bool sign);
 
+//! Check that the number of exponent bits is allowed, throw otherwise
+void check_exponent_format(std::uint8_t exp_bits);
+
+//! Check that the number of mantissa bits is allowed, throw otherwise
+void check_mantissa_format(std::uint8_t man_bits);
 #endif // _APYFLOAT_UTIL_H

--- a/src/apyfloat_wrapper.cc
+++ b/src/apyfloat_wrapper.cc
@@ -42,16 +42,6 @@ void bind_float(nb::module_& m)
             Returns
             -------
             :class:`APyFloat`
-
-            Examples
-            --------
-
-            .. code-block:: python
-
-                from apytypes import APyFloat
-
-                # `a`, initialized from floating-point values.
-                a = APyFloat.from_float(1.35, exp_bits=10, man_bits=15)
             )pbdoc"
         )
 

--- a/src/apyfloatarray.cc
+++ b/src/apyfloatarray.cc
@@ -1201,10 +1201,15 @@ APyFloatArray APyFloatArray::cast(
     std::optional<QuantizationMode> quantization
 ) const
 {
-    auto actual_exp_bits = new_exp_bits.value_or(exp_bits);
+    const auto actual_exp_bits = new_exp_bits.value_or(exp_bits);
+    const auto actual_man_bits = new_man_bits.value_or(man_bits);
+
+    check_exponent_format(actual_exp_bits);
+    check_mantissa_format(actual_man_bits);
+
     return _cast(
         actual_exp_bits,
-        new_man_bits.value_or(man_bits),
+        actual_man_bits,
         new_bias.value_or(APyFloat::ieee_bias(actual_exp_bits)),
         quantization.value_or(get_float_quantization_mode())
     );

--- a/src/apyfloatarray.cc
+++ b/src/apyfloatarray.cc
@@ -1067,6 +1067,9 @@ APyFloatArray APyFloatArray::from_double(
     std::optional<exp_t> bias
 )
 {
+    check_exponent_format(exp_bits);
+    check_mantissa_format(man_bits);
+
     if (nb::isinstance<nb::ndarray<>>(double_seq)) {
         // Sequence is NDArray. Initialize using `from_array`.
         auto ndarray = nb::cast<nb::ndarray<nb::c_contig>>(double_seq);

--- a/src/apyfloatarray.cc
+++ b/src/apyfloatarray.cc
@@ -14,6 +14,23 @@ namespace nb = nanobind;
 #include <stdexcept>
 #include <string>
 
+void APyFloatArray::create_in_place(
+    APyFloatArray* apyfloatarray,
+    const nanobind::sequence& sign_seq,
+    const nanobind::sequence& exp_seq,
+    const nanobind::sequence& man_seq,
+    std::uint8_t exp_bits,
+    std::uint8_t man_bits,
+    std::optional<exp_t> bias
+)
+{
+    check_exponent_format(exp_bits);
+    check_mantissa_format(man_bits);
+
+    new (apyfloatarray)
+        APyFloatArray(sign_seq, exp_seq, man_seq, exp_bits, man_bits, bias);
+}
+
 APyFloatArray::APyFloatArray(
     const nanobind::sequence& sign_seq,
     const nanobind::sequence& exp_seq,

--- a/src/apyfloatarray.h
+++ b/src/apyfloatarray.h
@@ -13,7 +13,6 @@
 class APyFloatArray {
 public:
     explicit APyFloatArray(
-
         const nanobind::sequence& sign_seq,
         const nanobind::sequence& exp_seq,
         const nanobind::sequence& man_seq,
@@ -91,6 +90,17 @@ public:
     /* ****************************************************************************** *
      *                       Static conversion from other types                       *
      * ****************************************************************************** */
+
+    //! Factory function for Python interface
+    static void create_in_place(
+        APyFloatArray* apyfloatarray,
+        const nanobind::sequence& sign_seq,
+        const nanobind::sequence& exp_seq,
+        const nanobind::sequence& man_seq,
+        std::uint8_t exp_bits,
+        std::uint8_t man_bits,
+        std::optional<exp_t> bias = std::nullopt
+    );
 
     //! Create an `APyFloatArray` tensor object initialized with values from a sequence
     //! of `doubles`

--- a/src/apyfloatarray_wrapper.cc
+++ b/src/apyfloatarray_wrapper.cc
@@ -16,19 +16,36 @@ void bind_float_array(nb::module_& m)
          * Constructor: construct from a list of Python integers
          */
         .def(
-            nb::init<
-                const nb::sequence&,
-                const nb::sequence&,
-                const nb::sequence&,
-                std::uint8_t,
-                std::uint8_t,
-                std::optional<int>>(),
+            "__init__",
+            &APyFloatArray::create_in_place,
             nb::arg("signs"),
             nb::arg("exps"),
             nb::arg("mans"),
             nb::arg("exp_bits"),
             nb::arg("man_bits"),
-            nb::arg("bias") = nb::none()
+            nb::arg("bias") = nb::none(),
+            R"pbdoc(
+            Create an :class:`APyFloat` object.
+
+            Parameters
+            ----------
+            signs : sequence of bools or ints
+                The sign of the float. False/0 means positive. True/non-zero means negative.
+            exps : sequence of ints
+                Exponents of the floats as stored, i.e., actual value + bias.
+            mans : sequence of ints
+                Mantissas of the floats as stored, i.e., without a hidden one.
+            exp_bits : int
+                Number of exponent bits.
+            man_bits : int
+                Number of mantissa bits.
+            bias : int, optional
+                Bias. If not provided, *bias* is ``2**exp_bits - 1``.
+
+            Returns
+            -------
+            :class:`APyFloatArray`
+            )pbdoc"
         )
 
         /*


### PR DESCRIPTION
* [x] Better exception when giving a too big format for scalar constructor
* [x] Give exception when giving a too big format for array constructor
* [x] Give exception when giving a too big format in `from_float`
* [x] Give exception when giving a too big format in `from_bits`
* [x] Give exception when giving a too big format in `cast`
* [x] Give exception when giving negative powers
