### PR TITLE
Fix in 'cast' when result is subnormal

### DIFF
--- a/lib/test/apyfloat/test_rounding.py
+++ b/lib/test/apyfloat/test_rounding.py
@@ -1164,6 +1164,13 @@ class TestAPyFloatQuantization:
             APyFloat(1, 30, 0, 5, 5).cast(4, 3).is_identical(APyFloat(1, 15, 0, 4, 3))
         )  # Should become infinity
 
+        # From https://github.com/apytypes/apytypes/issues/406
+        res = APyFloat(sign=0, exp=103, man=0, exp_bits=8, man_bits=23).cast(5, 10)
+        assert res.is_identical(APyFloat(sign=0, exp=0, man=1, exp_bits=5, man_bits=10))
+
+        res = APyFloat(sign=0, exp=103, man=1, exp_bits=8, man_bits=23).cast(5, 10)
+        assert res.is_identical(APyFloat(sign=0, exp=0, man=1, exp_bits=5, man_bits=10))
+
     def test_quantization_ties_odd(self):
         apytypes.set_float_quantization_mode(QuantizationMode.TIES_ODD)
         # Quantization from 0.xx
@@ -1944,6 +1951,12 @@ class TestAPyFloatQuantization:
                 pytest.fail(f"{larger_format} was rounded to {smaller_format}")
             if done_down and done_up:
                 break
+
+    def test_quantization_subnormal_shift(self):
+        """Result will be subnormal but require a left shift."""
+        assert (_ := APyFloat(0, 0, 1, 4, 4).cast(4, 10)).is_identical(
+            APyFloat(sign=0, exp=0, man=64, exp_bits=4, man_bits=10)
+        )
 
 
 def test_convenience_cast():

--- a/src/apyfloat.cc
+++ b/src/apyfloat.cc
@@ -224,8 +224,12 @@ APyFloat APyFloat::_checked_cast(
         res.exp = 0;
         // Cast mantissa
         res.man = prev_man;
-        std::uint8_t man_bits_delta = 1 - new_exp;
-        res.cast_mantissa_subnormal(man_bits_delta, quantization);
+        const int man_bits_delta = 1 - new_exp + (man_bits - new_man_bits);
+        if (man_bits_delta > 0) {
+            res.cast_mantissa_subnormal(man_bits_delta, quantization);
+        } else {
+            res.man <<= -man_bits_delta;
+        }
         return res;
     }
 


### PR DESCRIPTION
<!--
Thank you so much for your PR!
-->

# PR Summary
<!-- Please provide at least 1-2 sentences describing the pull request in detail
(Why is this change required?  What problem does it solve?) and link to relevant
issues and PRs.
-->
Fixes point five in #406, i.e. bug when casting to a subnormal number. Updated changelog.

# PR Checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

- [x] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] new and changed code is tested
- [x] relevant changes added to [CHANGELOG.md](https://github.com/apytypes/apytypes/blob/main/CHANGELOG.md)
