### PR TITLE
Add methods next_up and next_down for floating-point

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Methods `next_up()` and `next_down()` for floating-point,
+  based on the IEEE-754 standard.
+
 ### Changed
 
 ### Fixed

--- a/src/apyfloat.h
+++ b/src/apyfloat.h
@@ -320,6 +320,12 @@ public:
     cast_to_half(std::optional<QuantizationMode> quantization = std::nullopt) const;
     APyFloat
     cast_to_bfloat16(std::optional<QuantizationMode> quantization = std::nullopt) const;
+    //! The least floating-point number in the same format that compares greater.
+    //! Based on the IEEE-754 standard.
+    APyFloat next_up() const;
+    //! The least floating-point number in the same format that compares less.
+    //! Based on the IEEE-754 standard.
+    APyFloat next_down() const;
 
 private:
     std::uint8_t exp_bits, man_bits;

--- a/src/apyfloat_wrapper.cc
+++ b/src/apyfloat_wrapper.cc
@@ -623,5 +623,29 @@ void bind_float(nb::module_& m)
                 Quantization mode to use. If not provided, the global mode,
                 see :func:`get_float_quantization_mode`, is used.
             )pbdoc"
-        );
+        )
+        .def("next_up", &APyFloat::next_up, R"pbdoc(
+            Get the least floating-point number in the same format that compares greater.
+
+            See also
+            --------
+            next_down
+
+            Returns
+            -------
+            :class:`APyFloat`
+
+            )pbdoc")
+        .def("next_down", &APyFloat::next_down, R"pbdoc(
+            Get the least floating-point number in the same format that compares less.
+
+            See also
+            --------
+            next_up
+
+            Returns
+            -------
+            :class:`APyFloat`
+
+            )pbdoc");
 }


### PR DESCRIPTION
<!--
Thank you so much for your PR!
-->
This PR adds the methods `next_up` and `next_down` to `APyFloat`, which closes #95. Updated changelog.
# PR Summary
<!-- Please provide at least 1-2 sentences describing the pull request in detail
(Why is this change required?  What problem does it solve?) and link to relevant
issues and PRs.
-->

# PR Checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

- [x] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] new and changed code is tested
- [x] relevant changes added to [CHANGELOG.md](https://github.com/apytypes/apytypes/blob/main/CHANGELOG.md)
