### PR TITLE
Fix bug in comparison between APyFloat infinity and APyFixed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix bug in `APyFixedArray.__truediv__()` where program crashes on long-limb zero
   denominators.
 - Fix bug where single-dimensional tuple representations missed out on a comma.
+- Fix bug in comparison between floating-point infinity and fixed-point numbers.
 
 ### Removed
 

--- a/lib/apytypes/_apytypes.pyi
+++ b/lib/apytypes/_apytypes.pyi
@@ -1652,11 +1652,11 @@ class APyFloatArray:
             Floating point values to initialize from. The tensor shape will be taken
             from the sequence shape.
         exp_bits : int
-            Number of exponent bits in the created fixed-point tensor
+            Number of exponent bits in the created floating-point tensor
         man_bits : int
-            Number of mantissa bits in the created fixed-point tensor
+            Number of mantissa bits in the created floating-point tensor
         bias : int, optional
-            Bias in the created fixed-point tensor
+            Bias in the created floating-point tensor
 
         Returns
         -------

--- a/lib/test/apyfloat/test_comparisons.py
+++ b/lib/test/apyfloat/test_comparisons.py
@@ -71,6 +71,15 @@ def test_comparisons_with_apyfixed():
         APyFloat.from_float(float("nan"), 4, 3) < APyFixed.from_float(1000, 16, 16)
     )
 
+    assert APyFloat.from_float(float("-inf"), 4, 3) < APyFixed.from_float(1000, 16, 16)
+    assert APyFloat.from_float(float("-inf"), 4, 3) <= APyFixed.from_float(1000, 16, 16)
+    assert not APyFloat.from_float(float("-inf"), 4, 3) > APyFixed.from_float(
+        1000, 16, 16
+    )
+    assert not APyFloat.from_float(float("-inf"), 4, 3) >= APyFixed.from_float(
+        1000, 16, 16
+    )
+
 
 @pytest.mark.float_comp
 @pytest.mark.parametrize(

--- a/src/apyfloat.cc
+++ b/src/apyfloat.cc
@@ -1758,38 +1758,48 @@ bool APyFloat::operator!=(const APyFixed& rhs) const
 bool APyFloat::operator<=(const APyFixed& rhs) const
 {
     if (is_max_exponent()) {
+        if (man == 0) { // inf
+            return sign;
+        }
         return false;
     }
+
     return ((to_fixed()) <= rhs);
 }
 
 bool APyFloat::operator<(const APyFixed& rhs) const
 {
     if (is_max_exponent()) {
+        if (man == 0) { // inf
+            return sign;
+        }
         return false;
     }
+
     return ((to_fixed()) < rhs);
 }
 
 bool APyFloat::operator>=(const APyFixed& rhs) const
 {
-    if (is_nan()) {
+    if (is_max_exponent()) {
+        if (man == 0) { // inf
+            return !sign;
+        }
         return false;
     }
-    if (is_inf()) {
-        return true;
-    }
+
     return ((to_fixed()) >= rhs);
 }
 
 bool APyFloat::operator>(const APyFixed& rhs) const
 {
-    if (is_nan()) {
+    if (is_max_exponent()) {
+        if (man == 0) { // inf
+            return !sign;
+        }
         return false;
     }
-    if (is_inf()) {
-        return true;
-    }
+
     return ((to_fixed()) > rhs);
 }
 

--- a/src/apyfloatarray_wrapper.cc
+++ b/src/apyfloatarray_wrapper.cc
@@ -347,11 +347,11 @@ void bind_float_array(nb::module_& m)
                 Floating point values to initialize from. The tensor shape will be taken
                 from the sequence shape.
             exp_bits : int
-                Number of exponent bits in the created fixed-point tensor
+                Number of exponent bits in the created floating-point tensor
             man_bits : int
-                Number of mantissa bits in the created fixed-point tensor
+                Number of mantissa bits in the created floating-point tensor
             bias : int, optional
-                Bias in the created fixed-point tensor
+                Bias in the created floating-point tensor
 
             Returns
             -------
@@ -393,11 +393,11 @@ void bind_float_array(nb::module_& m)
             ndarray : ndarray
                 Values to initialize from. The tensor shape will be taken from the ndarray shape.
             exp_bits : int
-                Number of exponent bits in the created fixed-point tensor
+                Number of exponent bits in the created floating-point tensor
             man_bits : int
-                Number of mantissa bits in the created fixed-point tensor
+                Number of mantissa bits in the created floating-point tensor
             bias : int, optional
-                Bias in the created fixed-point tensor
+                Bias in the created floating-point tensor
 
             Returns
             -------


### PR DESCRIPTION
<!--
Thank you so much for your PR!
-->

# PR Summary
<!-- Please provide at least 1-2 sentences describing the pull request in detail
(Why is this change required?  What problem does it solve?) and link to relevant
issues and PRs.
-->
The comparison between APyFloat and APyFixed is sometimes incorrect when the floating-point value is infinity. This is because the sign is not taken into consideration. For example:
```Python
from apytypes import APyFloat, APyFixed
APyFloat.from_float(float("-inf"), 4, 3) < APyFixed.from_float(1000, 16, 16)
# False
APyFloat.from_float(float("-inf"), 4, 3) > APyFixed.from_float(1000, 16, 16)
# True
```

# PR Checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

- [N/A] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] new and changed code is tested
- [x] relevant changes added to [CHANGELOG.md](https://github.com/apytypes/apytypes/blob/main/CHANGELOG.md)
- [N/A] new functionality is documented
