### PR TITLE
Improve documentation for APyFloat*

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,10 @@ _version.pyi
 # Documentation ignores
 docs/_build/
 docs/xml/
+docs/examples/
+docs/sg_execution_times.rst
+docs/*.png
+comparison/*.png
 
 # C++ source ignores
 *.gcda

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Methods `next_up()` and `next_down()` for floating-point,
-  based on the IEEE-754 standard.
+- Added methods `next_up()` and `next_down()` for floating-point scalars.
 - Broadcasting support [as NumPy](https://numpy.org/doc/stable/user/basics.broadcasting.html)
   - `APyFixedArray.broadcast_to()`
   - `APyFloatArray.broadcast_to()`

--- a/docs/api/apyfloat.rst
+++ b/docs/api/apyfloat.rst
@@ -30,8 +30,11 @@
 
    .. automethod:: is_identical
 
-   Convenience casting methods
+   Convenience methods
    ---------------------------
+
+   Casting
+   ^^^^^^^
 
    .. automethod:: cast_to_bfloat16
 
@@ -40,6 +43,13 @@
    .. automethod:: cast_to_half
 
    .. automethod:: cast_to_single
+
+   Calculations
+   ^^^^^^^
+
+   .. automethod:: next_up
+
+   .. automethod:: next_down
 
    Properties
    ----------

--- a/docs/api/apyfloat.rst
+++ b/docs/api/apyfloat.rst
@@ -45,7 +45,7 @@
    .. automethod:: cast_to_single
 
    Calculations
-   ^^^^^^^
+   ^^^^^^^^^^^^
 
    .. automethod:: next_up
 

--- a/lib/apytypes/__init__.py
+++ b/lib/apytypes/__init__.py
@@ -88,6 +88,19 @@ where exp_bits_1 and exp_bits_2 are the bit widths of the operands, bias_1 and b
 Note that this formula still results in an IEEE-like bias when the inputs use IEEE-like biases.
 """
 
+APyFloatArray.__doc__ = r"""
+Class for multidimensional arrays with configurable floating-point formats.
+
+:class:`APyFloatArray` is a class for multidimensional arrays with configurable
+floating-point formats. The interface is much like the one of NumPy,
+and direct plotting is supported by most functions in Matplotlib.
+:class:`APyFloatArray` should always be preferred, if possible, when working with
+arrays as it allows for better performance, and integration with other features of APyTypes.
+
+For information about the workings of floating-point numbers, see its scalar
+equivalent :class:`APyFloat`.
+"""
+
 APyFixed.__doc__ = r"""
 Class for configurable scalar fixed-point formats.
 

--- a/lib/apytypes/__init__.py
+++ b/lib/apytypes/__init__.py
@@ -40,7 +40,52 @@ __all__ = [
 ]
 
 APyFloat.__doc__ = r"""
-Class for configurable floating-point formats.
+:class:`APyFloat` is a class for floating-point scalars with configurable formats. The
+implementation is a generalization of the IEEE 754 standard, meaning that features like
+subnormals, infinities, and NaN, are still supported. The format is defined
+by the number of exponent and mantissa bits, and a non-negative bias. These fields are
+named :attr:`exp_bits`, :attr:`man_bits`, and :attr:`bias` respectively. Similar to the hardware
+representation of a floating-point number, the value is stored using three fields;
+a sign bit :attr:`sign`, a biased exponent :attr:`exp`, and an integral mantissa with a hidden one :attr:`man`.
+The value of a *normal* number would thus be
+
+.. math::
+    (-1)^{\texttt{sign}} \times 2^{\texttt{exp} - \texttt{bias}} \times (1 + \texttt{man} \times 2^{\texttt{-man_bits}}).
+
+In general, if the bias is not explicitly given for a format :class:`APyFloat` will default to an IEEE-like bias
+using the formula
+
+.. math::
+    \texttt{bias} = 2^{\texttt{exp_bits - 1}} - 1.
+
+Arithmetic can be performed similarly to the operations of the built-in type
+:class:`float` in Python. The resulting word length from operations will be
+the same as the input operands', but if the operands do not share the same format, the resulting
+bit widths of the exponent and mantissa field will be the maximum of its inputs:
+
+.. code-block:: Python
+
+    from apytypes import APyFloat
+    a = APyFixed.from_float(1.25, exp_bits=5, man_bits=2)
+    b = APyFixed.from_float(1.75, exp_bits=5, man_bits=2)
+    # Operands with same format, result will have exp_bits=5, man_bits=2
+    c = a + b
+
+    d = APyFixed.from_float(1.75, exp_bits=4, man_bits=4)
+    # Operands with different formats, result will have exp_bits=5, man_bits=4
+    e = a + d
+
+
+If the operands of an arithmetic operation have IEEE-like biases, then the result will
+also have an IEEE-like bias -- based on the resulting number of exponent bits.
+To support operations with biases deviating from the standard, the bias of the resulting format
+is calculated as the "average" of the inputs' biases:
+
+.. math::
+    \texttt{bias}_3 = \frac{\left ( \left (\texttt{bias}_1 + 1 \right ) / 2^{\texttt{exp_bits}_1} + \left (\texttt{bias}_2 + 1 \right ) / 2^{\texttt{exp_bits}_2} \right ) \times 2^{\texttt{exp_bits}_3}}{2} - 1,
+
+where exp_bits_1 and exp_bits_2 are the bit widths of the operands, bias_1 and bias_2 are the input biases, and exp_bits_3 is the target bit width.
+Note that this formula still results in an IEEE-like bias when the inputs use IEEE-like biases.
 """
 
 APyFixed.__doc__ = r"""

--- a/lib/apytypes/__init__.py
+++ b/lib/apytypes/__init__.py
@@ -40,7 +40,9 @@ __all__ = [
 ]
 
 APyFloat.__doc__ = r"""
-:class:`APyFloat` is a class for floating-point scalars with configurable formats. The
+Floating-point scalar with configurable format.
+
+The
 implementation is a generalization of the IEEE 754 standard, meaning that features like
 subnormals, infinities, and NaN, are still supported. The format is defined
 by the number of exponent and mantissa bits, and a non-negative bias. These fields are

--- a/lib/apytypes/_apytypes.pyi
+++ b/lib/apytypes/_apytypes.pyi
@@ -907,6 +907,24 @@ class APyFloat:
         """
 
     def to_bits(self) -> int: ...
+    def next_up(self) -> APyFloat:
+        """
+        Get the smallest floating-point number in the same format that compares greater.
+
+        Returns
+        -------
+        :class:`APyFloat`
+        """
+
+    def next_down(self) -> APyFloat:
+        """
+        Get the smallest floating-point number in the same format that compares less.
+
+        Returns
+        -------
+        :class:`APyFloat`
+        """
+
     @property
     def bias(self) -> int: ...
     @property

--- a/lib/apytypes/_apytypes.pyi
+++ b/lib/apytypes/_apytypes.pyi
@@ -918,7 +918,7 @@ class APyFloat:
 
     def next_down(self) -> APyFloat:
         """
-        Get the smallest floating-point number in the same format that compares less.
+        Get the largest floating-point number in the same format that compares less.
 
         Returns
         -------

--- a/src/apyfloat.h
+++ b/src/apyfloat.h
@@ -322,7 +322,7 @@ public:
     cast_to_bfloat16(std::optional<QuantizationMode> quantization = std::nullopt) const;
     //! Get the smallest floating-point number in the same format that compares greater.
     APyFloat next_up() const;
-    //! Get the smallest floating-point number in the same format that compares less.
+    //! Get the largest floating-point number in the same format that compares less.
     APyFloat next_down() const;
 
 private:

--- a/src/apyfloat.h
+++ b/src/apyfloat.h
@@ -320,11 +320,9 @@ public:
     cast_to_half(std::optional<QuantizationMode> quantization = std::nullopt) const;
     APyFloat
     cast_to_bfloat16(std::optional<QuantizationMode> quantization = std::nullopt) const;
-    //! The least floating-point number in the same format that compares greater.
-    //! Based on the IEEE-754 standard.
+    //! Get the smallest floating-point number in the same format that compares greater.
     APyFloat next_up() const;
-    //! The least floating-point number in the same format that compares less.
-    //! Based on the IEEE-754 standard.
+    //! Get the smallest floating-point number in the same format that compares less.
     APyFloat next_down() const;
 
 private:

--- a/src/apyfloat_util.h
+++ b/src/apyfloat_util.h
@@ -183,6 +183,8 @@ APY_INLINE void quantize_mantissa(
     );
 }
 
+//! Quantize mantissa when the result is guaranteed to be either be 0 or 1.
+//! Quantization mode `STOCH_WEIGHTED` should be used with this function.
 APY_INLINE man_t
 quantize_close_to_zero(bool sign, man_t man, QuantizationMode quantization)
 {
@@ -206,16 +208,19 @@ quantize_close_to_zero(bool sign, man_t man, QuantizationMode quantization)
 //! Fast integer power by squaring.
 man_t ipow(man_t base, unsigned int n);
 
+//! Get the number of left shifts needed to make fx>=1.0
 APY_INLINE unsigned int leading_zeros_apyfixed(const APyFixed& fx)
 {
-    // Calculate the number of left shifts needed to make fx>=1.0
     const int zeros = fx.leading_zeros() - fx.int_bits();
     return std::max(0, zeros + 1);
 }
 
+//! Quantize mantissa stored as an `APyFixed`
 void quantize_apymantissa(
     APyFixed& apyman, bool sign, int bits, QuantizationMode quantization
 );
+//! Translate the quantization mode for floating-point to the fixed-point equivalent.
+//! This is used for the mantissa so the sign must be taken into account.
 QuantizationMode translate_quantization_mode(QuantizationMode quantization, bool sign);
 
 //! Check that the number of exponent bits is allowed, throw otherwise

--- a/src/apyfloat_wrapper.cc
+++ b/src/apyfloat_wrapper.cc
@@ -625,7 +625,7 @@ void bind_float(nb::module_& m)
             )pbdoc"
         )
         .def("next_up", &APyFloat::next_up, R"pbdoc(
-            Get the least floating-point number in the same format that compares greater.
+            Get the smallest floating-point number in the same format that compares greater.
 
             See also
             --------
@@ -637,7 +637,7 @@ void bind_float(nb::module_& m)
 
             )pbdoc")
         .def("next_down", &APyFloat::next_down, R"pbdoc(
-            Get the least floating-point number in the same format that compares less.
+            Get the smallest floating-point number in the same format that compares less.
 
             See also
             --------

--- a/src/apyfloat_wrapper.cc
+++ b/src/apyfloat_wrapper.cc
@@ -637,7 +637,7 @@ void bind_float(nb::module_& m)
 
             )pbdoc")
         .def("next_down", &APyFloat::next_down, R"pbdoc(
-            Get the smallest floating-point number in the same format that compares less.
+            Get the largest floating-point number in the same format that compares less.
 
             See also
             --------

--- a/src/apyfloat_wrapper.cc
+++ b/src/apyfloat_wrapper.cc
@@ -58,6 +58,8 @@ void bind_float(nb::module_& m)
             R"pbdoc(
             Create an :class:`APyFloat` object from a :class:`float`.
 
+            The quantization mode used is :class:`QuantizationMode.TIES_EVEN`.
+
             Parameters
             ----------
             value : float
@@ -82,6 +84,10 @@ void bind_float(nb::module_& m)
 
                 # `a`, initialized from floating-point values.
                 a = APyFloat.from_float(1.35, exp_bits=10, man_bits=15)
+
+            See also
+            --------
+            from_bits
             )pbdoc"
         )
         .def("__float__", &APyFloat::operator double)
@@ -106,27 +112,47 @@ void bind_float(nb::module_& m)
             bias : int, optional
                 Bias. If not provided, *bias* is ``2**exp_bits - 1``.
 
-            See also
-            --------
-            to_bits
-
             Returns
             -------
             :class:`APyFloat`
 
+            Examples
+            --------
+
+            .. code-block:: python
+
+                from apytypes import APyFloat
+
+                # `a`, initialized to -1.5 from a bit pattern.
+                a = APyFloat.from_bits(0b1_01111_10, exp_bits=5, man_bits=2)
+
+            See also
+            --------
+            to_bits
+            from_float
             )pbdoc"
         )
         .def("to_bits", &APyFloat::to_bits, R"pbdoc(
             Get the bit-representation of an :class:`APyFloat`.
 
-            See also
-            --------
-            from_bits
-
             Returns
             -------
             :class:`int`
 
+            Examples
+            --------
+
+            .. code-block:: python
+
+                from apytypes import APyFloat
+
+                # `a`, initialized to -1.5 from a bit pattern.
+                a = APyFloat.from_bits(0b1_01111_10, exp_bits=5, man_bits=2)
+                a.to_bits() == 0b1_01111_10 # True
+
+            See also
+            --------
+            from_bits
             )pbdoc")
         .def("__str__", &APyFloat::str)
         .def("__repr__", &APyFloat::repr)

--- a/src/apyfloatarray.h
+++ b/src/apyfloatarray.h
@@ -12,6 +12,8 @@
 
 class APyFloatArray {
 public:
+    //! Constructor taking a sequence of signs, biased exponents, and mantissas.
+    //! If no bias is given, an IEEE-like bias will be used.
     explicit APyFloatArray(
         const nanobind::sequence& sign_seq,
         const nanobind::sequence& exp_seq,
@@ -42,7 +44,9 @@ public:
     APyFloatArray operator*(const APyFloat& rhs) const;
     APyFloatArray operator/(const APyFloatArray& rhs) const;
     APyFloatArray operator/(const APyFloat& rhs) const;
+    //! Absolute value
     APyFloatArray abs() const;
+    //! Elementwise division with floating-point scalar
     APyFloatArray rtruediv(const APyFloat& rhs) const;
 
     /*!
@@ -77,12 +81,14 @@ public:
      */
     bool is_identical(const APyFloatArray& other) const;
 
