### PR TITLE
src: add broadcasting support

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -14,3 +14,4 @@ issues and PRs.
 - [ ] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
 - [ ] new and changed code is tested
 - [ ] relevant changes added to [CHANGELOG.md](https://github.com/apytypes/apytypes/blob/main/CHANGELOG.md)
+- [ ] new functionality is documented

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,13 +11,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Methods `next_up()` and `next_down()` for floating-point,
   based on the IEEE-754 standard.
+- Broadcasting support [as NumPy](https://numpy.org/doc/stable/user/basics.broadcasting.html)
+  - `APyFixedArray.broadcast_to()`
+  - `APyFloatArray.broadcast_to()`
+  - Automatic broadcasting on array arithmetic
 
 ### Changed
 
 ### Fixed
 
 - Smaller fixes in quantization for floating-point scalar multiplication.
-- Fix in floating-point 'cast'-method when result became subnormal.
+- Fix in floating-point `cast`-method when result became subnormal.
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Smaller fixes in quantization for floating-point scalar multiplication.
 - Fix in floating-point `cast`-method when result became subnormal.
+- Fix bug in `APyFixedArray.__truediv__()` where program crashes on long-limb zero
+  denominators.
+- Fix bug where single-dimensional tuple representations missed out on a comma
 
 ### Removed
 

--- a/docs/api/apyfixedarray.rst
+++ b/docs/api/apyfixedarray.rst
@@ -30,10 +30,15 @@
 
    .. automethod:: to_numpy
 
-   Tranposition
-   ------------
+   Transposition
+   -------------
 
    .. automethod:: transpose
+
+   Broadcasting
+   ------------
+
+   .. automethod:: broadcast_to
 
    Properties
    ----------
@@ -54,7 +59,7 @@
 
    .. autoproperty:: shape
 
-   Tranposition
-   ^^^^^^^^^^^^
+   Transposition
+   ^^^^^^^^^^^^^
 
    .. autoproperty:: T

--- a/docs/api/apyfloatarray.rst
+++ b/docs/api/apyfloatarray.rst
@@ -35,6 +35,11 @@
 
    .. automethod:: transpose
 
+   Broadcasting
+   ------------
+
+   .. automethod:: broadcast_to
+
    Convenience casting methods
    ---------------------------
 

--- a/docs/cpp_api/broadcast.rst
+++ b/docs/cpp_api/broadcast.rst
@@ -1,0 +1,5 @@
+``broadcast.h``
+===============
+
+.. doxygenfile:: broadcast.h
+    :project: APyTypes

--- a/docs/cpp_api/index.rst
+++ b/docs/cpp_api/index.rst
@@ -16,5 +16,6 @@ APyTypes C++ API
    apytypes_scratch_vector
    apytypes_simd
    apytypes_util
+   broadcast
    ieee754
    python_util

--- a/lib/apytypes/_apytypes.pyi
+++ b/lib/apytypes/_apytypes.pyi
@@ -574,6 +574,7 @@ class APyFixedArray:
         :class:`APyFixedArray`
         """
 
+    def broadcast_to(self, shape: tuple | int) -> APyFixedArray: ...
     def is_identical(self, other: APyFixedArray) -> bool:
         """
         Test if two :class:`APyFixedArray` objects are identical.
@@ -1156,6 +1157,7 @@ class APyFloatArray:
             see :func:`get_float_quantization_mode`, is used.
         """
 
+    def broadcast_to(self, shape: tuple | int) -> APyFloatArray: ...
     def cast_to_double(
         self, quantization: QuantizationMode | None = None
     ) -> APyFloatArray:

--- a/lib/test/apyfixedarray/test_arithmetic.py
+++ b/lib/test/apyfixedarray/test_arithmetic.py
@@ -360,6 +360,11 @@ def test_array_div():
         )
     )
 
+    # Does not die
+    a = APyFixedArray.from_float([5], bits=100, int_bits=50)
+    b = APyFixedArray.from_float([0], bits=250, int_bits=100)
+    assert (a / b).is_identical(APyFixedArray([0], bits=351, int_bits=201))
+
 
 def test_array_div_scalar():
     a = APyFixedArray.from_float([-5, -6, 7, 8, 9, 5], bits=10, int_bits=5)

--- a/lib/test/apyfixedarray/test_matmul.py
+++ b/lib/test/apyfixedarray/test_matmul.py
@@ -17,7 +17,7 @@ def test_dimension_mismatch_raises():
     with pytest.raises(
         ValueError,
         match=re.escape(
-            "APyFixedArray.__matmul__: input shape mismatch, lhs: (3), rhs: (2)"
+            "APyFixedArray.__matmul__: input shape mismatch, lhs: (3,), rhs: (2,)"
         ),
     ):
         _ = a @ b
@@ -25,7 +25,7 @@ def test_dimension_mismatch_raises():
     with pytest.raises(
         ValueError,
         match=re.escape(
-            "APyFixedArray.__matmul__: input shape mismatch, lhs: (2), rhs: (3)"
+            "APyFixedArray.__matmul__: input shape mismatch, lhs: (2,), rhs: (3,)"
         ),
     ):
         _ = b @ a

--- a/lib/test/apyfixedarray/test_representation.py
+++ b/lib/test/apyfixedarray/test_representation.py
@@ -6,11 +6,11 @@ import pytest
 def test_array_representation():
     assert (
         APyFixedArray([], bits=1, int_bits=-5).__repr__()
-        == "APyFixedArray([], shape=(0), bits=1, int_bits=-5)"
+        == "APyFixedArray([], shape=(0,), bits=1, int_bits=-5)"
     )
     assert (
         APyFixedArray([1, 2, 3], bits=2, int_bits=2).__repr__()
-        == "APyFixedArray([1, 2, 3], shape=(3), bits=2, int_bits=2)"
+        == "APyFixedArray([1, 2, 3], shape=(3,), bits=2, int_bits=2)"
     )
     assert (
         APyFixedArray([range(5, 8), range(3)], bits=10, int_bits=20).__repr__()

--- a/lib/test/apyfloatarray/test_arithmetic.py
+++ b/lib/test/apyfloatarray/test_arithmetic.py
@@ -9,7 +9,7 @@ from apytypes import (
 
 @pytest.mark.float_array
 def test_array_raises():
-    a = APyFloatArray([1], [5], [4], 10, 10)
+    a = APyFloatArray([1, 2, 3], [5, 2, 3], [4, 2, 3], 10, 10)
     b = APyFloatArray([1, 2], [5, 3], [4, 4], 10, 10)
     with pytest.raises(ValueError, match="APyFloatArray.__add__: shape mismatch"):
         _ = a + b

--- a/lib/test/apyfloatarray/test_representation.py
+++ b/lib/test/apyfloatarray/test_representation.py
@@ -7,19 +7,19 @@ def test_repr():
     arr = APyFloatArray([], [], [], 6, 7)
     assert (
         repr(arr)
-        == "APyFloatArray([], [], [], shape=(0), exp_bits=6, man_bits=7, bias=31)"
+        == "APyFloatArray([], [], [], shape=(0,), exp_bits=6, man_bits=7, bias=31)"
     )
 
     arr = APyFloatArray([1], [5], [3], 5, 2)
     assert (
         repr(arr)
-        == "APyFloatArray([1], [5], [3], shape=(1), exp_bits=5, man_bits=2, bias=15)"
+        == "APyFloatArray([1], [5], [3], shape=(1,), exp_bits=5, man_bits=2, bias=15)"
     )
 
     arr = APyFloatArray([1, 0], [5, 10], [3, 1], 5, 2)
     assert (
         repr(arr)
-        == "APyFloatArray([1, 0], [5, 10], [3, 1], shape=(2), exp_bits=5, man_bits=2, bias=15)"
+        == "APyFloatArray([1, 0], [5, 10], [3, 1], shape=(2,), exp_bits=5, man_bits=2, bias=15)"
     )
 
     arr = APyFloatArray([[1, 0]], [[5, 10]], [[3, 1]], 5, 2)

--- a/lib/test/test_broadcasting.py
+++ b/lib/test/test_broadcasting.py
@@ -1,0 +1,46 @@
+from apytypes import APyFixedArray, APyFixed, APyFloatArray, APyFloat
+
+import pytest
+from typing import List, Tuple
+from itertools import product
+
+
+def all_shapes(ndim: int, dim_elements: int) -> List[Tuple[int, ...]]:
+    """
+    Retrieve a list of all possible shapes with `ndim` dimensions, spanning from one to
+    `dim_elements` (inclusive)
+    """
+    return list(product(*[range(1, dim_elements + 1) for _ in range(ndim)]))
+
+
+@pytest.mark.parametrize(
+    "apyarray_from_float",
+    [
+        lambda f: APyFixedArray.from_float(f, int_bits=100, frac_bits=0),
+        # lambda f: APyFloatArray.from_float(f, man_bits=20, exp_bits=15),
+    ],
+)
+def test_array_broadcast_to(apyarray_from_float):
+    np = pytest.importorskip("numpy")
+
+    MAX_NDIM = 3
+    MAX_DIM_ELEMENTS = 4
+
+    # Iterate over all possible source and destination shapes
+    for src_ndim, dst_ndim in product(range(1, MAX_NDIM + 1), range(1, MAX_NDIM + 1)):
+        src_shapes = all_shapes(src_ndim, MAX_DIM_ELEMENTS)
+        dst_shapes = all_shapes(dst_ndim, MAX_DIM_ELEMENTS)
+        for src_shape, dst_shape in product(src_shapes, dst_shapes):
+            numpy_src = np.arange(np.prod(src_shape), dtype=float).reshape(src_shape)
+            apy_src = apyarray_from_float(numpy_src)
+            try:
+                numpy_res = np.broadcast_to(numpy_src, dst_shape)
+                apy_res = apy_src.broadcast_to(dst_shape).to_numpy()
+                assert np.all(numpy_res == apy_res)
+            except ValueError:
+                # `ValueError` raised by `np.broadcast_to()` or `apy_src.broadcast_to()`
+                # for illegal broadcast. Make sure *both* arrays raises `ValueError`
+                with pytest.raises(ValueError):
+                    np.broadcast_to(numpy_src, dst_shape)
+                with pytest.raises(ValueError, match="Operands could not be broadcast"):
+                    apy_src.broadcast_to(dst_shape)

--- a/lib/test/test_broadcasting.py
+++ b/lib/test/test_broadcasting.py
@@ -17,16 +17,16 @@ def all_shapes(ndim: int, dim_elements: int) -> List[Tuple[int, ...]]:
     "apyarray_from_float",
     [
         lambda f: APyFixedArray.from_float(f, int_bits=100, frac_bits=0),
-        # lambda f: APyFloatArray.from_float(f, man_bits=20, exp_bits=15),
+        lambda f: APyFloatArray.from_float(f, man_bits=20, exp_bits=15),
     ],
 )
 def test_array_broadcast_to(apyarray_from_float):
     np = pytest.importorskip("numpy")
 
     MAX_NDIM = 3
-    MAX_DIM_ELEMENTS = 4
+    MAX_DIM_ELEMENTS = 3
 
-    # Iterate over all possible source and destination shapes
+    # Iterate over all possible source and destination shapes and test
     for src_ndim, dst_ndim in product(range(1, MAX_NDIM + 1), range(1, MAX_NDIM + 1)):
         src_shapes = all_shapes(src_ndim, MAX_DIM_ELEMENTS)
         dst_shapes = all_shapes(dst_ndim, MAX_DIM_ELEMENTS)
@@ -44,3 +44,8 @@ def test_array_broadcast_to(apyarray_from_float):
                     np.broadcast_to(numpy_src, dst_shape)
                 with pytest.raises(ValueError, match="Operands could not be broadcast"):
                     apy_src.broadcast_to(dst_shape)
+
+    # Also test `broadcast_to` with integer
+    assert np.all(
+        apyarray_from_float([1.0]).broadcast_to(9).to_numpy() == np.ones((9,))
+    )

--- a/lib/test/test_broadcasting.py
+++ b/lib/test/test_broadcasting.py
@@ -66,6 +66,14 @@ def test_array_broadcast_to_raises(apyarray_from_float):
 
 
 @pytest.mark.parametrize(
+    "a_shape, b_shape",
+    [
+        ((5, 1, 3, 4), (5, 5, 1, 4)),
+        ((1, 3, 4), (5, 5, 1, 4)),
+        ((5, 1, 3, 4), (5, 1, 4)),
+    ],
+)
+@pytest.mark.parametrize(
     "bin_func",
     [
         lambda a, b: a + b,
@@ -75,9 +83,8 @@ def test_array_broadcast_to_raises(apyarray_from_float):
     ],
 )
 @pytest.mark.parametrize("from_float", apytypes_from_float_generators)
-def test_array_broadcast_arithmetic(bin_func, from_float):
+def test_array_broadcast_arithmetic(bin_func, from_float, a_shape, b_shape):
     np = pytest.importorskip("numpy")
-    a_shape, b_shape = ((5, 1, 3, 4), (5, 5, 1, 4))
     a = np.arange(1, np.prod(a_shape) + 1).reshape(a_shape)
     b = np.ones(b_shape)
     ref = bin_func(a, b)

--- a/lib/test/test_broadcasting.py
+++ b/lib/test/test_broadcasting.py
@@ -1,4 +1,4 @@
-from apytypes import APyFixedArray, APyFixed, APyFloatArray, APyFloat
+from apytypes import APyFixedArray, APyFloatArray
 
 import pytest
 from typing import List, Tuple
@@ -13,18 +13,18 @@ def all_shapes(ndim: int, dim_elements: int) -> List[Tuple[int, ...]]:
     return list(product(*[range(1, dim_elements + 1) for _ in range(ndim)]))
 
 
-@pytest.mark.parametrize(
-    "apyarray_from_float",
-    [
-        lambda f: APyFixedArray.from_float(f, int_bits=100, frac_bits=0),
-        lambda f: APyFloatArray.from_float(f, man_bits=20, exp_bits=15),
-    ],
-)
-def test_array_broadcast_to(apyarray_from_float):
-    np = pytest.importorskip("numpy")
+# APyTypes array convenience generators
+apytypes_from_float_generators = [
+    lambda f: APyFixedArray.from_float(f, int_bits=100, frac_bits=0),
+    lambda f: APyFloatArray.from_float(f, man_bits=20, exp_bits=15),
+]
 
+
+@pytest.mark.parametrize("apyarray_from_float", apytypes_from_float_generators)
+def test_array_broadcast_to(apyarray_from_float):
     MAX_NDIM = 3
     MAX_DIM_ELEMENTS = 3
+    np = pytest.importorskip("numpy")
 
     # Iterate over all possible source and destination shapes and test
     for src_ndim, dst_ndim in product(range(1, MAX_NDIM + 1), range(1, MAX_NDIM + 1)):
@@ -45,7 +45,21 @@ def test_array_broadcast_to(apyarray_from_float):
                 with pytest.raises(ValueError, match="Operands could not be broadcast"):
                     apy_src.broadcast_to(dst_shape)
 
-    # Also test `broadcast_to` with integer
+
+@pytest.mark.parametrize("apyarray_from_float", apytypes_from_float_generators)
+def test_array_broadcast_to_integer(apyarray_from_float):
+    np = pytest.importorskip("numpy")
     assert np.all(
         apyarray_from_float([1.0]).broadcast_to(9).to_numpy() == np.ones((9,))
     )
+
+
+@pytest.mark.parametrize("apyarray_from_float", apytypes_from_float_generators)
+def test_array_broadcast_to_raises(apyarray_from_float):
+    # Can not broadcast if any of the destination dimensions are zero
+    with pytest.raises(ValueError, match="Operands could not be broadcast together"):
+        apyarray_from_float([1.0]).broadcast_to((3, 2, 1, 0, 1))
+
+    # Can not broadcast if the destination number-of-dimensions is zero
+    with pytest.raises(ValueError, match="Operands could not be broadcast together"):
+        apyarray_from_float([1.0]).broadcast_to(tuple())

--- a/src/apybuffer.h
+++ b/src/apybuffer.h
@@ -18,21 +18,6 @@
 
 #include "apytypes_util.h"
 
-//! Retrieve the byte-strides from a shape
-template <typename T>
-[[maybe_unused]] static APY_INLINE std::vector<std::size_t>
-byte_strides_from_shape(const std::vector<std::size_t>& shape, std::size_t itemsize = 1)
-{
-    std::size_t n_bytes = sizeof(T) * itemsize;
-    std::vector<std::size_t> strides(shape.size(), 0);
-    for (std::size_t i = 0; i < shape.size(); i++) {
-        strides[shape.size() - 1 - i] = std::accumulate(
-            shape.crbegin(), shape.crbegin() + i, n_bytes, std::multiplies {}
-        );
-    }
-    return strides;
-}
-
 template <typename T, typename Allocator = std::allocator<T>> class APyBuffer {
 
     //! APyBuffers are to be inherited from. All fields and constructors are protected.
@@ -51,7 +36,7 @@ protected:
     //! Retrieve a Python Buffer structure compatible with the Buffer Protocol
     Py_buffer get_py_buffer()
     {
-        _strides = byte_strides_from_shape<T>(_shape, _itemsize);
+        _strides = strides_from_shape(_shape, _itemsize * sizeof(T));
         return Py_buffer {
             (void*)&_data[0],                // void       *buf
             nullptr,                         // PyObject   *obj

--- a/src/apybuffer.h
+++ b/src/apybuffer.h
@@ -18,13 +18,6 @@
 
 #include "apytypes_util.h"
 
-//! Fold a shape under multiplication
-[[maybe_unused]] static APY_INLINE std::size_t
-fold_shape(const std::vector<std::size_t>& shape)
-{
-    return std::accumulate(shape.cbegin(), shape.cend(), 1, std::multiplies {});
-}
-
 //! Retrieve the byte-strides from a shape
 template <typename T>
 [[maybe_unused]] static APY_INLINE std::vector<std::size_t>

--- a/src/apyfixedarray.cc
+++ b/src/apyfixedarray.cc
@@ -252,8 +252,8 @@ APyFixedArray APyFixedArray::operator+(const APyFixedArray& rhs) const
         if (broadcast_shape.size() == 0) {
             throw std::length_error(fmt::format(
                 "APyFixedArray.__add__: shape mismatch, lhs.shape={}, rhs.shape={}",
-                string_from_vec(_shape),
-                string_from_vec(rhs._shape)
+                tuple_string_from_vec(_shape),
+                tuple_string_from_vec(rhs._shape)
             ));
         }
         return broadcast_to(broadcast_shape) + rhs.broadcast_to(broadcast_shape);
@@ -280,8 +280,8 @@ APyFixedArray APyFixedArray::operator-(const APyFixedArray& rhs) const
         if (broadcast_shape.size() == 0) {
             throw std::length_error(fmt::format(
                 "APyFixedArray.__sub__: shape mismatch, lhs.shape={}, rhs.shape={}",
-                string_from_vec(_shape),
-                string_from_vec(rhs._shape)
+                tuple_string_from_vec(_shape),
+                tuple_string_from_vec(rhs._shape)
             ));
         }
         return broadcast_to(broadcast_shape) - rhs.broadcast_to(broadcast_shape);
@@ -344,8 +344,8 @@ APyFixedArray APyFixedArray::operator*(const APyFixedArray& rhs) const
         if (broadcast_shape.size() == 0) {
             throw std::length_error(fmt::format(
                 "APyFixedArray.__mul__: shape mismatch, lhs.shape={}, rhs.shape={}",
-                string_from_vec(_shape),
-                string_from_vec(rhs._shape)
+                tuple_string_from_vec(_shape),
+                tuple_string_from_vec(rhs._shape)
             ));
         }
         return broadcast_to(broadcast_shape) * rhs.broadcast_to(broadcast_shape);
@@ -464,8 +464,8 @@ APyFixedArray APyFixedArray::operator/(const APyFixedArray& rhs) const
         if (broadcast_shape.size() == 0) {
             throw std::length_error(fmt::format(
                 "APyFixedArray.__div__: shape mismatch, lhs.shape={}, rhs.shape={}",
-                string_from_vec(_shape),
-                string_from_vec(rhs._shape)
+                tuple_string_from_vec(_shape),
+                tuple_string_from_vec(rhs._shape)
             ));
         }
         return broadcast_to(broadcast_shape) / rhs.broadcast_to(broadcast_shape);
@@ -720,9 +720,9 @@ APyFixedArray APyFixedArray::matmul(const APyFixedArray& rhs) const
 
     // Unsupported `__matmul__` dimensionality, raise exception
     throw std::length_error(fmt::format(
-        "APyFixedArray.__matmul__: input shape mismatch, lhs: ({}), rhs: ({})",
-        string_from_vec(_shape),
-        string_from_vec(rhs._shape)
+        "APyFixedArray.__matmul__: input shape mismatch, lhs: {}, rhs: {}",
+        tuple_string_from_vec(_shape),
+        tuple_string_from_vec(rhs._shape)
     ));
 }
 
@@ -765,9 +765,9 @@ APyFixedArray APyFixedArray::broadcast_to(const std::vector<std::size_t> shape) 
     if (!is_broadcastable(_shape, shape)) {
         throw nb::value_error(
             fmt::format(
-                "Operands could not be broadcast together with shapes: ({}), ({})",
-                string_from_vec(_shape),
-                string_from_vec(shape)
+                "Operands could not be broadcast together with shapes: {}, {}",
+                tuple_string_from_vec(_shape),
+                tuple_string_from_vec(shape)
             )
                 .c_str()
         );
@@ -809,9 +809,9 @@ std::string APyFixedArray::repr() const
 
         ss.seekp(-2, ss.cur);
     }
-    ss << "], shape=(";
-    ss << string_from_vec(_shape);
-    ss << "), "
+    ss << "], shape=";
+    ss << tuple_string_from_vec(_shape);
+    ss << ", "
        << "bits=" << std::dec << bits() << ", "
        << "int_bits=" << std::dec << int_bits() << ")";
     return ss.str();

--- a/src/apyfixedarray.cc
+++ b/src/apyfixedarray.cc
@@ -755,30 +755,14 @@ APyFixedArray APyFixedArray::broadcast_to(const std::vector<std::size_t> shape) 
     }
 
     APyFixedArray result(shape, bits(), int_bits());
-    broadcast_data_copy(
-        std::begin(_data),        // src
-        std::begin(result._data), // dst
-        _shape,                   // src shape
-        shape,                    // dst shape
-        _itemsize                 // itemsize
-    );
-
+    broadcast_data_copy(_data.begin(), result._data.begin(), _shape, shape, _itemsize);
     return result;
 }
 
 APyFixedArray
 APyFixedArray::broadcast_to_python(const std::variant<nb::tuple, nb::int_> shape) const
 {
-    std::vector<std::size_t> cpp_shape {};
-    if (std::holds_alternative<nb::tuple>(shape)) {
-        auto nb_tuple = std::get<nb::tuple>(shape);
-        for (const auto& tuple_element : nb_tuple) {
-            cpp_shape.push_back(nb::cast<std::size_t>(tuple_element));
-        }
-    } else { /* std::holds_alternative<nb::int_> */
-        cpp_shape.push_back(static_cast<std::size_t>(std::get<nb::int_>(shape)));
-    }
-    return broadcast_to(cpp_shape);
+    return broadcast_to(cpp_shape_from_python_shape(shape));
 }
 
 std::string APyFixedArray::repr() const

--- a/src/apyfixedarray.h
+++ b/src/apyfixedarray.h
@@ -137,8 +137,8 @@ public:
     //! Broadcast to a new shape
     APyFixedArray broadcast_to(const std::vector<std::size_t> shape) const;
 
-    APyFixedArray
-    broadcast_to_python(const std::variant<nanobind::tuple, nanobind::int_> shape
+    //! Python-exposed `broadcast_to`
+    APyFixedArray broadcast_to_python(const std::variant<nb::tuple, nb::int_> shape
     ) const;
 
     //! Python `__repr__()` function

--- a/src/apyfixedarray.h
+++ b/src/apyfixedarray.h
@@ -134,6 +134,13 @@ public:
      * *                          Public member functions                           * *
      * ****************************************************************************** */
 
+    //! Broadcast to a new shape
+    APyFixedArray broadcast_to(const std::vector<std::size_t> shape) const;
+
+    APyFixedArray
+    broadcast_to_python(const std::variant<nanobind::tuple, nanobind::int_> shape
+    ) const;
+
     //! Python `__repr__()` function
     std::string repr() const;
 

--- a/src/apyfixedarray_wrapper.cc
+++ b/src/apyfixedarray_wrapper.cc
@@ -342,7 +342,24 @@ void bind_fixed_array(nb::module_& m)
             :class:`APyFixedArray`
             )pbdoc"
         )
-        .def("broadcast_to", &APyFixedArray::broadcast_to_python, nb::arg("shape"))
+        .def(
+            "broadcast_to",
+            &APyFixedArray::broadcast_to_python,
+            nb::arg("shape"),
+            R"pbdoc(
+            Broadcast array to new shape.
+
+            Parameters
+            ----------
+            shape : tuple or int
+                The shape to broadcast to. A single integer ``i`` is interpreted as ``(i,)``.
+
+            Returns
+            -------
+            :class:`APyFixedArray`
+
+            )pbdoc"
+        )
 
         /*
          * Static methods
@@ -369,11 +386,11 @@ void bind_fixed_array(nb::module_& m)
                 Floating point values to initialize from. The tensor shape will be taken
                 from the sequence shape.
             int_bits : int, optional
-                Number of integer bits in the created fixed-point tensor
+                Number of integer bits in the created fixed-point tensor.
             frac_bits : int, optional
-                Number of fractional bits in the created fixed-point tensor
+                Number of fractional bits in the created fixed-point tensor.
             bits : int, optional
-                Total number of bits in the created fixed-point tensor
+                Total number of bits in the created fixed-point tensor.
 
             Returns
             -------
@@ -421,11 +438,11 @@ void bind_fixed_array(nb::module_& m)
             ndarray : ndarray
                 Values to initialize from. The tensor shape will be taken from the ndarray shape.
             int_bits : int, optional
-                Number of integer bits in the created fixed-point tensor
+                Number of integer bits in the created fixed-point tensor.
             frac_bits : int, optional
-                Number of fractional bits in the created fixed-point tensor
+                Number of fractional bits in the created fixed-point tensor.
             bits : int, optional
-                Total number of bits in the created fixed-point tensor
+                Total number of bits in the created fixed-point tensor.
 
             Returns
             -------

--- a/src/apyfixedarray_wrapper.cc
+++ b/src/apyfixedarray_wrapper.cc
@@ -343,6 +343,7 @@ void bind_fixed_array(nb::module_& m)
             :class:`APyFixedArray`
             )pbdoc"
         )
+        .def("broadcast_to", &APyFixedArray::broadcast_to_python, nb::arg("shape"))
 
         /*
          * Static methods

--- a/src/apyfixedarray_wrapper.cc
+++ b/src/apyfixedarray_wrapper.cc
@@ -1,7 +1,6 @@
 #include "apyfixed.h"
 #include "apyfixedarray.h"
 #include "apyfixedarray_iterator.h"
-#include "apytypes_common.h"
 
 #include <nanobind/nanobind.h>
 #include <nanobind/operators.h>

--- a/src/apyfloatarray.cc
+++ b/src/apyfloatarray.cc
@@ -101,8 +101,8 @@ APyFloatArray APyFloatArray::operator+(const APyFloatArray& rhs) const
         if (broadcast_shape.size() == 0) {
             throw std::length_error(fmt::format(
                 "APyFloatArray.__add__: shape mismatch, lhs.shape={}, rhs.shape={}",
-                string_from_vec(shape),
-                string_from_vec(rhs.shape)
+                tuple_string_from_vec(shape),
+                tuple_string_from_vec(rhs.shape)
             ));
         }
         return broadcast_to(broadcast_shape) + rhs.broadcast_to(broadcast_shape);
@@ -475,8 +475,8 @@ APyFloatArray APyFloatArray::operator-(const APyFloatArray& rhs) const
         if (broadcast_shape.size() == 0) {
             throw std::length_error(fmt::format(
                 "APyFloatArray.__sub__: shape mismatch, lhs.shape={}, rhs.shape={}",
-                string_from_vec(shape),
-                string_from_vec(rhs.shape)
+                tuple_string_from_vec(shape),
+                tuple_string_from_vec(rhs.shape)
             ));
         }
         return broadcast_to(broadcast_shape) - rhs.broadcast_to(broadcast_shape);
@@ -515,20 +515,11 @@ APyFloatArray APyFloatArray::operator*(const APyFloatArray& rhs) const
         if (broadcast_shape.size() == 0) {
             throw std::length_error(fmt::format(
                 "APyFloatArray.__mul__: shape mismatch, lhs.shape={}, rhs.shape={}",
-                string_from_vec(shape),
-                string_from_vec(rhs.shape)
+                tuple_string_from_vec(shape),
+                tuple_string_from_vec(rhs.shape)
             ));
         }
         return broadcast_to(broadcast_shape) * rhs.broadcast_to(broadcast_shape);
-    }
-
-    // Make sure `_shape` of `*this` and `rhs` are the same
-    if (shape != rhs.shape) {
-        throw std::length_error(fmt::format(
-            "APyFloatArray.__mul__: shape mismatch, lhs.shape={}, rhs.shape={}",
-            string_from_vec(shape),
-            string_from_vec(rhs.shape)
-        ));
     }
 
     // Calculate new format
@@ -899,21 +890,11 @@ APyFloatArray APyFloatArray::operator/(const APyFloatArray& rhs) const
         if (broadcast_shape.size() == 0) {
             throw std::length_error(fmt::format(
                 "APyFloatArray.__truediv__: shape mismatch, lhs.shape={}, rhs.shape={}",
-                string_from_vec(shape),
-                string_from_vec(rhs.shape)
+                tuple_string_from_vec(shape),
+                tuple_string_from_vec(rhs.shape)
             ));
         }
         return broadcast_to(broadcast_shape) / rhs.broadcast_to(broadcast_shape);
-    }
-
-    // Make sure `_shape` of `*this` and `rhs` are the same
-    if (shape != rhs.shape) {
-        throw std::length_error(fmt::format(
-            "APyFloatArray.__truediv__: shape mismatch, lhs.shape={}, "
-            "rhs.shape={}",
-            string_from_vec(shape),
-            string_from_vec(rhs.shape)
-        ));
     }
 
     // Calculate new format
@@ -999,9 +980,9 @@ std::variant<APyFloatArray, APyFloat> APyFloatArray::matmul(const APyFloatArray&
 
     // Unsupported `__matmul__` dimensionality, raise exception
     throw std::length_error(fmt::format(
-        "APyFloatArray.__matmul__: input shape mismatch, lhs: ({}), rhs: ({})",
-        string_from_vec(shape),
-        string_from_vec(rhs.shape)
+        "APyFloatArray.__matmul__: input shape mismatch, lhs: {}, rhs: {}",
+        tuple_string_from_vec(shape),
+        tuple_string_from_vec(rhs.shape)
     ));
 }
 
@@ -1026,9 +1007,9 @@ std::string APyFloatArray::repr() const
     } else {
         ss << "[], [], [], ";
     }
-    ss << "shape=(";
-    ss << string_from_vec(shape);
-    ss << "), "
+    ss << "shape=";
+    ss << tuple_string_from_vec(shape);
+    ss << ", "
        << "exp_bits=" << static_cast<unsigned>(exp_bits) << ", "
        << "man_bits=" << static_cast<unsigned>(man_bits) << ", "
        << "bias=" << bias << ")";
@@ -1225,9 +1206,9 @@ APyFloatArray APyFloatArray::broadcast_to(const std::vector<std::size_t> shape) 
     if (!is_broadcastable(this->shape, shape)) {
         throw nb::value_error(
             fmt::format(
-                "Operands could not be broadcast together with shapes: ({}), ({})",
-                string_from_vec(this->shape),
-                string_from_vec(shape)
+                "Operands could not be broadcast together with shapes: {}, {}",
+                tuple_string_from_vec(this->shape),
+                tuple_string_from_vec(shape)
             )
                 .c_str()
         );

--- a/src/apyfloatarray.h
+++ b/src/apyfloatarray.h
@@ -126,6 +126,17 @@ public:
 
     void _set_values_from_ndarray(const nanobind::ndarray<nanobind::c_contig>& ndarray);
 
+    /* ****************************************************************************** *
+     * *                          Public member functions                           * *
+     * ****************************************************************************** */
+
+    //! Broadcast to a new shape
+    APyFloatArray broadcast_to(const std::vector<std::size_t> shape) const;
+
+    //! Python-exposed `broadcast_to`
+    APyFloatArray broadcast_to_python(const std::variant<nb::tuple, nb::int_> shape
+    ) const;
+
     //! Transposition function. For a 1-D array, returns an exact copy of `*this`. For
     //! a 2-D array, returns the matrix transposition of `*this`.
     APyFloatArray transpose() const;

--- a/src/apyfloatarray_wrapper.cc
+++ b/src/apyfloatarray_wrapper.cc
@@ -452,6 +452,7 @@ void bind_float_array(nb::module_& m)
             -------
             :class:`APyFloatArray`
             )pbdoc")
+        .def("broadcast_to", &APyFloatArray::broadcast_to_python, nb::arg("shape"))
 
         // Iteration and friends
         .def("__getitem__", &APyFloatArray::get_item, nb::arg("idx"))

--- a/src/apyfloatarray_wrapper.cc
+++ b/src/apyfloatarray_wrapper.cc
@@ -452,7 +452,24 @@ void bind_float_array(nb::module_& m)
             -------
             :class:`APyFloatArray`
             )pbdoc")
-        .def("broadcast_to", &APyFloatArray::broadcast_to_python, nb::arg("shape"))
+        .def(
+            "broadcast_to",
+            &APyFloatArray::broadcast_to_python,
+            nb::arg("shape"),
+            R"pbdoc(
+            Broadcast array to new shape.
+
+            Parameters
+            ----------
+            shape : tuple or int
+                The shape to broadcast to. A single integer ``i`` is interpreted as ``(i,)``.
+
+            Returns
+            -------
+            :class:`APyFloatArray`
+
+            )pbdoc"
+        )
 
         // Iteration and friends
         .def("__getitem__", &APyFloatArray::get_item, nb::arg("idx"))

--- a/src/apytypes_util.h
+++ b/src/apytypes_util.h
@@ -22,6 +22,7 @@
 #include <sstream>          // std::stringstream
 #include <string>           // std::string
 #include <tuple>            // std::tuple
+#include <variant>          // std::variant
 #include <vector>           // std::vector
 
 /*
@@ -1049,6 +1050,22 @@ strides_from_shape(const std::vector<std::size_t>& shape)
         );
     }
     return strides;
+}
+
+//! Create a C++ shape vector (`std::vector<std::size_t>`) from a Python shape object
+//! (`std::variant<nanobind::tuple, nanobind::int_>`).
+static APY_INLINE std::vector<std::size_t>
+cpp_shape_from_python_shape(const std::variant<nanobind::tuple, nanobind::int_>& shape)
+{
+    std::vector<std::size_t> cpp_shape {};
+    if (std::holds_alternative<nanobind::tuple>(shape)) {
+        for (const auto& element : std::get<nanobind::tuple>(shape)) {
+            cpp_shape.push_back(nanobind::cast<std::size_t>(element));
+        }
+    } else {
+        cpp_shape.push_back(static_cast<std::size_t>(std::get<nanobind::int_>(shape)));
+    }
+    return cpp_shape;
 }
 
 //! Macro for creating a void-specialization state-less functor `FUNCTOR_NAME` from a

--- a/src/apytypes_util.h
+++ b/src/apytypes_util.h
@@ -8,6 +8,8 @@
 #include <nanobind/nanobind.h>
 #include <nanobind/stl/string.h>
 
+#include "fmt/format.h"
+
 #include <algorithm>        // std::find
 #include <cstddef>          // std::size_t
 #include <cstdint>          // int64_t
@@ -1006,17 +1008,22 @@ uint64_t_from_limb_vector(const std::vector<mp_limb_t>& limb_vec, std::size_t n)
     }
 }
 
-template <typename T> std::string string_from_vec(const std::vector<T>& vec)
+//! Construct a Python tuple-literal-string from a vector of `T`. The type `T` must be
+//! convertible to string through both a `std::stringstream` and `fmt::format({})`.
+template <typename T> std::string tuple_string_from_vec(const std::vector<T>& vec)
 {
     if (vec.size() == 0) {
-        return "";
+        return "()";
+    } else if (vec.size() == 1) {
+        return fmt::format("({},)", vec[0]);
+    } else {
+        std::stringstream ss;
+        ss << "(";
+        for (auto& d : vec) {
+            ss << d << ", ";
+        }
+        return ss.str().substr(0, ss.str().length() - 2).append(")");
     }
-
-    std::stringstream ss;
-    for (auto& d : vec) {
-        ss << d << ", ";
-    }
-    return ss.str().substr(0, ss.str().length() - 2);
 }
 
 [[maybe_unused, nodiscard]] static APY_INLINE mp_limb_t

--- a/src/apytypes_util.h
+++ b/src/apytypes_util.h
@@ -1041,12 +1041,12 @@ fold_shape(const std::vector<std::size_t>& shape)
 
 //! Compute the strides from a shape
 [[maybe_unused]] static APY_INLINE std::vector<std::size_t>
-strides_from_shape(const std::vector<std::size_t>& shape)
+strides_from_shape(const std::vector<std::size_t>& shape, std::size_t acc_base = 1)
 {
     std::vector<std::size_t> strides(shape.size(), 0);
     for (std::size_t i = 0; i < shape.size(); i++) {
         strides[shape.size() - 1 - i] = std::accumulate(
-            shape.crbegin(), shape.crbegin() + i, 1, std::multiplies {}
+            shape.crbegin(), shape.crbegin() + i, acc_base, std::multiplies {}
         );
     }
     return strides;
@@ -1054,8 +1054,9 @@ strides_from_shape(const std::vector<std::size_t>& shape)
 
 //! Create a C++ shape vector (`std::vector<std::size_t>`) from a Python shape object
 //! (`std::variant<nanobind::tuple, nanobind::int_>`).
-static APY_INLINE std::vector<std::size_t>
-cpp_shape_from_python_shape(const std::variant<nanobind::tuple, nanobind::int_>& shape)
+static APY_INLINE std::vector<std::size_t> cpp_shape_from_python_shape_like(
+    const std::variant<nanobind::tuple, nanobind::int_>& shape
+)
 {
     std::vector<std::size_t> cpp_shape {};
     if (std::holds_alternative<nanobind::tuple>(shape)) {

--- a/src/apytypes_util.h
+++ b/src/apytypes_util.h
@@ -16,6 +16,7 @@
 #include <iomanip>          // std::setfill, std::setw
 #include <ios>              // std::hex
 #include <iterator>         // std::distance
+#include <numeric>          // std::accumulate, std::multiplies
 #include <optional>         // std::optional, std::nullopt
 #include <regex>            // std::regex, std::regex_replace
 #include <sstream>          // std::stringstream
@@ -1028,6 +1029,26 @@ twos_complement_overflow(mp_limb_t value, int bits)
         return mp_limb_t(signed_limb);
     }
     return value;
+}
+
+//! Fold a shape under multiplication
+[[maybe_unused]] static APY_INLINE std::size_t
+fold_shape(const std::vector<std::size_t>& shape)
+{
+    return std::accumulate(shape.cbegin(), shape.cend(), 1, std::multiplies {});
+}
+
+//! Compute the strides from a shape
+[[maybe_unused]] static APY_INLINE std::vector<std::size_t>
+strides_from_shape(const std::vector<std::size_t>& shape)
+{
+    std::vector<std::size_t> strides(shape.size(), 0);
+    for (std::size_t i = 0; i < shape.size(); i++) {
+        strides[shape.size() - 1 - i] = std::accumulate(
+            shape.crbegin(), shape.crbegin() + i, 1, std::multiplies {}
+        );
+    }
+    return strides;
 }
 
 //! Macro for creating a void-specialization state-less functor `FUNCTOR_NAME` from a

--- a/src/broadcast.h
+++ b/src/broadcast.h
@@ -21,11 +21,8 @@ static APY_INLINE bool is_broadcastable(
         return false;
     }
 
-    // Can not broadcast if either source or destination has any zero-dimension
+    // Can not broadcast if destination shape has any zero-dimension
     auto is_zero = [](auto n) { return n == 0; };
-    if (std::any_of(std::begin(src_shape), std::end(src_shape), is_zero)) {
-        return false;
-    }
     if (std::any_of(std::begin(dst_shape), std::end(dst_shape), is_zero)) {
         return false;
     }

--- a/src/broadcast.h
+++ b/src/broadcast.h
@@ -1,0 +1,139 @@
+/*
+ * Common general broadcasting functionality for APyTypes
+ *
+ * NumPy fundamental broadcasting:
+ * https://numpy.org/doc/stable/user/basics.broadcasting.html
+ */
+
+#include "apytypes_util.h"
+
+#include <algorithm> // std::any_of, std::copy_n
+#include <tuple>
+#include <vector> // std::vector
+
+//! Test if the shape `src_shape` can be broadcast to `dst_shape`
+static APY_INLINE bool is_broadcastable(
+    const std::vector<std::size_t>& src_shape, const std::vector<std::size_t>& dst_shape
+)
+{
+    // Can not broadcast if either source or destination shape are zero-dimensional
+    if (src_shape.size() == 0 || dst_shape.size() == 0) {
+        return false;
+    }
+
+    // Can not broadcast if either source or destination has any zero-dimension
+    auto is_zero = [](auto n) { return n == 0; };
+    if (std::any_of(std::begin(src_shape), std::end(src_shape), is_zero)) {
+        return false;
+    }
+    if (std::any_of(std::begin(dst_shape), std::end(dst_shape), is_zero)) {
+        return false;
+    }
+
+    // Can not broadcast if destination shape has fewer dimensions than source shape
+    if (src_shape.size() > dst_shape.size()) {
+        return false;
+    }
+
+    // Iterate shapes from the trailing (right-most) dimensions
+    auto [src_it, dst_it] = std::make_tuple(src_shape.crbegin(), dst_shape.crbegin());
+    while (src_it != src_shape.crend() && dst_it != dst_shape.crend()) {
+        if (*src_it != 1) {
+            if (*src_it != *dst_it) {
+                return false;
+            }
+        }
+        ++src_it;
+        ++dst_it;
+    }
+
+    return true;
+}
+
+//! Perform a broadcast by copying data. This function assumes that `src_shape` can be
+//! broadcast to `dst_shape`, i.e., `is_broadcastable(src_shape, dst_shape) == true`. It
+//! further assumes that the data in `src` is stored in C-style order and that `dst` has
+//! enough space to store the broadcast result.
+template <typename RANDOM_ACCESS_CONST_ITERATOR, typename RANDOM_ACCESS_ITERATOR>
+static APY_INLINE void broadcast_data_copy(
+    RANDOM_ACCESS_CONST_ITERATOR src_it,
+    RANDOM_ACCESS_ITERATOR dst_it,
+    const std::vector<std::size_t>& src_shape,
+    const std::vector<std::size_t>& dst_shape,
+    std::size_t itemsize = 1 // TODO
+)
+{
+    std::size_t src_elements = fold_shape(src_shape);
+    std::size_t dst_elements = fold_shape(dst_shape);
+    std::size_t broadcast_elements = dst_elements / src_elements;
+
+    // Compute the destination stride vector
+    std::vector<std::size_t> dst_stride = strides_from_shape(dst_shape);
+
+    // Compute the adjusted source shape
+    std::size_t index_diff = dst_shape.size() - src_shape.size();
+    std::vector<std::size_t> src_shape_adjusted(dst_shape.size());
+    for (std::size_t i = 0; i < dst_shape.size(); i++) {
+        if (i < index_diff) {
+            src_shape_adjusted[i] = 1;
+        } else {
+            src_shape_adjusted[i] = src_shape[i - index_diff];
+        }
+    }
+
+    // Compute the broadcasting vector
+    std::vector<std::size_t> broadcast_vector(dst_shape.size());
+    for (std::size_t i = 0; i < dst_shape.size(); i++) {
+        broadcast_vector[i] = dst_shape[i] - src_shape_adjusted[i] + 1;
+    }
+
+    // Compute broadcast offsets (stride-weighted permutations of broadcasting vector)
+    std::vector<std::size_t> broadcast_offset(broadcast_elements);
+    for (std::size_t i = 0; i < broadcast_elements; i++) {
+        std::size_t index = i;
+        std::vector<std::size_t> broadcast_cord(src_shape_adjusted.size());
+        for (std::size_t j = dst_shape.size(); j--;) {
+            if (index == 0) {
+                break;
+            }
+            broadcast_cord[j] = index % broadcast_vector[j];
+            index /= broadcast_vector[j];
+        }
+
+        // Convert broadcast coordinate to weighted offset
+        std::size_t offset = 0;
+        for (std::size_t j = 0; j < broadcast_cord.size(); j++) {
+            offset += dst_stride[j] * broadcast_cord[j];
+        }
+        broadcast_offset[i] = offset;
+    }
+
+    // Loop over elements in the source vector and broadcast
+    std::vector<std::size_t> src_cord(src_shape_adjusted.size());
+    for (std::size_t i = 0; i < src_elements; i++) {
+        // Compute the source coordinate for the i-th source element
+        std::size_t index = i;
+        for (std::size_t j = src_shape_adjusted.size(); j--;) {
+            if (index == 0) {
+                break;
+            }
+            src_cord[j] = index % src_shape_adjusted[j];
+            index /= src_shape_adjusted[j];
+        }
+
+        // Convert source coordinate for the i-th element to reference destination index
+        std::size_t dst_idx = 0;
+        for (std::size_t j = 0; j < src_cord.size(); j++) {
+            dst_idx += dst_stride[j] * src_cord[j];
+        }
+
+        // Broadcast the data
+        for (std::size_t j = 0; j < broadcast_elements; j++) {
+            std::copy_n(
+                src_it + i * itemsize,
+                itemsize,
+                dst_it + (dst_idx + broadcast_offset[j]) * itemsize
+            );
+        }
+    }
+}

--- a/src/broadcast.h
+++ b/src/broadcast.h
@@ -38,10 +38,8 @@ static APY_INLINE bool is_broadcastable(
     // Iterate shapes from the trailing (right-most) dimensions
     auto [src_it, dst_it] = std::make_tuple(src_shape.crbegin(), dst_shape.crbegin());
     while (src_it != src_shape.crend() && dst_it != dst_shape.crend()) {
-        if (*src_it != 1) {
-            if (*src_it != *dst_it) {
-                return false;
-            }
+        if (*src_it != 1 && *src_it != *dst_it) {
+            return false;
         }
         ++src_it;
         ++dst_it;


### PR DESCRIPTION
This PR adds broadcasting support for the APyTypes array types.
Closes #302 

Also fixes a bug in `APyFixedArray.__truediv__` that would cause the program to crash on multi-limb division-by-zero.

## TODO
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

- [X] Implement general broadcasting functionality
- [X] Implement `APyFixedArray.broadcast_to(shape)`
- [x] Implement `APyFloatArray.broadcast_to(shape)`
- [x] Automatic broadcasting for arithmetic operators
- [x] new and changed code is tested
- [x] relevant changes added to [CHANGELOG.md](https://github.com/apytypes/apytypes/blob/main/CHANGELOG.md)
