### PR TITLE
Fixes in quantization for floating-point scalar multiplication

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- v0.1.1 Smaller fixes in quantization for floating-point scalar multiplication.
+
 ### Removed
 
 ## [0.1.0] - 2024-05-15

--- a/lib/test/apyfloat/test_rounding.py
+++ b/lib/test/apyfloat/test_rounding.py
@@ -381,6 +381,58 @@ class TestAPyFloatQuantizationMul:
                 APyFloat(sign=1, exp=0, man=1, exp_bits=5, man_bits=10)
             )
 
+    def test_stoch_weighted(self):
+        with APyFloatQuantizationContext(QuantizationMode.STOCH_WEIGHTED):
+            # 1.25 * 1.25 should quantize to 1.5 or 1.75
+            res = APyFloat(0, 15, 1, 5, 2) * APyFloat(0, 15, 1, 5, 2)
+            assert res.is_identical(APyFloat(0, 15, 2, 5, 2)) or (
+                res.is_identical(APyFloat(0, 15, 3, 5, 2))
+            )
+
+            res = APyFloat(0, 15, 1, 5, 52) * APyFloat(0, 15, 1, 5, 52)
+            assert res.is_identical(APyFloat(0, 15, 2, 5, 52)) or (
+                res.is_identical(APyFloat(0, 15, 3, 5, 52))
+            )
+
+            # Should quantize to zero or smallest subnormal
+            res = APyFloat(0, 1, 0, 4, 2) * APyFloat(0, 1, 0, 4, 2)
+            assert res.is_identical(APyFloat(0, 0, 0, 4, 2)) or (
+                res.is_identical(APyFloat(0, 0, 1, 4, 2))
+            )
+
+            res = APyFloat(0, 0, (1 << 27) - 1, 4, 52) * APyFloat(
+                0, 0, (1 << 30) - 1, 4, 52
+            )
+            assert res.is_identical(APyFloat(0, 0, 0, 4, 52)) or (
+                res.is_identical(APyFloat(0, 0, 1, 4, 52))
+            )
+
+    def test_stoch_equal(self):
+        with APyFloatQuantizationContext(QuantizationMode.STOCH_EQUAL):
+            # 1.25 * 1.25 should quantize to 1.5 or 1.75
+            res = APyFloat(0, 15, 1, 5, 2) * APyFloat(0, 15, 1, 5, 2)
+            assert res.is_identical(APyFloat(0, 15, 2, 5, 2)) or (
+                res.is_identical(APyFloat(0, 15, 3, 5, 2))
+            )
+
+            res = APyFloat(0, 15, 1, 5, 52) * APyFloat(0, 15, 1, 5, 52)
+            assert res.is_identical(APyFloat(0, 15, 2, 5, 52)) or (
+                res.is_identical(APyFloat(0, 15, 3, 5, 52))
+            )
+
+            # Should quantize to zero or smallest subnormal
+            res = APyFloat(0, 1, 0, 4, 2) * APyFloat(0, 1, 0, 4, 2)
+            assert res.is_identical(APyFloat(0, 0, 0, 4, 2)) or (
+                res.is_identical(APyFloat(0, 0, 1, 4, 2))
+            )
+
+            res = APyFloat(0, 0, (1 << 27) - 1, 4, 52) * APyFloat(
+                0, 0, (1 << 30) - 1, 4, 52
+            )
+            assert res.is_identical(APyFloat(0, 0, 0, 4, 52)) or (
+                res.is_identical(APyFloat(0, 0, 1, 4, 52))
+            )
+
 
 @pytest.mark.float_div
 class TestAPyFloatQuantizationDiv:

--- a/lib/test/apyfloat/test_rounding.py
+++ b/lib/test/apyfloat/test_rounding.py
@@ -313,6 +313,19 @@ class TestAPyFloatQuantizationMul:
             res = APyFloat(1, 30, 3, 5, 2) * APyFloat(0, 30, 3, 5, 2)
             assert res.is_identical(APyFloat(1, 30, 3, 5, 2))
 