+    //! Test if two `APyFloatArray` objects have the same format
     APY_INLINE bool same_type_as(const APyFloatArray& other) const
     {
         return man_bits == other.man_bits && exp_bits == other.exp_bits
             && bias == other.bias;
     }
 
+    //! Test if the `APyFloatArray` object has the same format as a `APyFloat` object
     APY_INLINE bool same_type_as(const APyFloat& other) const
     {
         return man_bits == other.get_man_bits() && exp_bits == other.get_exp_bits()
@@ -124,6 +130,7 @@ public:
         std::optional<exp_t> bias = std::nullopt
     );
 
+    //! Set data fields based on an and-array of doubles
     void _set_values_from_ndarray(const nanobind::ndarray<nanobind::c_contig>& ndarray);
 
     /* ****************************************************************************** *
@@ -149,6 +156,7 @@ public:
         std::optional<QuantizationMode> quantization = std::nullopt
     ) const;
 
+    //! Internal cast method when format is given fully
     APyFloatArray _cast(
         std::uint8_t exp_bits,
         std::uint8_t man_bits,
@@ -156,6 +164,7 @@ public:
         std::optional<QuantizationMode> quantization = std::nullopt
     ) const;
 
+    //! Internal cast method when format and quantization mode is given
     APyFloatArray _cast(
         std::uint8_t exp_bits,
         std::uint8_t man_bits,
@@ -163,34 +172,47 @@ public:
         QuantizationMode quantization
     ) const;
 
+    //! Change the number of mantissa and exponent bits for cases where it is known that
+    //! quantization does not happen, i.e., the resulting number of bits is not shorter.
     APyFloatArray cast_no_quant(
         std::uint8_t exp_bits,
         std::uint8_t man_bits,
         std::optional<exp_t> bias = std::nullopt
     ) const;
-
+    //! Retrieve the bias
     APY_INLINE exp_t get_bias() const { return bias; }
+    //! Retrieve the bit width of the mantissa field
     APY_INLINE std::uint8_t get_man_bits() const { return man_bits; }
+    //! Retrieve the bit width of the exponent field
     APY_INLINE std::uint8_t get_exp_bits() const { return exp_bits; }
+    //! Retrieve the bit width of the entire floating-point format
     APY_INLINE std::uint8_t get_bits() const { return exp_bits + man_bits + 1; }
-
-    enum class ArithmeticOperation { ADDITION, SUBTRACTION, MULTIPLICATION, DIVISION };
 
     /* ******************************************************************************
      * * Convenience methods                                                        *
      * ******************************************************************************
      */
+    //! Convenience method when target format is known to correspond to a
+    //! double-precision floating-point
     APyFloatArray
     cast_to_double(std::optional<QuantizationMode> quantization = std::nullopt) const;
+    //! Convenience method when target format is known to correspond to a
+    //! single-precision floating-point
     APyFloatArray
     cast_to_single(std::optional<QuantizationMode> quantization = std::nullopt) const;
+    //! Convenience method when target format is known to correspond to a half-precision
+    //! floating-point
     APyFloatArray
     cast_to_half(std::optional<QuantizationMode> quantization = std::nullopt) const;
+    //! Convenience method when target format is known to correspond to a 16-bit brain
+    //! float
     APyFloatArray
     cast_to_bfloat16(std::optional<QuantizationMode> quantization = std::nullopt) const;
 
 private:
+    //! Default constructor
     APyFloatArray() = default;
+    //! Constructor specifying only the shape and format of the array
     APyFloatArray(
         const std::vector<std::size_t>& shape,
         exp_t exp_bits,
@@ -220,7 +242,13 @@ private:
      * multiplication.
      */
     APyFloatArray checked_2d_matmul(const APyFloatArray& rhs) const;
+    //! Compute the sum of all elements
     APyFloat vector_sum(const QuantizationMode quantization) const;
+    /*!
+     * Perform hadamard multiplication of `*this` and `rhs`, and store result in `res`.
+     * This method assumes that the shape of `*this` and `rhs` are equal,
+     * anything else is undefined behaviour.
+     */
     void hadamard_multiplication(
         const APyFloatData* rhs,
         const uint8_t rhs_exp_bits,

--- a/src/apytypes_common.h
+++ b/src/apytypes_common.h
@@ -37,7 +37,7 @@ enum class OverflowMode {
 /* ********************************************************************************** *
  * *                          Context management for APyTypes                       * *
  * ********************************************************************************** */
-
+// Base class defining the interface for context managers
 class ContextManager {
 public:
     virtual ~ContextManager() = default;


### PR DESCRIPTION
<!--
Thank you so much for your PR!
-->

# PR Summary
<!-- Please provide at least 1-2 sentences describing the pull request in detail
(Why is this change required?  What problem does it solve?) and link to relevant
issues and PRs.
-->
This PR contains general improvements to the documentation for the floating-point types.

* [x] Reword description for `next_up` and `next_down`.
* [x] Add description for methods missing comments in `APyFloat` and `APyFloatArray`.
* [x] Add more description to `APyFloat` and `APyFloatArray`.

Documentation regarding `APyFloatQuantizationContext`, `APyFloatAccumulatorContext`, and sign of zero will be added in a different PR.