+            # Tests from https://github.com/apytypes/apytypes/issues/406
+            res = APyFloat(1, 1, 1023, 5, 10) * APyFloat(1, 26, 80, 5, 10)
+            assert res.is_identical(
+                APyFloat(sign=0, exp=13, man=80, exp_bits=5, man_bits=10)
+            )
+
+            res = APyFloat(sign=0, exp=2, man=72, exp_bits=5, man_bits=10) * APyFloat(
+                sign=0, exp=0, man=58, exp_bits=5, man_bits=10
+            )
+            assert res.is_identical(
+                APyFloat(sign=0, exp=0, man=1, exp_bits=5, man_bits=10)
+            )
+
     def test_to_neg(self):
         with APyFloatQuantizationContext(QuantizationMode.TO_NEG):
             # Should round down
@@ -345,6 +358,28 @@ class TestAPyFloatQuantizationMul:
             # Big negative number should become infinity
             res = APyFloat(1, 30, 3, 5, 2) * APyFloat(0, 30, 3, 5, 2)
             assert res.is_identical(APyFloat(1, 31, 0, 5, 2))
+
+    def test_jam(self):
+        # TODO: more tests
+        with APyFloatQuantizationContext(QuantizationMode.JAM):
+            # Test jamming for subnormal result
+            res = APyFloat(sign=0, exp=0, man=1, exp_bits=5, man_bits=10) * APyFloat(
+                sign=1, exp=0, man=1, exp_bits=5, man_bits=10
+            )
+            assert res.is_identical(
+                APyFloat(sign=1, exp=0, man=1, exp_bits=5, man_bits=10)
+            )
+
+    def test_jam_unbiased(self):
+        # TODO: more tests
+        with APyFloatQuantizationContext(QuantizationMode.JAM_UNBIASED):
+            # Test jamming for subnormal result
+            res = APyFloat(sign=0, exp=0, man=1, exp_bits=5, man_bits=10) * APyFloat(
+                sign=1, exp=0, man=1, exp_bits=5, man_bits=10
+            )
+            assert res.is_identical(
+                APyFloat(sign=1, exp=0, man=1, exp_bits=5, man_bits=10)
+            )
 
 
 @pytest.mark.float_div

--- a/src/apyfloat.cc
+++ b/src/apyfloat.cc
@@ -1101,7 +1101,7 @@ APyFloat APyFloat::operator*(const APyFloat& y) const
         if (tmp_exp <= 0) {
             if (tmp_exp < -static_cast<std::int64_t>(res.man_bits)) {
                 // Exponent too small after rounding
-                res.man = quantize_close_to_zero(sign, new_man, quantization);
+                res.man = quantize_close_to_zero(res.sign, new_man, quantization);
                 res.exp = 0;
                 return res;
             }
@@ -1117,7 +1117,7 @@ APyFloat APyFloat::operator*(const APyFloat& y) const
             res_exp,
             res.max_exponent(),
             man_bits_delta,
-            sign,
+            res.sign,
             two_res,
             quantization
         );

--- a/src/apyfloat_util.h
+++ b/src/apyfloat_util.h
@@ -184,15 +184,20 @@ void APY_INLINE quantize_mantissa(
 }
 
 man_t APY_INLINE
-quantize_close_to_zero(bool sign, int64_t man, QuantizationMode quantization)
+quantize_close_to_zero(bool sign, man_t man, QuantizationMode quantization)
 {
     switch (quantization) {
     case QuantizationMode::TRN_AWAY:
+    case QuantizationMode::JAM:
+    case QuantizationMode::JAM_UNBIASED:
         return 1;
     case QuantizationMode::TRN:
         return sign;
     case QuantizationMode::TRN_INF:
         return !sign;
+    case QuantizationMode::STOCH_EQUAL:
+        // STOCH_WEIGHTED should not use this function
+        return random_number_float() & 1;
     default:
         return 0;
     }


### PR DESCRIPTION
<!--
Thank you so much for your PR!
-->

## PR Summary
<!-- Please provide at least 1-2 sentences describing the pull request in detail
(Why is this change required?  What problem does it solve?) and link to relevant
issues and PRs.
-->
Fixes third point in #406. Fixed that scalar floating-point multiplication was sometimes off by one LSB for directed quantization modes. Fixed jamming for subnormal numbers as well. Lastly, updated changelog.

## PR Checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

- [x] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] new and changed code is tested
- [x] relevant changes added to [CHANGELOG.md](https://github.com/apytypes/apytypes/blob/main/CHANGELOG.md)
