### PR TITLE
Array creation pr

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `min()`
   - `nanmax()`
   - `nanmin()`
+- Array creation functions added:
+  - `eye()`
+  - `identity()`
+  - `ones()`
+  - `ones_like()`
+  - `zeros()`
+  - `zeros_like()`
+  - `full()`
+  - `full_like()`
 - Added `array_utils.h` to contain shared functions between float and fixed arrays.
 - Added support for higher dimensions (ndim > 2) in `transpose()`.
 

--- a/docs/api/apyfixedarray.rst
+++ b/docs/api/apyfixedarray.rst
@@ -15,6 +15,19 @@
 
    .. automethod:: from_float
 
+   Other creation functions
+   ------------------------
+
+   .. automethod:: zeros
+
+   .. automethod:: ones
+
+   .. automethod:: eye
+
+   .. automethod:: identity
+
+   .. automethod:: full
+
    Change word length
    ------------------
 

--- a/docs/api/apyfloatarray.rst
+++ b/docs/api/apyfloatarray.rst
@@ -15,6 +15,19 @@
 
    .. automethod:: from_float
 
+   Other creation functions
+   ------------------------
+
+   .. automethod:: zeros
+
+   .. automethod:: ones
+
+   .. automethod:: eye
+
+   .. automethod:: identity
+
+   .. automethod:: full
+
    Change word length
    ------------------
 

--- a/docs/api/arrayfunctions.rst
+++ b/docs/api/arrayfunctions.rst
@@ -14,3 +14,19 @@ Array functions
 .. autofunction:: apytypes.swapaxes
 
 .. autofunction:: apytypes.expand_dims
+
+.. automethod:: apytypes.zeros
+
+.. automethod:: apytypes.ones
+
+.. automethod:: apytypes.eye
+
+.. automethod:: apytypes.identity
+
+.. automethod:: apytypes.full
+
+.. automethod:: apytypes.zeros_like
+
+.. automethod:: apytypes.ones_like
+
+.. automethod:: apytypes.full_like

--- a/docs/api/arrayfunctions.rst
+++ b/docs/api/arrayfunctions.rst
@@ -15,18 +15,18 @@ Array functions
 
 .. autofunction:: apytypes.expand_dims
 
-.. automethod:: apytypes.zeros
+.. autofunction:: apytypes.zeros
 
-.. automethod:: apytypes.ones
+.. autofunction:: apytypes.ones
 
-.. automethod:: apytypes.eye
+.. autofunction:: apytypes.eye
 
-.. automethod:: apytypes.identity
+.. autofunction:: apytypes.identity
 
-.. automethod:: apytypes.full
+.. autofunction:: apytypes.full
 
-.. automethod:: apytypes.zeros_like
+.. autofunction:: apytypes.zeros_like
 
-.. automethod:: apytypes.ones_like
+.. autofunction:: apytypes.ones_like
 
-.. automethod:: apytypes.full_like
+.. autofunction:: apytypes.full_like

--- a/lib/apytypes/__init__.py
+++ b/lib/apytypes/__init__.py
@@ -36,6 +36,7 @@ from apytypes._array_functions import (
     identity,
     full,
     full_like,
+    arange,
 )
 
 from apytypes._version import version as __version__
@@ -74,6 +75,7 @@ __all__ = [
     "identity",
     "full",
     "full_like",
+    "arange",
 ]
 
 APyFloat.__doc__ = r"""

--- a/lib/apytypes/__init__.py
+++ b/lib/apytypes/__init__.py
@@ -28,6 +28,13 @@ from apytypes._array_functions import (
     moveaxis,
     swapaxes,
     expand_dims,
+    zeros,
+    zeros_like,
+    ones,
+    ones_like,
+    eye,
+    identity,
+    full,
 )
 
 from apytypes._version import version as __version__
@@ -58,6 +65,13 @@ __all__ = [
     "moveaxis",
     "swapaxes",
     "expand_dims",
+    "zeros",
+    "zeros_like",
+    "ones",
+    "ones_like",
+    "eye",
+    "identity",
+    "full",
 ]
 
 APyFloat.__doc__ = r"""

--- a/lib/apytypes/__init__.py
+++ b/lib/apytypes/__init__.py
@@ -35,6 +35,7 @@ from apytypes._array_functions import (
     eye,
     identity,
     full,
+    full_like,
 )
 
 from apytypes._version import version as __version__
@@ -72,6 +73,7 @@ __all__ = [
     "eye",
     "identity",
     "full",
+    "full_like",
 ]
 
 APyFloat.__doc__ = r"""

--- a/lib/apytypes/__init__.pyi
+++ b/lib/apytypes/__init__.pyi
@@ -23,6 +23,7 @@ from ._apytypes import (
     set_float_quantization_seed as set_float_quantization_seed,
 )
 from ._array_functions import (
+    arange as arange,
     convolve as convolve,
     expand_dims as expand_dims,
     eye as eye,
@@ -76,6 +77,7 @@ __all__: list = [
     "identity",
     "full",
     "full_like",
+    "arange",
 ]
 
 annotations: __future__._Feature = ...

--- a/lib/apytypes/__init__.pyi
+++ b/lib/apytypes/__init__.pyi
@@ -27,6 +27,7 @@ from ._array_functions import (
     expand_dims as expand_dims,
     eye as eye,
     full as full,
+    full_like as full_like,
     identity as identity,
     moveaxis as moveaxis,
     ones as ones,
@@ -74,6 +75,7 @@ __all__: list = [
     "eye",
     "identity",
     "full",
+    "full_like",
 ]
 
 annotations: __future__._Feature = ...

--- a/lib/apytypes/__init__.pyi
+++ b/lib/apytypes/__init__.pyi
@@ -25,13 +25,20 @@ from ._apytypes import (
 from ._array_functions import (
     convolve as convolve,
     expand_dims as expand_dims,
+    eye as eye,
+    full as full,
+    identity as identity,
     moveaxis as moveaxis,
+    ones as ones,
+    ones_like as ones_like,
     ravel as ravel,
     reshape as reshape,
     shape as shape,
     squeeze as squeeze,
     swapaxes as swapaxes,
     transpose as transpose,
+    zeros as zeros,
+    zeros_like as zeros_like,
 )
 
 __all__: list = [
@@ -60,6 +67,13 @@ __all__: list = [
     "moveaxis",
     "swapaxes",
     "expand_dims",
+    "zeros",
+    "zeros_like",
+    "ones",
+    "ones_like",
+    "eye",
+    "identity",
+    "full",
 ]
 
 annotations: __future__._Feature = ...

--- a/lib/apytypes/_apytypes.pyi
+++ b/lib/apytypes/_apytypes.pyi
@@ -639,27 +639,7 @@ class APyFixedArray:
         :class:`APyFixedArray`
         """
 
-    def flatten(self) -> APyFixedArray:
-        """
-        Return a copy of the array collapsed into one dimension.
-
-
-        Examples
-        --------
-        >>> from apytypes import APyFixedArray
-        >>> arr = APyFixedArray([[2, 3], [4, 5]], int_bits=2, frac_bits=1)
-        >>> arr.to_numpy()
-        array([[ 1. ,  1.5],
-               [-2. , -1.5]])
-
-        >>> arr.flatten().to_numpy()
-        array([ 1. ,  1.5, -2. , -1.5])
-
-        Returns
-        -------
-        :class:`APyFixedArray`
-        """
-
+    @overload
     def ravel(self) -> APyFixedArray:
         """
         Return a copy of the array collapsed into one dimension. Same as flatten with
@@ -675,6 +655,50 @@ class APyFixedArray:
                [-2. , -1.5]])
 
         >>> arr.ravel().to_numpy()
+        array([ 1. ,  1.5, -2. , -1.5])
+
+        Returns
+        -------
+        :class:`APyFixedArray`
+        """
+
+    @overload
+    def ravel(self) -> APyFixedArray:
+        """
+        Return a copy of the array collapsed into one dimension. Same as flatten with
+        current memory-copy model.
+
+
+        Examples
+        --------
+        >>> from apytypes import APyFixedArray
+        >>> arr = APyFixedArray([[2, 3], [4, 5]], int_bits=2, frac_bits=1)
+        >>> arr.to_numpy()
+        array([[ 1. ,  1.5],
+               [-2. , -1.5]])
+
+        >>> arr.ravel().to_numpy()
+        array([ 1. ,  1.5, -2. , -1.5])
+
+        Returns
+        -------
+        :class:`APyFixedArray`
+        """
+
+    def flatten(self) -> APyFixedArray:
+        """
+        Return a copy of the array collapsed into one dimension.
+
+
+        Examples
+        --------
+        >>> from apytypes import APyFixedArray
+        >>> arr = APyFixedArray([[2, 3], [4, 5]], int_bits=2, frac_bits=1)
+        >>> arr.to_numpy()
+        array([[ 1. ,  1.5],
+               [-2. , -1.5]])
+
+        >>> arr.flatten().to_numpy()
         array([ 1. ,  1.5, -2. , -1.5])
 
         Returns
@@ -1328,6 +1352,101 @@ class APyFixedArray:
         Returns
         -------
         :class:`APyFixedArray`
+        """
+
+    @staticmethod
+    def zeros(
+        shape: tuple,
+        int_bits: int | None = None,
+        frac_bits: int | None = None,
+        bits: int | None = None,
+    ) -> APyFixedArray:
+        """
+        Initializes an array with zeros.
+
+        Parameters:
+            shape (tuple): Shape of the array.
+            int_bits (optional): Number of integer bits.
+            frac_bits (optional): Number of fractional bits.
+            bits (optional): Total number of bits.
+
+        Returns:
+            APyFixedArray: An array initialized with zeros.
+        """
+
+    @staticmethod
+    def ones(
+        shape: tuple,
+        int_bits: int | None = None,
+        frac_bits: int | None = None,
+        bits: int | None = None,
+    ) -> APyFixedArray:
+        """
+        Initializes an array with ones.
+
+        Parameters:
+            shape (tuple): Shape of the array.
+            int_bits (optional): Number of integer bits.
+            frac_bits (optional): Number of fractional bits.
+            bits (optional): Total number of bits.
+
+        Returns:
+            APyFixedArray: An array initialized with ones.
+        """
+
+    @staticmethod
+    def eye(
+        n: int,
+        m: int | None = None,
+        int_bits: int | None = None,
+        frac_bits: int | None = None,
+        bits: int | None = None,
+    ) -> APyFixedArray:
+        """
+        Initializes an array with the specified value on the diagonal.
+
+        Parameters:
+            n : number of rows.
+            m (optional) : number of columns.
+            int_bits (optional): Number of integer bits.
+            frac_bits (optional): Number of fractional bits.
+            bits (optional): Total number of bits.
+
+        Returns:
+            APyFixedArray: An array with the specified value on the diagonal.
+        """
+
+    @staticmethod
+    def identity(
+        n: int,
+        int_bits: int | None = None,
+        frac_bits: int | None = None,
+        bits: int | None = None,
+    ) -> APyFixedArray:
+        """
+        Initializes an identity matrix with decimal one on the diagonal.
+
+        Parameters:
+            n : Number of rows (and columns) in n x n output.
+            int_bits (optional): Number of integer bits.
+            frac_bits (optional): Number of fractional bits.
+            bits (optional): Total number of bits.
+
+        Returns:
+            APyFixedArray: An identity matrix with decimal one on the diagonal.
+        """
+
+    @staticmethod
+    def full(shape: tuple, fill_value: APyFixed) -> APyFixedArray:
+        """
+        Initializes an array with the specified value.
+
+        Parameters:
+            shape (tuple): Shape of the array.
+            fill_value (APyFixed): Value to fill the array.
+
+        Returns:
+            APyFixedArray: An array filled with the specified value.
         """
 
     def __lshift__(self, shift_amnt: int) -> APyFixedArray: ...

--- a/lib/apytypes/_apytypes.pyi
+++ b/lib/apytypes/_apytypes.pyi
@@ -2485,6 +2485,83 @@ class APyFloatArray:
         :class:`APyFloatArray`
         """
 
+    @staticmethod
+    def zeros(
+        shape: tuple, exp_bits: int, man_bits: int, bias: int | None = None
+    ) -> APyFloatArray:
+        """
+        Initializes an array with the specified value.
+
+        Parameters:
+            shape (tuple): Shape of the array.
+            fill_value (APyFloat): Value to fill the array.
+
+        Returns:
+            APyFixedArray: An array filled with the specified value.
+        """
+
+    @staticmethod
+    def ones(
+        shape: tuple, exp_bits: int, man_bits: int, bias: int | None = None
+    ) -> APyFloatArray:
+        """
+        Initializes an array with the specified value.
+
+        Parameters:
+            shape (tuple): Shape of the array.
+            fill_value (APyFloat): Value to fill the array.
+
+        Returns:
+            APyFixedArray: An array filled with the specified value.
+        """
+
+    @staticmethod
+    def eye(
+        n: int,
+        exp_bits: int,
+        man_bits: int,
+        m: int | None = None,
+        bias: int | None = None,
+    ) -> APyFloatArray:
+        """
+        Initializes an array with the specified value.
+
+        Parameters:
+            shape (tuple): Shape of the array.
+            fill_value (APyFloat): Value to fill the array.
+
+        Returns:
+            APyFixedArray: An array filled with the specified value.
+        """
+
+    @staticmethod
+    def identity(
+        n: int, exp_bits: int, man_bits: int, bias: int | None = None
+    ) -> APyFloatArray:
+        """
+        Initializes an array with the specified value.
+
+        Parameters:
+            shape (tuple): Shape of the array.
+            fill_value (APyFloat): Value to fill the array.
+
+        Returns:
+            APyFixedArray: An array filled with the specified value.
+        """
+
+    @staticmethod
+    def full(shape: tuple, fill_value: APyFloat) -> APyFloatArray:
+        """
+        Initializes an array with the specified value.
+
+        Parameters:
+            shape (tuple): Shape of the array.
+            fill_value (APyFloat): Value to fill the array.
+
+        Returns:
+            APyFixedArray: An array filled with the specified value.
+        """
+
     def __matmul__(self, rhs: APyFloatArray) -> APyFloatArray | APyFloat: ...
     def __repr__(self) -> str: ...
     def __len__(self) -> int: ...

--- a/lib/apytypes/_apytypes.pyi
+++ b/lib/apytypes/_apytypes.pyi
@@ -1340,14 +1340,21 @@ class APyFixedArray:
         """
         Initializes an array with zeros.
 
-        Parameters:
-            shape (tuple): Shape of the array.
-            int_bits (optional): Number of integer bits.
-            frac_bits (optional): Number of fractional bits.
-            bits (optional): Total number of bits.
+        Parameters
+        ----------
+        shape : tuple
+            Shape of the array.
+        int_bits : int, optional
+            Number of integer bits. Default is None.
+        frac_bits : int, optional
+            Number of fractional bits. Default is None.
+        bits : int, optional
+            Total number of bits. Default is None.
 
-        Returns:
-            APyFixedArray: An array initialized with zeros.
+        Returns
+        -------
+        APyFixedArray
+            An array initialized with zeros.
         """
 
     @staticmethod
@@ -1360,14 +1367,21 @@ class APyFixedArray:
         """
         Initializes an array with ones.
 
-        Parameters:
-            shape (tuple): Shape of the array.
-            int_bits (optional): Number of integer bits.
-            frac_bits (optional): Number of fractional bits.
-            bits (optional): Total number of bits.
+        Parameters
+        ----------
+        shape : tuple
+            Shape of the array.
+        int_bits : int, optional
+            Number of integer bits. Default is None.
+        frac_bits : int, optional
+            Number of fractional bits. Default is None.
+        bits : int, optional
+            Total number of bits. Default is None.
 
-        Returns:
-            APyFixedArray: An array initialized with ones.
+        Returns
+        -------
+        APyFixedArray
+            An array initialized with ones.
         """
 
     @staticmethod
@@ -1379,17 +1393,25 @@ class APyFixedArray:
         bits: int | None = None,
     ) -> APyFixedArray:
         """
-        Initializes an array with the specified value on the diagonal.
+        Initializes an array with ones on the diagonal.
 
-        Parameters:
-            n : number of rows.
-            m (optional) : number of columns.
-            int_bits (optional): Number of integer bits.
-            frac_bits (optional): Number of fractional bits.
-            bits (optional): Total number of bits.
+        Parameters
+        ----------
+        n : int
+            Number of rows.
+        m : int, optional
+            Number of columns. Default is None.
+        int_bits : int, optional
+            Number of integer bits. Default is None.
+        frac_bits : int, optional
+            Number of fractional bits. Default is None.
+        bits : int, optional
+            Total number of bits. Default is None.
 
-        Returns:
-            APyFixedArray: An array with the specified value on the diagonal.
+        Returns
+        -------
+        APyFixedArray
+            An array with the specified value on the diagonal.
         """
 
     @staticmethod
@@ -1400,16 +1422,23 @@ class APyFixedArray:
         bits: int | None = None,
     ) -> APyFixedArray:
         """
-        Initializes an identity matrix with decimal one on the diagonal.
+        Initializes an identity matrix with ones on the diagonal.
 
-        Parameters:
-            n : Number of rows (and columns) in n x n output.
-            int_bits (optional): Number of integer bits.
-            frac_bits (optional): Number of fractional bits.
-            bits (optional): Total number of bits.
+        Parameters
+        ----------
+        n : int
+            Number of rows (and columns) in n x n output.
+        int_bits : int, optional
+            Number of integer bits. Default is None.
+        frac_bits : int, optional
+            Number of fractional bits. Default is None.
+        bits : int, optional
+            Total number of bits. Default is None.
 
-        Returns:
-            APyFixedArray: An identity matrix with decimal one on the diagonal.
+        Returns
+        -------
+        APyFixedArray
+            An identity matrix with ones on the diagonal.
         """
 
     @staticmethod
@@ -1417,12 +1446,17 @@ class APyFixedArray:
         """
         Initializes an array with the specified value.
 
-        Parameters:
-            shape (tuple): Shape of the array.
-            fill_value (APyFixed): Value to fill the array.
+        Parameters
+        ----------
+        shape : tuple
+            Shape of the array.
+        fill_value : APyFixed
+            Value to fill the array.
 
-        Returns:
-            APyFixedArray: An array filled with the specified value.
+        Returns
+        -------
+        APyFixedArray
+            An array filled with the specified value.
         """
 
     def __lshift__(self, shift_amnt: int) -> APyFixedArray: ...
@@ -2490,14 +2524,23 @@ class APyFloatArray:
         shape: tuple, exp_bits: int, man_bits: int, bias: int | None = None
     ) -> APyFloatArray:
         """
-        Initializes an array with the specified value.
+        Initializes an array with zeros.
 
-        Parameters:
-            shape (tuple): Shape of the array.
-            fill_value (APyFloat): Value to fill the array.
+        Parameters
+        ----------
+        shape : tuple
+            Shape of the array.
+        exp_bits : int
+            Number of exponent bits.
+        man_bits : int
+            Number of mantissa bits.
+        bias : optional
+            Set bias. Default is None.
 
-        Returns:
-            APyFixedArray: An array filled with the specified value.
+        Returns
+        -------
+        APyFloatArray
+            An array filled with zeros.
         """
 
     @staticmethod
@@ -2505,14 +2548,23 @@ class APyFloatArray:
         shape: tuple, exp_bits: int, man_bits: int, bias: int | None = None
     ) -> APyFloatArray:
         """
-        Initializes an array with the specified value.
+        Initializes an array with ones.
 
-        Parameters:
-            shape (tuple): Shape of the array.
-            fill_value (APyFloat): Value to fill the array.
+        Parameters
+        ----------
+        shape : tuple
+            Shape of the array.
+        exp_bits : int
+            Number of exponent bits.
+        man_bits : int
+            Number of mantissa bits.
+        bias : optional
+            Set bias. Default is None.
 
-        Returns:
-            APyFixedArray: An array filled with the specified value.
+        Returns
+        -------
+        APyFloatArray
+            An array filled with ones.
         """
 
     @staticmethod
@@ -2524,14 +2576,25 @@ class APyFloatArray:
         bias: int | None = None,
     ) -> APyFloatArray:
         """
-        Initializes an array with the specified value.
+        Initializes an array with ones on the diagonal.
 
-        Parameters:
-            shape (tuple): Shape of the array.
-            fill_value (APyFloat): Value to fill the array.
+        Parameters
+        ----------
+        n : int
+            Number of rows (and columns) in the n x n output.
+        exp_bits : int
+            Number of exponent bits.
+        man_bits : int
+            Number of mantissa bits.
+        m : int, optional
+            Number of columns. Default is None, which results in an n x n output.
+        bias : optional
+            Set bias. Default is None.
 
-        Returns:
-            APyFixedArray: An array filled with the specified value.
+        Returns
+        -------
+        APyFloatArray
+            An array with the specified value on the diagonal.
         """
 
     @staticmethod
@@ -2539,27 +2602,41 @@ class APyFloatArray:
         n: int, exp_bits: int, man_bits: int, bias: int | None = None
     ) -> APyFloatArray:
         """
-        Initializes an array with the specified value.
+        Initializes an identity matrix with ones on the diagonal.
 
-        Parameters:
-            shape (tuple): Shape of the array.
-            fill_value (APyFloat): Value to fill the array.
+        Parameters
+        ----------
+        n : int
+            Number of rows (and columns) in the n x n output.
+        exp_bits : int
+            Number of exponent bits.
+        man_bits : int
+            Number of mantissa bits.
+        bias : optional
+            Set bias. Default is None.
 
-        Returns:
-            APyFixedArray: An array filled with the specified value.
+        Returns
+        -------
+        APyFloatArray
+            An identity matrix with ones on the diagonal.
         """
 
     @staticmethod
     def full(shape: tuple, fill_value: APyFloat) -> APyFloatArray:
         """
-        Initializes an array with the specified value.
+        Initializes an array filled with the specified value.
 
-        Parameters:
-            shape (tuple): Shape of the array.
-            fill_value (APyFloat): Value to fill the array.
+        Parameters
+        ----------
+        shape : tuple
+            Shape of the array.
+        fill_value : APyFloat
+            Value to fill the array.
 
-        Returns:
-            APyFixedArray: An array filled with the specified value.
+        Returns
+        -------
+        APyFloatArray
+            An array filled with the specified value.
         """
 
     def __matmul__(self, rhs: APyFloatArray) -> APyFloatArray | APyFloat: ...

--- a/lib/apytypes/_apytypes.pyi
+++ b/lib/apytypes/_apytypes.pyi
@@ -639,52 +639,6 @@ class APyFixedArray:
         :class:`APyFixedArray`
         """
 
-    @overload
-    def ravel(self) -> APyFixedArray:
-        """
-        Return a copy of the array collapsed into one dimension. Same as flatten with
-        current memory-copy model.
-
-
-        Examples
-        --------
-        >>> from apytypes import APyFixedArray
-        >>> arr = APyFixedArray([[2, 3], [4, 5]], int_bits=2, frac_bits=1)
-        >>> arr.to_numpy()
-        array([[ 1. ,  1.5],
-               [-2. , -1.5]])
-
-        >>> arr.ravel().to_numpy()
-        array([ 1. ,  1.5, -2. , -1.5])
-
-        Returns
-        -------
-        :class:`APyFixedArray`
-        """
-
-    @overload
-    def ravel(self) -> APyFixedArray:
-        """
-        Return a copy of the array collapsed into one dimension. Same as flatten with
-        current memory-copy model.
-
-
-        Examples
-        --------
-        >>> from apytypes import APyFixedArray
-        >>> arr = APyFixedArray([[2, 3], [4, 5]], int_bits=2, frac_bits=1)
-        >>> arr.to_numpy()
-        array([[ 1. ,  1.5],
-               [-2. , -1.5]])
-
-        >>> arr.ravel().to_numpy()
-        array([ 1. ,  1.5, -2. , -1.5])
-
-        Returns
-        -------
-        :class:`APyFixedArray`
-        """
-
     def flatten(self) -> APyFixedArray:
         """
         Return a copy of the array collapsed into one dimension.
@@ -699,6 +653,28 @@ class APyFixedArray:
                [-2. , -1.5]])
 
         >>> arr.flatten().to_numpy()
+        array([ 1. ,  1.5, -2. , -1.5])
+
+        Returns
+        -------
+        :class:`APyFixedArray`
+        """
+
+    def ravel(self) -> APyFixedArray:
+        """
+        Return a copy of the array collapsed into one dimension. Same as flatten with
+        current memory-copy model.
+
+
+        Examples
+        --------
+        >>> from apytypes import APyFixedArray
+        >>> arr = APyFixedArray([[2, 3], [4, 5]], int_bits=2, frac_bits=1)
+        >>> arr.to_numpy()
+        array([[ 1. ,  1.5],
+               [-2. , -1.5]])
+
+        >>> arr.ravel().to_numpy()
         array([ 1. ,  1.5, -2. , -1.5])
 
         Returns

--- a/lib/apytypes/_array_functions.py
+++ b/lib/apytypes/_array_functions.py
@@ -1,4 +1,5 @@
 from typing import Tuple, Union
+from apytypes import APyFixedArray, APyFixed, APyFloat, APyFloatArray
 
 
 def squeeze(a, axis=None):
@@ -416,14 +417,14 @@ def expand_dims(a, axis):
 # =============================================================================
 
 
-def zeros(a_type, shape, int_bits=8, frac_bits=8, exp_bits=None, mantissa_bits=None):
+def zeros(shape, int_bits=None, frac_bits=None, exp_bits=None, mantissa_bits=None):
     """
     Initializes an array with zeros.
 
+    Word lengths need to be specified and decide the return type of the array.
+
     Parameters
     ----------
-    a_type : :class:`APyFloatArray` or :class:`APyFixedArray`
-        The type of array to initialize.
     shape : tuple
         Shape of the array.
     int_bits : int, optional
@@ -441,70 +442,28 @@ def zeros(a_type, shape, int_bits=8, frac_bits=8, exp_bits=None, mantissa_bits=N
         The initialized array with zeros.
     """
 
+    a_type = _get_return_type(int_bits, frac_bits, exp_bits, mantissa_bits)
     try:
         zeros = a_type.zeros
     except AttributeError:
         raise TypeError(f"Cannot make zeros array of type {type(a_type)}")
-    if hasattr(a_type, "int_bits") and hasattr(a_type, "frac_bits"):
+    if a_type is APyFixedArray:
         return zeros(shape=shape, int_bits=int_bits, frac_bits=frac_bits)
 
-    if hasattr(a_type, "exp_bits") and hasattr(a_type, "mantissa_bits"):
-        return None
+    if a_type is APyFloatArray:
+        return zeros(shape=shape, exp_bits=exp_bits, man_bits=mantissa_bits)
 
     raise ValueError("Only 'fixed' and 'float' array_types are defined")
 
 
-def zeros_like(
-    a, a_type=None, int_bits=None, frac_bits=None, exp_bits=None, mantissa_bits=None
-):
+def ones(shape, int_bits=None, frac_bits=None, exp_bits=None, mantissa_bits=None):
     """
-    Return an array of zeros with the same shape and type as a given array.
+    Initializes an array with ones.
+
+    Word lengths need to be specified and decide the return type of the array.
 
     Parameters
     ----------
-    a : :class:`APyFloatArray` or :class:`APyFixedArray`
-        The shape and data-type of a define these same attributes of the returned array.
-    a_type : :class:`APyFloatArray` or :class:`APyFixedArray`, optional
-        The type of array to initialize.
-    int_bits : int, optional
-        Number of integer bits.
-    frac_bits : int, optional
-        Number of fractional bits.
-    exp_bits : int, optional
-        Number of exponential bits.
-    mantissa_bits : int, optional
-        Number of mantissa bits.
-
-    Returns
-    -------
-    result : :class:`APyFloatArray` or :class:`APyFixedArray`
-        The initialized array with zeros.
-    """
-    a_type = a_type or a
-    try:
-        zeros = a_type.zeros
-    except AttributeError:
-        raise TypeError(f"Cannot make zeros array of type {type(a_type)}")
-
-    if hasattr(a_type, "int_bits") and hasattr(a_type, "frac_bits"):
-        int_bits = int_bits or a.int_bits
-        frac_bits = frac_bits or a.frac_bits
-        return zeros(shape=a.shape, int_bits=int_bits, frac_bits=frac_bits)
-
-    if hasattr(a_type, "exp_bits") and hasattr(a_type, "mantissa_bits"):
-        return None
-
-    raise ValueError("Only 'fixed' and 'float' array_types are defined")
-
-
-def ones(a_type, shape, int_bits=8, frac_bits=8, exp_bits=None, mantissa_bits=None):
-    """
-    Return an array of ones with the same shape and type as a given array.
-
-    Parameters
-    ----------
-    a_type : :class:`APyFloatArray` or :class:`APyFixedArray`, optional
-        The type of array to initialize.
     shape : tuple
         Shape of the array.
     int_bits : int, optional
@@ -521,64 +480,27 @@ def ones(a_type, shape, int_bits=8, frac_bits=8, exp_bits=None, mantissa_bits=No
     result : :class:`APyFloatArray` or :class:`APyFixedArray`
         The array initialized filled with ones.
     """
+    a_type = _get_return_type(int_bits, frac_bits, exp_bits, mantissa_bits)
     try:
         ones = a_type.ones
     except AttributeError:
         raise TypeError(f"Cannot make ones array of type {type(a_type)}")
-    if hasattr(a_type, "int_bits") and hasattr(a_type, "frac_bits"):
+    if a_type is APyFixedArray or isinstance(a_type, APyFixedArray):
         return ones(shape=shape, int_bits=int_bits, frac_bits=frac_bits)
 
-    if hasattr(a_type, "exp_bits") and hasattr(a_type, "mantissa_bits"):
-        return None
+    if a_type is APyFloatArray or isinstance(a_type, APyFloatArray):
+        return ones(shape=shape, exp_bits=exp_bits, man_bits=mantissa_bits)
 
     raise ValueError("Only 'fixed' and 'float' array_types are defined")
 
 
-def ones_like(
-    a, a_type=None, int_bits=None, frac_bits=None, exp_bits=None, mantissa_bits=None
+def eye(
+    n: int, m=None, int_bits=None, frac_bits=None, exp_bits=None, mantissa_bits=None
 ):
     """
-    Return an array of zeros with the same shape and type as a given array.
-
-    Parameters
-    ----------
-    a_type : :class:`APyFloatArray` or :class:`APyFixedArray`, optional
-        The type of array to initialize.
-    shape : tuple
-        Shape of the array.
-    int_bits : int, optional
-        Number of integer bits.
-    frac_bits : int, optional
-        Number of fractional bits.
-    exp_bits : int, optional
-        Number of exponential bits.
-    mantissa_bits : int, optional
-        Number of mantissa bits.
-
-    Returns
-    -------
-    result : :class:`APyFloatArray` or :class:`APyFixedArray`
-        The array initialized filled with ones.
-    """
-    a_type = a_type or a
-    try:
-        ones = a_type.ones
-    except AttributeError:
-        raise TypeError(f"Cannot make ones array of type {type(a_type)}")
-    if hasattr(a_type, "int_bits") and hasattr(a_type, "frac_bits"):
-        int_bits = int_bits or a.int_bits
-        frac_bits = frac_bits or a.frac_bits
-        return ones(shape=a.shape, int_bits=int_bits, frac_bits=frac_bits)
-
-    if hasattr(a_type, "exp_bits") and hasattr(a_type, "mantissa_bits"):
-        return None
-
-    raise ValueError("Only 'fixed' and 'float' array_types are defined")
-
-
-def eye(a_type, n, m=None, int_bits=8, frac_bits=8, exp_bits=None, mantissa_bits=None):
-    """
     Return a 2-D array with ones on the diagonal and zeros elsewhere.
+
+    Word lengths need to be specified and decide the return type of the array.
 
     Parameters
     ----------
@@ -602,24 +524,25 @@ def eye(a_type, n, m=None, int_bits=8, frac_bits=8, exp_bits=None, mantissa_bits
     result : :class:`APyFloatArray` or :class:`APyFixedArray`
         An array where all elements are equal to zero, except for the k-th diagonal, whose values are equal to one.
     """
+    a_type = _get_return_type(int_bits, frac_bits, exp_bits, mantissa_bits)
     try:
         eye = a_type.eye
     except AttributeError:
         raise TypeError(f"Cannot make eye array of type {type(a_type)}")
-    if hasattr(a_type, "int_bits") and hasattr(a_type, "frac_bits"):
+    if a_type is APyFixedArray or isinstance(a_type, APyFixedArray):
         return eye(n=n, m=m, int_bits=int_bits, frac_bits=frac_bits)
 
-    if hasattr(a_type, "exp_bits") and hasattr(a_type, "mantissa_bits"):
-        return None
+    if a_type is APyFloatArray or isinstance(a_type, APyFloatArray):
+        return eye(n=n, m=m, exp_bits=exp_bits, man_bits=mantissa_bits)
 
     raise ValueError("Only 'fixed' and 'float' array_types are defined")
 
 
-def identity(a_type, n, int_bits=8, frac_bits=8, exp_bits=None, mantissa_bits=None):
+def identity(n, int_bits=None, frac_bits=None, exp_bits=None, mantissa_bits=None):
     """
     Return the identity array.
 
-    The identity array is a square array with ones on the main diagonal.
+    Word lengths need to be specified and decides return type of Array.
 
     Parameters
     ----------
@@ -641,22 +564,22 @@ def identity(a_type, n, int_bits=8, frac_bits=8, exp_bits=None, mantissa_bits=No
     result : :class:`APyFloatArray` or :class:`APyFixedArray`
         n x n array with its main diagonal set to one, and all other elements 0.
     """
+    a_type = _get_return_type(int_bits, frac_bits, exp_bits, mantissa_bits)
     try:
         identity = a_type.identity
     except AttributeError:
         raise TypeError(f"Cannot make identity array of type {type(a_type)}")
 
-    if hasattr(a_type, "int_bits") and hasattr(a_type, "frac_bits"):
+    if a_type is APyFixedArray or isinstance(a_type, APyFixedArray):
         return identity(n=n, int_bits=int_bits, frac_bits=frac_bits)
 
-    if hasattr(a_type, "exp_bits") and hasattr(a_type, "mantissa_bits"):
-        return None
+    if a_type is APyFloatArray or isinstance(a_type, APyFloatArray):
+        return identity(n=n, exp_bits=exp_bits, man_bits=mantissa_bits)
 
     raise ValueError("Only 'fixed' and 'float' array_types are defined")
 
 
 def full(
-    a_type,
     shape,
     fill_value,
     int_bits=None,
@@ -667,10 +590,12 @@ def full(
     """
     Return a new array of given shape and type, filled with fill_value.
 
+    If fill_value is an int or float, you must specify the word lengths (int_bits, frac_bits or exp_bits, mantissa_bits).
+    If fill_value is an APyFloat or APyFixed, the array will use the provided word lengths if specified.
+    If no word lengths are specified, the resulting array will inherit the word lengths from fill_value.
+
     Parameters
     ----------
-    a_type : :class:`APyFloatArray` or :class:`APyFixedArray`, optional
-        The type of array to initialize.
     shape : tuple
         Shape of the array.
     fill_value : :class:`APyFloat` or :class:`APyFixedArray` or int or float
@@ -687,47 +612,32 @@ def full(
     Returns
     -------
     result : :class:`APyFloatArray` or :class:`APyFixedArray`
-        Array of fill_value with the given shape and a_type.
+        Array of fill_value with the given shape.
     """
+    fill_value = _normalize_fill_value(
+        fill_value, int_bits, frac_bits, exp_bits, mantissa_bits
+    )
     try:
-        full = a_type.full
+        if isinstance(fill_value, APyFixed):
+            full = APyFixedArray.full
+        elif isinstance(fill_value, APyFloat):
+            full = APyFloatArray.full
+        else:
+            raise (AttributeError)
     except AttributeError:
-        raise TypeError(f"Cannot make full array of type {type(a_type)}")
-
-    if hasattr(a_type, "int_bits") and hasattr(a_type, "frac_bits"):
-        if isinstance(fill_value, (int, float)):
-            from apytypes import APyFixed
-
-            fill_value = APyFixed.from_float(
-                fill_value, int_bits=int_bits, frac_bits=frac_bits
-            )
-
-        return full(shape, fill_value)
-
-    if hasattr(a_type, "exp_bits") and hasattr(a_type, "mantissa_bits"):
-        return None
-
-    raise ValueError("Only 'fixed' and 'float' array_types are defined")
+        raise TypeError(f"Cannot make full array of type {type(fill_value)}")
+    return full(shape, fill_value)
 
 
-def full_like(
-    a,
-    fill_value,
-    a_type=None,
-    int_bits=None,
-    frac_bits=None,
-    exp_bits=None,
-    mantissa_bits=None,
-):
+def zeros_like(a, int_bits=None, frac_bits=None, exp_bits=None, mantissa_bits=None):
     """
-    Return a full array with the same shape and type as a given array.
+    Return an array of zeros with the same shape and type as a given array.
+    Defaults to `a` wordlength
 
     Parameters
     ----------
-    a : :class:`APyFloatArray` or :class:`APyFixedArray`, optional
-        The shape and array type of the returned array.
-    fill_value : :class:`APyFloat` or :class:`APyFixedArray` or int or float
-        Fill value.
+    a : :class:`APyFloatArray` or :class:`APyFixedArray`
+        The shape and data-type define these same attributes of the returned array.
     int_bits : int, optional
         Number of integer bits.
     frac_bits : int, optional
@@ -740,35 +650,159 @@ def full_like(
     Returns
     -------
     result : :class:`APyFloatArray` or :class:`APyFixedArray`
-        Array of fill_value with the same shape and type as a.
+        The initialized array with zeros.
     """
-    a_type = a if a_type is None else a_type
     try:
-        full = a_type.full
+        zeros = a.zeros
     except AttributeError:
-        raise TypeError(f"Cannot make full array of type {type(a_type)}")
+        raise TypeError(f"Cannot make zeros array of type {type(a)}")
 
-    if hasattr(a_type, "int_bits") and hasattr(a_type, "frac_bits"):
+    if isinstance(a, APyFixedArray):
         int_bits = int_bits or a.int_bits
         frac_bits = frac_bits or a.frac_bits
-        if isinstance(fill_value, (int, float)):
-            from apytypes import APyFixed
+        return zeros(shape=a.shape, int_bits=int_bits, frac_bits=frac_bits)
 
-            fill_value = APyFixed.from_float(
-                fill_value, int_bits=int_bits, frac_bits=frac_bits
-            )
-
-        return full(a.shape, fill_value)
-
-    if hasattr(a_type, "exp_bits") and hasattr(a_type, "mantissa_bits"):
-        return None
+    if isinstance(a, APyFloatArray):
+        exp_bits = exp_bits or a.exp_bits
+        mantissa_bits = mantissa_bits or a.man_bits
+        return zeros(shape=a.shape, exp_bits=exp_bits, man_bits=mantissa_bits)
 
     raise ValueError("Only 'fixed' and 'float' array_types are defined")
+
+
+def ones_like(a, int_bits=None, frac_bits=None, exp_bits=None, mantissa_bits=None):
+    """
+    Return an array of ones with the same shape and type as a given array.
+    Defaults to `a` wordlength
+
+    Parameters
+    ----------
+    a : :class:`APyFloatArray` or :class:`APyFixedArray`
+        The shape and data-type of a define these same attributes of the returned array.
+    int_bits : int, optional
+        Number of integer bits.
+    frac_bits : int, optional
+        Number of fractional bits.
+    exp_bits : int, optional
+        Number of exponential bits.
+    mantissa_bits : int, optional
+        Number of mantissa bits.
+
+    Returns
+    -------
+    result : :class:`APyFloatArray` or :class:`APyFixedArray`
+        The array initialized filled with ones.
+    """
+    try:
+        ones = a.ones
+    except AttributeError:
+        raise TypeError(f"Cannot make ones array of type {type(a)}")
+
+    if isinstance(a, APyFixedArray):
+        int_bits = int_bits or a.int_bits
+        frac_bits = frac_bits or a.frac_bits
+        return ones(shape=a.shape, int_bits=int_bits, frac_bits=frac_bits)
+
+    if isinstance(a, APyFloatArray):
+        exp_bits = exp_bits or a.exp_bits
+        mantissa_bits = mantissa_bits or a.man_bits
+        return ones(shape=a.shape, exp_bits=exp_bits, man_bits=mantissa_bits)
+
+    raise ValueError("Only 'fixed' and 'float' array_types are defined")
+
+
+def full_like(
+    a,
+    fill_value,
+    int_bits=None,
+    frac_bits=None,
+    exp_bits=None,
+    mantissa_bits=None,
+):
+    """
+    Return a full array with the same shape and type as a given array.
+
+    If fill_value is an int or float, you must specify the word lengths (int_bits, frac_bits or exp_bits, mantissa_bits).
+    If fill_value is an APyFloat or APyFixed, the array will use the provided word lengths if specified.
+    If no word lengths are specified, the resulting array will inherit the word lengths from fill_value.
+
+    Parameters
+    ----------
+    a : :class:`APyFloatArray` or :class:`APyFixedArray`
+        The shape and array type of the returned array.
+    fill_value : :class:`APyFloat` or :class:`APyFixed` or int or float
+        The value to fill the array with.
+    int_bits : int, optional
+        Number of integer bits for APyFixed.
+    frac_bits : int, optional
+        Number of fractional bits for APyFixed.
+    exp_bits : int, optional
+        Number of exponent bits for APyFloat.
+    mantissa_bits : int, optional
+        Number of mantissa bits for APyFloat.
+
+    Returns
+    -------
+    result : :class:`APyFloatArray` or :class:`APyFixedArray`
+        Array filled with fill_value, having the same shape and type as `a`.
+    """
+    try:
+        full = a.full
+    except AttributeError:
+        raise TypeError(f"Cannot make full array of type {type(a)}")
+
+    fill_value = _normalize_fill_value(
+        fill_value, int_bits, frac_bits, exp_bits, mantissa_bits
+    )
+    return full(a.shape, fill_value)
 
 
 # =============================================================================
 # Helpers
 # =============================================================================
+def _get_return_type(int_bits, frac_bits, exp_bits, mantissa_bits):
+    if int_bits and frac_bits:
+        return APyFixedArray
+    elif exp_bits and mantissa_bits:
+        return APyFloatArray
+    raise ValueError("You need to specify wordlengths in this function")
+
+
+def _normalize_fill_value(
+    fill_value: Union[APyFixed, APyFloat, int, float],
+    int_bits=None,
+    frac_bits=None,
+    exp_bits=None,
+    mantissa_bits=None,
+):
+    if isinstance(fill_value, (int, float)):
+        if int_bits is not None and frac_bits is not None:
+            return APyFixed.from_float(
+                fill_value, int_bits=int_bits, frac_bits=frac_bits
+            )
+        elif exp_bits is not None and mantissa_bits is not None:
+            return APyFloat.from_float(
+                fill_value, exp_bits=exp_bits, man_bits=mantissa_bits
+            )
+        else:
+            raise ValueError(
+                "You need to specify wordlengths if input is a Python float or integer"
+            )
+
+    elif isinstance(fill_value, APyFixed):
+        int_bits = int_bits or fill_value.int_bits
+        frac_bits = frac_bits or fill_value.frac_bits
+        return fill_value.cast(int_bits, frac_bits)
+
+    elif isinstance(fill_value, APyFloat):
+        exp_bits = exp_bits or fill_value.exp_bits
+        mantissa_bits = mantissa_bits or fill_value.man_bits
+        return fill_value.cast(exp_bits, mantissa_bits, fill_value.bias)
+
+    else:
+        raise ValueError(
+            "Only int, float, APyFloat and APyFixed are supported for fill_value"
+        )
 
 
 def _normalize_axis(axis: int, ndim: int) -> int:

--- a/lib/apytypes/_array_functions.py
+++ b/lib/apytypes/_array_functions.py
@@ -412,6 +412,132 @@ def expand_dims(a, axis):
 
 
 # =============================================================================
+# array creation
+# =============================================================================
+
+
+def zeros(
+    a_type, shape, int_bits=None, frac_bits=None, exp_bits=None, mantissa_bits=None
+):
+    try:
+        zeros = a_type.zeros
+    except AttributeError:
+        raise TypeError(f"Cannot make zeros array of type {type(a_type)}")
+    if hasattr(a_type, "int_bits") and hasattr(a_type, "frac_bits"):
+        return zeros(shape=shape, int_bits=int_bits, frac_bits=frac_bits)
+
+    if hasattr(a_type, "exp_bits") and hasattr(a_type, "mantissa_bits"):
+        return None
+
+    else:
+        raise ValueError("Only 'fixed' and 'float' array_types are defined")
+
+
+def zeros_like(
+    a, a_type=None, int_bits=None, frac_bits=None, exp_bits=None, mantissa_bits=None
+):
+    a_type = a if a_type is None else a_type
+    try:
+        zeros = a_type.zeros
+    except AttributeError:
+        raise TypeError(f"Cannot make zeros array of type {type(a_type)}")
+    if hasattr(a_type, "int_bits") and hasattr(a_type, "frac_bits"):
+        return zeros(shape=a.shape, int_bits=int_bits, frac_bits=frac_bits)
+
+    if hasattr(a_type, "exp_bits") and hasattr(a_type, "mantissa_bits"):
+        return None
+
+    else:
+        raise ValueError("Only 'fixed' and 'float' array_types are defined")
+
+
+def ones(
+    a_type, shape, int_bits=None, frac_bits=None, exp_bits=None, mantissa_bits=None
+):
+    try:
+        ones = a_type.ones
+    except AttributeError:
+        raise TypeError(f"Cannot make ones array of type {type(a_type)}")
+    if hasattr(a_type, "int_bits") and hasattr(a_type, "frac_bits"):
+        return ones(shape=shape, int_bits=int_bits, frac_bits=frac_bits)
+
+    if hasattr(a_type, "exp_bits") and hasattr(a_type, "mantissa_bits"):
+        return None
+
+    else:
+        raise ValueError("Only 'fixed' and 'float' array_types are defined")
+
+
+def ones_like(
+    a, a_type=None, int_bits=None, frac_bits=None, exp_bits=None, mantissa_bits=None
+):
+    a_type = a if a_type is None else a_type
+    try:
+        ones = a_type.ones
+    except AttributeError:
+        raise TypeError(f"Cannot make zeros array of type {type(a_type)}")
+    if hasattr(a_type, "int_bits") and hasattr(a_type, "frac_bits"):
+        return ones(shape=a.shape, int_bits=int_bits, frac_bits=frac_bits)
+
+    if hasattr(a_type, "exp_bits") and hasattr(a_type, "mantissa_bits"):
+        return None
+
+    else:
+        raise ValueError("Only 'fixed' and 'float' array_types are defined")
+
+
+def eye(
+    a_type, n, m=None, int_bits=None, frac_bits=None, exp_bits=None, mantissa_bits=None
+):
+    try:
+        eye = a_type.eye
+    except AttributeError:
+        raise TypeError(f"Cannot make eye array of type {type(a_type)}")
+    if hasattr(a_type, "int_bits") and hasattr(a_type, "frac_bits"):
+        return eye(n=n, m=m, int_bits=int_bits, frac_bits=frac_bits)
+
+    if hasattr(a_type, "exp_bits") and hasattr(a_type, "mantissa_bits"):
+        return None
+
+    else:
+        raise ValueError("Only 'fixed' and 'float' array_types are defined")
+
+
+def identity(
+    a_type, n, int_bits=None, frac_bits=None, exp_bits=None, mantissa_bits=None
+):
+    try:
+        identity = a_type.identity
+    except AttributeError:
+        raise TypeError(f"Cannot make identity array of type {type(a_type)}")
+
+    if hasattr(a_type, "int_bits") and hasattr(a_type, "frac_bits"):
+        return identity(n=n, int_bits=int_bits, frac_bits=frac_bits)
+
+    if hasattr(a_type, "exp_bits") and hasattr(a_type, "mantissa_bits"):
+        return None
+
+    else:
+        raise ValueError("Only 'fixed' and 'float' array_types are defined")
+
+
+def full(a_type, shape, fill_value):
+    try:
+        full = a_type.full
+    except AttributeError:
+        raise TypeError(f"Cannot make full array of type {type(a_type)}")
+
+    if hasattr(a_type, "int_bits") and hasattr(a_type, "frac_bits"):
+        return full(shape, fill_value)
+
+    if hasattr(a_type, "exp_bits") and hasattr(a_type, "mantissa_bits"):
+        return None
+
+    else:
+        raise ValueError("Only 'fixed' and 'float' array_types are defined")
+
+
+# =============================================================================
 # Helpers
 # =============================================================================
 

--- a/lib/apytypes/_array_functions.py
+++ b/lib/apytypes/_array_functions.py
@@ -1,5 +1,4 @@
 from typing import Tuple, Union
-from apytypes import APyFixedArray, APyFixed, APyFloat, APyFloatArray
 
 
 def squeeze(a, axis=None):
@@ -442,6 +441,8 @@ def zeros(shape, int_bits=None, frac_bits=None, exp_bits=None, mantissa_bits=Non
         The initialized array with zeros.
     """
 
+    from apytypes import APyFixedArray, APyFloatArray
+
     a_type = _get_return_type(int_bits, frac_bits, exp_bits, mantissa_bits)
     try:
         zeros = a_type.zeros
@@ -480,6 +481,9 @@ def ones(shape, int_bits=None, frac_bits=None, exp_bits=None, mantissa_bits=None
     result : :class:`APyFloatArray` or :class:`APyFixedArray`
         The array initialized filled with ones.
     """
+
+    from apytypes import APyFixedArray, APyFloatArray
+
     a_type = _get_return_type(int_bits, frac_bits, exp_bits, mantissa_bits)
     try:
         ones = a_type.ones
@@ -524,6 +528,9 @@ def eye(
     result : :class:`APyFloatArray` or :class:`APyFixedArray`
         An array where all elements are equal to zero, except for the k-th diagonal, whose values are equal to one.
     """
+
+    from apytypes import APyFixedArray, APyFloatArray
+
     a_type = _get_return_type(int_bits, frac_bits, exp_bits, mantissa_bits)
     try:
         eye = a_type.eye
@@ -564,6 +571,9 @@ def identity(n, int_bits=None, frac_bits=None, exp_bits=None, mantissa_bits=None
     result : :class:`APyFloatArray` or :class:`APyFixedArray`
         n x n array with its main diagonal set to one, and all other elements 0.
     """
+
+    from apytypes import APyFixedArray, APyFloatArray
+
     a_type = _get_return_type(int_bits, frac_bits, exp_bits, mantissa_bits)
     try:
         identity = a_type.identity
@@ -614,6 +624,9 @@ def full(
     result : :class:`APyFloatArray` or :class:`APyFixedArray`
         Array of fill_value with the given shape.
     """
+
+    from apytypes import APyFixedArray, APyFixed, APyFloat, APyFloatArray
+
     fill_value = _normalize_fill_value(
         fill_value, int_bits, frac_bits, exp_bits, mantissa_bits
     )
@@ -657,6 +670,8 @@ def zeros_like(a, int_bits=None, frac_bits=None, exp_bits=None, mantissa_bits=No
     except AttributeError:
         raise TypeError(f"Cannot make zeros array of type {type(a)}")
 
+    from apytypes import APyFixedArray, APyFloatArray
+
     if isinstance(a, APyFixedArray):
         int_bits = int_bits or a.int_bits
         frac_bits = frac_bits or a.frac_bits
@@ -697,6 +712,8 @@ def ones_like(a, int_bits=None, frac_bits=None, exp_bits=None, mantissa_bits=Non
         ones = a.ones
     except AttributeError:
         raise TypeError(f"Cannot make ones array of type {type(a)}")
+
+    from apytypes import APyFixedArray, APyFloatArray
 
     if isinstance(a, APyFixedArray):
         int_bits = int_bits or a.int_bits
@@ -761,6 +778,8 @@ def full_like(
 # Helpers
 # =============================================================================
 def _get_return_type(int_bits, frac_bits, exp_bits, mantissa_bits):
+    from apytypes import APyFixedArray, APyFloatArray
+
     if int_bits and frac_bits:
         return APyFixedArray
     elif exp_bits and mantissa_bits:
@@ -769,12 +788,14 @@ def _get_return_type(int_bits, frac_bits, exp_bits, mantissa_bits):
 
 
 def _normalize_fill_value(
-    fill_value: Union[APyFixed, APyFloat, int, float],
+    fill_value,
     int_bits=None,
     frac_bits=None,
     exp_bits=None,
     mantissa_bits=None,
 ):
+    from apytypes import APyFixed, APyFloat
+
     if isinstance(fill_value, (int, float)):
         if int_bits is not None and frac_bits is not None:
             return APyFixed.from_float(

--- a/lib/apytypes/_array_functions.py
+++ b/lib/apytypes/_array_functions.py
@@ -416,9 +416,31 @@ def expand_dims(a, axis):
 # =============================================================================
 
 
-def zeros(
-    a_type, shape, int_bits=None, frac_bits=None, exp_bits=None, mantissa_bits=None
-):
+def zeros(a_type, shape, int_bits=8, frac_bits=8, exp_bits=None, mantissa_bits=None):
+    """
+    Initializes an array with zeros.
+
+    Parameters
+    ----------
+    a_type : :class:`APyFloatArray` or :class:`APyFixedArray`
+        The type of array to initialize.
+    shape : tuple
+        Shape of the array.
+    int_bits : int, optional
+        Number of integer bits.
+    frac_bits : int, optional
+        Number of fractional bits.
+    exp_bits : int, optional
+        Number of exponential bits.
+    mantissa_bits : int, optional
+        Number of mantissa bits.
+
+    Returns
+    -------
+    result : :class:`APyFloatArray` or :class:`APyFixedArray`
+        The initialized array with zeros.
+    """
+
     try:
         zeros = a_type.zeros
     except AttributeError:
@@ -429,31 +451,76 @@ def zeros(
     if hasattr(a_type, "exp_bits") and hasattr(a_type, "mantissa_bits"):
         return None
 
-    else:
-        raise ValueError("Only 'fixed' and 'float' array_types are defined")
+    raise ValueError("Only 'fixed' and 'float' array_types are defined")
 
 
 def zeros_like(
     a, a_type=None, int_bits=None, frac_bits=None, exp_bits=None, mantissa_bits=None
 ):
-    a_type = a if a_type is None else a_type
+    """
+    Return an array of zeros with the same shape and type as a given array.
+
+    Parameters
+    ----------
+    a : :class:`APyFloatArray` or :class:`APyFixedArray`
+        The shape and data-type of a define these same attributes of the returned array.
+    a_type : :class:`APyFloatArray` or :class:`APyFixedArray`, optional
+        The type of array to initialize.
+    int_bits : int, optional
+        Number of integer bits.
+    frac_bits : int, optional
+        Number of fractional bits.
+    exp_bits : int, optional
+        Number of exponential bits.
+    mantissa_bits : int, optional
+        Number of mantissa bits.
+
+    Returns
+    -------
+    result : :class:`APyFloatArray` or :class:`APyFixedArray`
+        The initialized array with zeros.
+    """
+    a_type = a_type or a
     try:
         zeros = a_type.zeros
     except AttributeError:
         raise TypeError(f"Cannot make zeros array of type {type(a_type)}")
+
     if hasattr(a_type, "int_bits") and hasattr(a_type, "frac_bits"):
+        int_bits = int_bits or a.int_bits
+        frac_bits = frac_bits or a.frac_bits
         return zeros(shape=a.shape, int_bits=int_bits, frac_bits=frac_bits)
 
     if hasattr(a_type, "exp_bits") and hasattr(a_type, "mantissa_bits"):
         return None
 
-    else:
-        raise ValueError("Only 'fixed' and 'float' array_types are defined")
+    raise ValueError("Only 'fixed' and 'float' array_types are defined")
 
 
-def ones(
-    a_type, shape, int_bits=None, frac_bits=None, exp_bits=None, mantissa_bits=None
-):
+def ones(a_type, shape, int_bits=8, frac_bits=8, exp_bits=None, mantissa_bits=None):
+    """
+    Return an array of ones with the same shape and type as a given array.
+
+    Parameters
+    ----------
+    a_type : :class:`APyFloatArray` or :class:`APyFixedArray`, optional
+        The type of array to initialize.
+    shape : tuple
+        Shape of the array.
+    int_bits : int, optional
+        Number of integer bits.
+    frac_bits : int, optional
+        Number of fractional bits.
+    exp_bits : int, optional
+        Number of exponential bits.
+    mantissa_bits : int, optional
+        Number of mantissa bits.
+
+    Returns
+    -------
+    result : :class:`APyFloatArray` or :class:`APyFixedArray`
+        The array initialized filled with ones.
+    """
     try:
         ones = a_type.ones
     except AttributeError:
@@ -464,31 +531,77 @@ def ones(
     if hasattr(a_type, "exp_bits") and hasattr(a_type, "mantissa_bits"):
         return None
 
-    else:
-        raise ValueError("Only 'fixed' and 'float' array_types are defined")
+    raise ValueError("Only 'fixed' and 'float' array_types are defined")
 
 
 def ones_like(
     a, a_type=None, int_bits=None, frac_bits=None, exp_bits=None, mantissa_bits=None
 ):
-    a_type = a if a_type is None else a_type
+    """
+    Return an array of zeros with the same shape and type as a given array.
+
+    Parameters
+    ----------
+    a_type : :class:`APyFloatArray` or :class:`APyFixedArray`, optional
+        The type of array to initialize.
+    shape : tuple
+        Shape of the array.
+    int_bits : int, optional
+        Number of integer bits.
+    frac_bits : int, optional
+        Number of fractional bits.
+    exp_bits : int, optional
+        Number of exponential bits.
+    mantissa_bits : int, optional
+        Number of mantissa bits.
+
+    Returns
+    -------
+    result : :class:`APyFloatArray` or :class:`APyFixedArray`
+        The array initialized filled with ones.
+    """
+    a_type = a_type or a
     try:
         ones = a_type.ones
     except AttributeError:
-        raise TypeError(f"Cannot make zeros array of type {type(a_type)}")
+        raise TypeError(f"Cannot make ones array of type {type(a_type)}")
     if hasattr(a_type, "int_bits") and hasattr(a_type, "frac_bits"):
+        int_bits = int_bits or a.int_bits
+        frac_bits = frac_bits or a.frac_bits
         return ones(shape=a.shape, int_bits=int_bits, frac_bits=frac_bits)
 
     if hasattr(a_type, "exp_bits") and hasattr(a_type, "mantissa_bits"):
         return None
 
-    else:
-        raise ValueError("Only 'fixed' and 'float' array_types are defined")
+    raise ValueError("Only 'fixed' and 'float' array_types are defined")
 
 
-def eye(
-    a_type, n, m=None, int_bits=None, frac_bits=None, exp_bits=None, mantissa_bits=None
-):
+def eye(a_type, n, m=None, int_bits=8, frac_bits=8, exp_bits=None, mantissa_bits=None):
+    """
+    Return a 2-D array with ones on the diagonal and zeros elsewhere.
+
+    Parameters
+    ----------
+    a_type : :class:`APyFloatArray` or :class:`APyFixedArray`, optional
+        The type of array to initialize.
+    n : int
+        Number of rows in the output.
+    m : int, optional
+        Number of columns in the output. If None, defaults to N.
+    int_bits : int, optional
+        Number of integer bits.
+    frac_bits : int, optional
+        Number of fractional bits.
+    exp_bits : int, optional
+        Number of exponential bits.
+    mantissa_bits : int, optional
+        Number of mantissa bits.
+
+    Returns
+    -------
+    result : :class:`APyFloatArray` or :class:`APyFixedArray`
+        An array where all elements are equal to zero, except for the k-th diagonal, whose values are equal to one.
+    """
     try:
         eye = a_type.eye
     except AttributeError:
@@ -499,13 +612,35 @@ def eye(
     if hasattr(a_type, "exp_bits") and hasattr(a_type, "mantissa_bits"):
         return None
 
-    else:
-        raise ValueError("Only 'fixed' and 'float' array_types are defined")
+    raise ValueError("Only 'fixed' and 'float' array_types are defined")
 
 
-def identity(
-    a_type, n, int_bits=None, frac_bits=None, exp_bits=None, mantissa_bits=None
-):
+def identity(a_type, n, int_bits=8, frac_bits=8, exp_bits=None, mantissa_bits=None):
+    """
+    Return the identity array.
+
+    The identity array is a square array with ones on the main diagonal.
+
+    Parameters
+    ----------
+    a_type : :class:`APyFloatArray` or :class:`APyFixedArray`, optional
+        The type of array to initialize.
+    n : int
+        Number of rows (and columns) in n x n output.
+    int_bits : int, optional
+        Number of integer bits.
+    frac_bits : int, optional
+        Number of fractional bits.
+    exp_bits : int, optional
+        Number of exponential bits.
+    mantissa_bits : int, optional
+        Number of mantissa bits.
+
+    Returns
+    -------
+    result : :class:`APyFloatArray` or :class:`APyFixedArray`
+        n x n array with its main diagonal set to one, and all other elements 0.
+    """
     try:
         identity = a_type.identity
     except AttributeError:
@@ -517,24 +652,118 @@ def identity(
     if hasattr(a_type, "exp_bits") and hasattr(a_type, "mantissa_bits"):
         return None
 
-    else:
-        raise ValueError("Only 'fixed' and 'float' array_types are defined")
+    raise ValueError("Only 'fixed' and 'float' array_types are defined")
 
 
-def full(a_type, shape, fill_value):
+def full(
+    a_type,
+    shape,
+    fill_value,
+    int_bits=None,
+    frac_bits=None,
+    exp_bits=None,
+    mantissa_bits=None,
+):
+    """
+    Return a new array of given shape and type, filled with fill_value.
+
+    Parameters
+    ----------
+    a_type : :class:`APyFloatArray` or :class:`APyFixedArray`, optional
+        The type of array to initialize.
+    shape : tuple
+        Shape of the array.
+    fill_value : :class:`APyFloat` or :class:`APyFixedArray` or int or float
+        Fill value.
+    int_bits : int, optional
+        Number of integer bits.
+    frac_bits : int, optional
+        Number of fractional bits.
+    exp_bits : int, optional
+        Number of exponential bits.
+    mantissa_bits : int, optional
+        Number of mantissa bits.
+
+    Returns
+    -------
+    result : :class:`APyFloatArray` or :class:`APyFixedArray`
+        Array of fill_value with the given shape and a_type.
+    """
     try:
         full = a_type.full
     except AttributeError:
         raise TypeError(f"Cannot make full array of type {type(a_type)}")
 
     if hasattr(a_type, "int_bits") and hasattr(a_type, "frac_bits"):
+        if isinstance(fill_value, (int, float)):
+            from apytypes import APyFixed
+
+            fill_value = APyFixed.from_float(
+                fill_value, int_bits=int_bits, frac_bits=frac_bits
+            )
+
         return full(shape, fill_value)
 
     if hasattr(a_type, "exp_bits") and hasattr(a_type, "mantissa_bits"):
         return None
 
-    else:
-        raise ValueError("Only 'fixed' and 'float' array_types are defined")
+    raise ValueError("Only 'fixed' and 'float' array_types are defined")
+
+
+def full_like(
+    a,
+    fill_value,
+    a_type=None,
+    int_bits=None,
+    frac_bits=None,
+    exp_bits=None,
+    mantissa_bits=None,
+):
+    """
+    Return a full array with the same shape and type as a given array.
+
+    Parameters
+    ----------
+    a : :class:`APyFloatArray` or :class:`APyFixedArray`, optional
+        The shape and array type of the returned array.
+    fill_value : :class:`APyFloat` or :class:`APyFixedArray` or int or float
+        Fill value.
+    int_bits : int, optional
+        Number of integer bits.
+    frac_bits : int, optional
+        Number of fractional bits.
+    exp_bits : int, optional
+        Number of exponential bits.
+    mantissa_bits : int, optional
+        Number of mantissa bits.
+
+    Returns
+    -------
+    result : :class:`APyFloatArray` or :class:`APyFixedArray`
+        Array of fill_value with the same shape and type as a.
+    """
+    a_type = a if a_type is None else a_type
+    try:
+        full = a_type.full
+    except AttributeError:
+        raise TypeError(f"Cannot make full array of type {type(a_type)}")
+
+    if hasattr(a_type, "int_bits") and hasattr(a_type, "frac_bits"):
+        int_bits = int_bits or a.int_bits
+        frac_bits = frac_bits or a.frac_bits
+        if isinstance(fill_value, (int, float)):
+            from apytypes import APyFixed
+
+            fill_value = APyFixed.from_float(
+                fill_value, int_bits=int_bits, frac_bits=frac_bits
+            )
+
+        return full(a.shape, fill_value)
+
+    if hasattr(a_type, "exp_bits") and hasattr(a_type, "mantissa_bits"):
+        return None
+
+    raise ValueError("Only 'fixed' and 'float' array_types are defined")
 
 
 # =============================================================================

--- a/lib/apytypes/_array_functions.pyi
+++ b/lib/apytypes/_array_functions.pyi
@@ -250,10 +250,29 @@ def full_like(
     exp_bits: None = None,
     mantissa_bits: None = None,
 ) -> APyFixedArray: ...
-@overload
 def full_like(
     a: APyArray,
     fill_value: Union[int, float] = None,
+    int_bits: None = None,
+    frac_bits: None = None,
+    exp_bits: int = None,
+    mantissa_bits: int = None,
+) -> APyFloatArray: ...
+@overload
+def arange(
+    start: Union[int, float],
+    stop: Union[int, float] = None,
+    step: Union[int, float, None] = None,
+    int_bits: int = None,
+    frac_bits: int = None,
+    exp_bits: None = None,
+    mantissa_bits: None = None,
+) -> APyFixedArray: ...
+@overload
+def arange(
+    start: Union[int, float],
+    stop: Union[int, float] = None,
+    step: Union[int, float, None] = None,
     int_bits: None = None,
     frac_bits: None = None,
     exp_bits: int = None,

--- a/lib/apytypes/_array_functions.pyi
+++ b/lib/apytypes/_array_functions.pyi
@@ -1,6 +1,6 @@
-from typing import overload, Sequence
-from apytypes import APyFloatArray, APyFixedArray
-from apytypes.typing import APyArray
+from typing import overload, Sequence, Union
+from apytypes import APyFloatArray, APyFixedArray, APyFixed, APyFloat
+from apytypes.typing import APyArray, APyScalar
 
 @overload
 def squeeze(
@@ -62,54 +62,200 @@ def expand_dims(a: APyFloatArray, axis: int | Sequence[int]) -> APyFloatArray: .
 def expand_dims(a: APyFixedArray, axis: int | Sequence[int]) -> APyFixedArray: ...
 def expand_dims(a: APyArray, axis: int | Sequence[int]) -> APyArray: ...
 @overload
-def eye(
-    a_type: APyArray,
-    shape: tuple[int, ...],
+def identity(
+    n: int,
     int_bits: int = None,
     frac_bits: int = None,
-    exp_bits: int = None,
-    mantissa_bits: int = None,
-) -> APyArray: ...
-@overload
-def eye(
-    a_type: APyFloatArray,
-    shape: tuple[int, ...],
-    int_bits: int = None,
-    frac_bits: int = None,
+    exp_bits: None = None,
+    mantissa_bits: None = None,
+) -> APyFixedArray: ...
+def identity(
+    n: int,
+    int_bits: None = None,
+    frac_bits: None = None,
     exp_bits: int = None,
     mantissa_bits: int = None,
 ) -> APyFloatArray: ...
+@overload
 def eye(
-    a_type: APyFixedArray,
+    n: int,
+    m: int = None,
+    int_bits: int = None,
+    frac_bits: int = None,
+    exp_bits: None = None,
+    mantissa_bits: None = None,
+) -> APyFixedArray: ...
+def eye(
+    n: int,
+    m: int = None,
+    int_bits: None = None,
+    frac_bits: None = None,
+    exp_bits: int = None,
+    mantissa_bits: int = None,
+) -> APyFloatArray: ...
+@overload
+def zeros(
     shape: tuple[int, ...],
     int_bits: int = None,
     frac_bits: int = None,
     exp_bits: None = None,
     mantissa_bits: None = None,
 ) -> APyFixedArray: ...
-@overload
 def zeros(
-    a_type: APyArray,
     shape: tuple[int, ...],
-    int_bits: int = None,
-    frac_bits: int = None,
-    exp_bits: int = None,
-    mantissa_bits: int = None,
-) -> APyArray: ...
-@overload
-def zeros(
-    a_type: APyFloatArray,
-    shape: tuple[int, ...],
-    int_bits: int = None,
-    frac_bits: int = None,
+    int_bits: None = None,
+    frac_bits: None = None,
     exp_bits: int = None,
     mantissa_bits: int = None,
 ) -> APyFloatArray: ...
-def zeros(
-    a_type: APyFixedArray,
+@overload
+def ones(
     shape: tuple[int, ...],
     int_bits: int = None,
     frac_bits: int = None,
     exp_bits: None = None,
     mantissa_bits: None = None,
 ) -> APyFixedArray: ...
+def ones(
+    shape: tuple[int, ...],
+    int_bits: None = None,
+    frac_bits: None = None,
+    exp_bits: int = None,
+    mantissa_bits: int = None,
+) -> APyFloatArray: ...
+@overload
+def full(
+    shape: tuple[int, ...],
+    fill_value: APyScalar = None,
+    int_bits: None = None,
+    frac_bits: None = None,
+    exp_bits: None = None,
+    mantissa_bits: None = None,
+) -> APyArray: ...
+@overload
+def full(
+    shape: tuple[int, ...],
+    fill_value: APyFixed = None,
+    int_bits: None = None,
+    frac_bits: None = None,
+    exp_bits: None = None,
+    mantissa_bits: None = None,
+) -> APyFixedArray: ...
+@overload
+def full(
+    shape: tuple[int, ...],
+    fill_value: APyFloat = None,
+    int_bits: None = None,
+    frac_bits: None = None,
+    exp_bits: None = None,
+    mantissa_bits: None = None,
+) -> APyFloatArray: ...
+@overload
+def full(
+    shape: tuple[int, ...],
+    fill_value: Union[int, float] = None,
+    int_bits: int = None,
+    frac_bits: int = None,
+    exp_bits: None = None,
+    mantissa_bits: None = None,
+) -> APyFixedArray: ...
+@overload
+def full(
+    shape: tuple[int, ...],
+    fill_value: Union[int, float] = None,
+    int_bits: None = None,
+    frac_bits: None = None,
+    exp_bits: int = None,
+    mantissa_bits: int = None,
+) -> APyFloatArray: ...
+@overload
+def zeros_like(
+    a: APyArray,
+    int_bits: None = None,
+    frac_bits: None = None,
+    exp_bits: None = None,
+    mantissa_bits: None = None,
+) -> APyArray: ...
+@overload
+def zeros_like(
+    a: APyFixedArray,
+    int_bits: None = None,
+    frac_bits: None = None,
+    exp_bits: None = None,
+    mantissa_bits: None = None,
+) -> APyFixedArray: ...
+def zeros_like(
+    a: APyFloatArray,
+    int_bits: None = None,
+    frac_bits: None = None,
+    exp_bits: None = None,
+    mantissa_bits: None = None,
+) -> APyFloatArray: ...
+@overload
+def ones_like(
+    a: APyArray,
+    int_bits: None = None,
+    frac_bits: None = None,
+    exp_bits: None = None,
+    mantissa_bits: None = None,
+) -> APyArray: ...
+@overload
+def ones_like(
+    a: APyFixedArray,
+    int_bits: None = None,
+    frac_bits: None = None,
+    exp_bits: None = None,
+    mantissa_bits: None = None,
+) -> APyFixedArray: ...
+def ones_like(
+    a: APyFloatArray,
+    int_bits: None = None,
+    frac_bits: None = None,
+    exp_bits: None = None,
+    mantissa_bits: None = None,
+) -> APyFloatArray: ...
+@overload
+def full_like(
+    a: APyArray,
+    fill_value: APyScalar = None,
+    int_bits: None = None,
+    frac_bits: None = None,
+    exp_bits: None = None,
+    mantissa_bits: None = None,
+) -> APyArray: ...
+@overload
+def full_like(
+    a: APyArray,
+    fill_value: APyFixed = None,
+    int_bits: None = None,
+    frac_bits: None = None,
+    exp_bits: None = None,
+    mantissa_bits: None = None,
+) -> APyFixedArray: ...
+@overload
+def full_like(
+    a: APyArray,
+    fill_value: APyFloat = None,
+    int_bits: None = None,
+    frac_bits: None = None,
+    exp_bits: None = None,
+    mantissa_bits: None = None,
+) -> APyFloatArray: ...
+@overload
+def full_like(
+    a: APyArray,
+    fill_value: Union[int, float] = None,
+    int_bits: int = None,
+    frac_bits: int = None,
+    exp_bits: None = None,
+    mantissa_bits: None = None,
+) -> APyFixedArray: ...
+@overload
+def full_like(
+    a: APyArray,
+    fill_value: Union[int, float] = None,
+    int_bits: None = None,
+    frac_bits: None = None,
+    exp_bits: int = None,
+    mantissa_bits: int = None,
+) -> APyFloatArray: ...

--- a/lib/apytypes/_array_functions.pyi
+++ b/lib/apytypes/_array_functions.pyi
@@ -61,3 +61,55 @@ def expand_dims(a: APyFloatArray, axis: int | Sequence[int]) -> APyFloatArray: .
 @overload
 def expand_dims(a: APyFixedArray, axis: int | Sequence[int]) -> APyFixedArray: ...
 def expand_dims(a: APyArray, axis: int | Sequence[int]) -> APyArray: ...
+@overload
+def eye(
+    a_type: APyArray,
+    shape: tuple[int, ...],
+    int_bits: int = None,
+    frac_bits: int = None,
+    exp_bits: int = None,
+    mantissa_bits: int = None,
+) -> APyArray: ...
+@overload
+def eye(
+    a_type: APyFloatArray,
+    shape: tuple[int, ...],
+    int_bits: int = None,
+    frac_bits: int = None,
+    exp_bits: int = None,
+    mantissa_bits: int = None,
+) -> APyFloatArray: ...
+def eye(
+    a_type: APyFixedArray,
+    shape: tuple[int, ...],
+    int_bits: int = None,
+    frac_bits: int = None,
+    exp_bits: None = None,
+    mantissa_bits: None = None,
+) -> APyFixedArray: ...
+@overload
+def zeros(
+    a_type: APyArray,
+    shape: tuple[int, ...],
+    int_bits: int = None,
+    frac_bits: int = None,
+    exp_bits: int = None,
+    mantissa_bits: int = None,
+) -> APyArray: ...
+@overload
+def zeros(
+    a_type: APyFloatArray,
+    shape: tuple[int, ...],
+    int_bits: int = None,
+    frac_bits: int = None,
+    exp_bits: int = None,
+    mantissa_bits: int = None,
+) -> APyFloatArray: ...
+def zeros(
+    a_type: APyFixedArray,
+    shape: tuple[int, ...],
+    int_bits: int = None,
+    frac_bits: int = None,
+    exp_bits: None = None,
+    mantissa_bits: None = None,
+) -> APyFixedArray: ...

--- a/lib/apytypes/_typing.py
+++ b/lib/apytypes/_typing.py
@@ -1,6 +1,7 @@
 from typing import Union
-from apytypes import APyFloatArray, APyFixedArray
+from apytypes import APyFloatArray, APyFixedArray, APyFloat, APyFixed
 # The following are type aliases. Once Python 3.9 is dropped, they should be annotated
 # using ``typing.TypeAlias`` and Unions should be converted to using ``|`` syntax.
 
 APyArray = Union[APyFixedArray, APyFloatArray]
+APyScalar = Union[APyFixed, APyFloat]

--- a/lib/test/test_array_functions.py
+++ b/lib/test/test_array_functions.py
@@ -15,6 +15,7 @@ from apytypes import (
     ones_like,
     full,
     full_like,
+    arange,
     APyFloat,
     APyFixed,
     APyFixedArray,
@@ -254,10 +255,14 @@ def test_zeros(shape):
 
     # Test cases for APyFixedArray
     check_zeros(int_bits=5, frac_bits=5)
+
     check_zeros(int_bits=12314, frac_bits=1832)
 
+    check_zeros(int_bits=0, frac_bits=5)
     # Test cases for APyFloatArray
     check_zeros(exp_bits=13, mantissa_bits=28)
+
+    check_zeros(exp_bits=13, mantissa_bits=0)
     check_zeros(exp_bits=16, mantissa_bits=5)
 
 
@@ -388,12 +393,19 @@ def test_full(shape):
         APyFixedArray, fill_value=shape[0] + shape[1], int_bits=12314, frac_bits=1832
     )
 
+    check_full(
+        APyFixedArray, fill_value=shape[0] + shape[1], int_bits=0, frac_bits=1832
+    )
+
     # Test cases for APyFloatArray
     check_full(
         APyFloatArray, fill_value=shape[0] + shape[1], exp_bits=13, mantissa_bits=28
     )
     check_full(
         APyFloatArray, fill_value=shape[0] + shape[1], exp_bits=16, mantissa_bits=5
+    )
+    check_full(
+        APyFloatArray, fill_value=shape[0] + shape[1], exp_bits=0, mantissa_bits=5
     )
 
 
@@ -449,11 +461,114 @@ def test_full_like(shape):
     check_full_like(
         APyFixedArray, fill_value=shape[0] + shape[1], int_bits=12314, frac_bits=1832
     )
+    check_full_like(
+        APyFixedArray, fill_value=shape[0] + shape[1], int_bits=0, frac_bits=5
+    )
+
+    check_full_like(
+        APyFixedArray, fill_value=shape[0] + shape[1], int_bits=5, frac_bits=0
+    )
+
+    check_full_like(
+        APyFixedArray, fill_value=shape[0] + shape[1], int_bits=5, frac_bits=0
+    )
 
     # Test cases for APyFloatArray
+
     check_full_like(
         APyFloatArray, fill_value=shape[0] + shape[1], exp_bits=13, mantissa_bits=28
     )
     check_full_like(
         APyFloatArray, fill_value=shape[0] + shape[1], exp_bits=16, mantissa_bits=5
+    )
+    check_full_like(
+        APyFloatArray, fill_value=shape[0] + shape[1], exp_bits=16, mantissa_bits=0
+    )
+
+
+def test_arrange():
+    a = arange(10, int_bits=10, frac_bits=5)
+    b = APyFixedArray.from_float([i for i in range(10)], int_bits=10, frac_bits=5)
+    assert a.is_identical(b), "Arrange for APyFixedArray failed"
+
+    a = arange(10, exp_bits=10, mantissa_bits=5)
+    b = APyFloatArray.from_float([i for i in range(10)], exp_bits=10, man_bits=5)
+    assert a.is_identical(b), "Arrange for APyFloatArray failed"
+
+    a = arange(5, 8, int_bits=10, frac_bits=5)
+    assert a.is_identical(APyFixedArray.from_float([5, 6, 7], int_bits=10, frac_bits=5))
+
+    a = arange(8, 5, -1, int_bits=10, frac_bits=5)
+    assert a.is_identical(APyFixedArray.from_float([8, 7, 6], int_bits=10, frac_bits=5))
+
+    a = arange(8, 5, -2, int_bits=10, frac_bits=5)
+    assert a.is_identical(APyFixedArray.from_float([8, 6], int_bits=10, frac_bits=5))
+
+    a = arange(8, 5, -3, int_bits=10, frac_bits=5)
+    assert a.is_identical(APyFixedArray.from_float([8], int_bits=10, frac_bits=5))
+
+    a = arange(0, 2, 2 ** (-2), int_bits=10, frac_bits=2)
+    assert a.is_identical(
+        APyFixedArray.from_float(
+            [0.0, 0.25, 0.5, 0.75, 1.0, 1.25, 1.5, 1.75], int_bits=10, frac_bits=2
+        )
+    )
+
+    a = arange(0, 2, 2 ** (-2), int_bits=10, frac_bits=2)
+    assert a.is_identical(
+        APyFixedArray.from_float(
+            [0.0, 0.25, 0.5, 0.75, 1.0, 1.25, 1.5, 1.75], int_bits=10, frac_bits=2
+        )
+    )
+
+    a = arange(0, 1, 2 ** (-4), int_bits=10, frac_bits=4)
+    assert a.is_identical(
+        APyFixedArray.from_float(
+            [
+                0,
+                0.0625,
+                0.125,
+                0.1875,
+                0.25,
+                0.3125,
+                0.375,
+                0.4375,
+                0.5,
+                0.5625,
+                0.625,
+                0.6875,
+                0.75,
+                0.8125,
+                0.875,
+                0.9375,
+            ],
+            int_bits=10,
+            frac_bits=4,
+        )
+    )
+
+    a = arange(1, 0, -(2 ** (-4)), int_bits=10, frac_bits=4)
+    assert a.is_identical(
+        APyFixedArray.from_float(
+            [
+                0.0625,
+                0.125,
+                0.1875,
+                0.25,
+                0.3125,
+                0.375,
+                0.4375,
+                0.5,
+                0.5625,
+                0.625,
+                0.6875,
+                0.75,
+                0.8125,
+                0.875,
+                0.9375,
+                1,
+            ][::-1],
+            int_bits=10,
+            frac_bits=4,
+        )
     )

--- a/lib/test/test_array_functions.py
+++ b/lib/test/test_array_functions.py
@@ -7,6 +7,10 @@ from apytypes import (
     moveaxis,
     expand_dims,
     swapaxes,
+    eye,
+    identity,
+    zeros,
+    ones,
     APyFixedArray,
     APyFloatArray,
 )
@@ -132,3 +136,95 @@ def test_expanddims():
     b = _floatArrange(10).reshape((1, 2, 5))
     c = expand_dims(a, 0)
     assert c.is_identical(b), "expanddims failed for float array"
+
+
+@pytest.mark.parametrize(
+    "n, m, nums",
+    [
+        (1, 1, [1]),
+        (1, 2, [1, 0]),
+        (2, None, [1, 0, 0, 1]),
+        (2, 3, [1, 0, 0, 0, 1, 0]),
+        (4, None, [1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1]),
+    ],
+)
+def test_eye_fixed(n, m, nums):
+    int_bits, frac_bits = 5, 5
+    a = eye(APyFixedArray, n=n, m=m, int_bits=int_bits, frac_bits=frac_bits)
+    m = n if m is None else m
+    b = APyFixedArray.from_float(nums, int_bits=int_bits, frac_bits=frac_bits).reshape(
+        (n, m)
+    )
+    if not a.is_identical(b):
+        pytest.fail(
+            f"eye on FixedArray didn't work when n={n}, m={m}. Expected result was {nums} but got \n {a}"
+        )
+
+    int_bits, frac_bits = 12314, 1832
+    a = eye(APyFixedArray, n=n, m=m, int_bits=int_bits, frac_bits=frac_bits)
+    b = APyFixedArray.from_float(nums, int_bits=int_bits, frac_bits=frac_bits).reshape(
+        (n, m)
+    )
+    if not a.is_identical(b):
+        pytest.fail(
+            f"eye on FixedArray didn't work when n={n}, m={m}. Expected result was {nums} but got \n {a}"
+        )
+
+
+@pytest.mark.parametrize(
+    "n, nums",
+    [
+        (1, [1]),
+        (2, [1, 0, 0, 1]),
+        (3, [1, 0, 0, 0, 1, 0, 0, 0, 1]),
+        (4, [1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1]),
+        (
+            5,
+            [1, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 1],
+        ),
+    ],
+)
+def test_identity_fixed(n, nums):
+    int_bits, frac_bits = 5, 5
+    a = identity(APyFixedArray, n=n, int_bits=int_bits, frac_bits=frac_bits)
+    b = APyFixedArray.from_float(nums, int_bits=int_bits, frac_bits=frac_bits).reshape(
+        (n, n)
+    )
+    if not a.is_identical(b):
+        pytest.fail(
+            f"identity on FixedArray didn't work when n={n}. Expected result was {nums} but got \n {a}"
+        )
+
+    int_bits, frac_bits = 38231, 1237
+    a = identity(APyFixedArray, n=n, int_bits=int_bits, frac_bits=frac_bits)
+    b = APyFixedArray.from_float(nums, int_bits=int_bits, frac_bits=frac_bits).reshape(
+        (n, n)
+    )
+    if not a.is_identical(b):
+        pytest.fail(
+            f"identity on FixedArray didn't work when n={n}. Expected result was {nums} but got \n {a}"
+        )
+
+
+@pytest.mark.parametrize("shape", [(i, j) for i in range(1, 5) for j in range(1, 5)])
+def test_zeros_fixed(shape):
+    int_bits, frac_bits = 5, 5
+    a = zeros(APyFixedArray, shape, int_bits=int_bits, frac_bits=frac_bits)
+    b = APyFixedArray.from_float(
+        [0] * (shape[0] * shape[1]), int_bits=int_bits, frac_bits=frac_bits
+    ).reshape(shape)
+    if not a.is_identical(b):
+        pytest.fail(f"zeros on FixedArray didn't work when shape={shape}.")
+
+
+@pytest.mark.parametrize("shape", [(i, j) for i in range(1, 5) for j in range(1, 5)])
+def test_ones_fixed(shape):
+    int_bits, frac_bits = 5, 5
+    a = ones(APyFixedArray, shape, int_bits=int_bits, frac_bits=frac_bits)
+    b = APyFixedArray.from_float(
+        [1] * (shape[0] * shape[1]), int_bits=int_bits, frac_bits=frac_bits
+    ).reshape(shape)
+    print(a)
+    print(b)
+    if not a.is_identical(b):
+        pytest.fail(f"ones on FixedArray didn't work when shape={shape}.")

--- a/lib/test/test_array_functions.py
+++ b/lib/test/test_array_functions.py
@@ -1,4 +1,5 @@
 from apytypes import (
+    APyFixed,
     squeeze,
     reshape,
     shape,
@@ -10,7 +11,11 @@ from apytypes import (
     eye,
     identity,
     zeros,
+    zeros_like,
     ones,
+    ones_like,
+    full,
+    full_like,
     APyFixedArray,
     APyFloatArray,
 )
@@ -218,13 +223,69 @@ def test_zeros_fixed(shape):
 
 
 @pytest.mark.parametrize("shape", [(i, j) for i in range(1, 5) for j in range(1, 5)])
+def test_zeros_like_fixed(shape):
+    int_bits, frac_bits = 5, 5
+    b = APyFixedArray.from_float(
+        [0] * (shape[0] * shape[1]), int_bits=int_bits, frac_bits=frac_bits
+    ).reshape(shape)
+
+    a = zeros_like(b, int_bits=int_bits, frac_bits=frac_bits)
+    if not a.is_identical(b):
+        pytest.fail(f"zeros on FixedArray didn't work when shape={shape}.")
+
+
+@pytest.mark.parametrize("shape", [(i, j) for i in range(1, 5) for j in range(1, 5)])
 def test_ones_fixed(shape):
     int_bits, frac_bits = 5, 5
     a = ones(APyFixedArray, shape, int_bits=int_bits, frac_bits=frac_bits)
     b = APyFixedArray.from_float(
         [1] * (shape[0] * shape[1]), int_bits=int_bits, frac_bits=frac_bits
     ).reshape(shape)
-    print(a)
-    print(b)
+    if not a.is_identical(b):
+        pytest.fail(f"ones on FixedArray didn't work when shape={shape}.")
+
+
+@pytest.mark.parametrize("shape", [(i, j) for i in range(1, 5) for j in range(1, 5)])
+def test_ones_like_fixed(shape):
+    int_bits, frac_bits = 5, 5
+    b = APyFixedArray.from_float(
+        [1] * (shape[0] * shape[1]), int_bits=int_bits, frac_bits=frac_bits
+    ).reshape(shape)
+    a = ones_like(b, int_bits=int_bits, frac_bits=frac_bits)
+    if not a.is_identical(b):
+        pytest.fail(f"ones on FixedArray didn't work when shape={shape}.")
+
+
+@pytest.mark.parametrize("shape", [(i, j) for i in range(1, 5) for j in range(1, 5)])
+def test_full_fixed(shape):
+    int_bits, frac_bits = 5, 5
+    b = APyFixedArray.from_float(
+        [shape[0] + shape[1]] * (shape[0] * shape[1]),
+        int_bits=int_bits,
+        frac_bits=frac_bits,
+    ).reshape(shape)
+    num = APyFixed.from_float(
+        shape[0] + shape[1], int_bits=int_bits, frac_bits=frac_bits
+    )
+    a = full(APyFixedArray, shape, num, int_bits=int_bits, frac_bits=frac_bits)
+    if not a.is_identical(b):
+        pytest.fail(f"ones on FixedArray didn't work when shape={shape}.")
+
+
+@pytest.mark.parametrize("shape", [(i, j) for i in range(1, 5) for j in range(1, 5)])
+def test_full_like_fixed(shape):
+    int_bits, frac_bits = 5, 5
+    b = APyFixedArray.from_float(
+        [shape[0] + shape[1]] * (shape[0] * shape[1]),
+        int_bits=int_bits,
+        frac_bits=frac_bits,
+    ).reshape(shape)
+    num = APyFixed.from_float(
+        shape[0] + shape[1], int_bits=int_bits, frac_bits=frac_bits
+    )
+    a = full_like(b, num, int_bits=int_bits, frac_bits=frac_bits)
+    if not a.is_identical(b):
+        pytest.fail(f"ones on FixedArray didn't work when shape={shape}.")
+    a = full_like(b, shape[0] + shape[1], int_bits=int_bits, frac_bits=frac_bits)
     if not a.is_identical(b):
         pytest.fail(f"ones on FixedArray didn't work when shape={shape}.")

--- a/src/apyfixed_util.h
+++ b/src/apyfixed_util.h
@@ -20,7 +20,8 @@ mp_limb_t get_data_from_double(double value, int bits, int frac_bits, int shift_
 //! Fast integer power by squaring.
 APyFixed ipow(APyFixed base, unsigned int n);
 
-static APY_INLINE APyFixed decimal_one(int bits, int int_bits)
+//! Get bit pattern for the value one
+static APY_INLINE APyFixed one(int bits, int int_bits)
 {
     std::size_t bit_index = bits - int_bits;
     std::size_t limb_bits = sizeof(mp_limb_t) * 8;

--- a/src/apyfixed_util.h
+++ b/src/apyfixed_util.h
@@ -20,6 +20,21 @@ mp_limb_t get_data_from_double(double value, int bits, int frac_bits, int shift_
 //! Fast integer power by squaring.
 APyFixed ipow(APyFixed base, unsigned int n);
 
+static APY_INLINE APyFixed decimal_one(int bits, int int_bits)
+{
+    std::size_t bit_index = bits - int_bits;
+    std::size_t limb_bits = sizeof(mp_limb_t) * 8;
+    std::size_t limb_index = bit_index / limb_bits;
+    std::size_t bit_offset = bit_index % limb_bits;
+
+    std::size_t num_limbs = limb_index + 1;
+    std::vector<mp_limb_t> data(num_limbs, static_cast<mp_limb_t>(0));
+
+    // Set the specified bit to 1
+    data[limb_index] |= static_cast<mp_limb_t>(1) << bit_offset;
+
+    return APyFixed(bits, int_bits, data);
+}
 /* ********************************************************************************** *
  * *    Fixed-point iterator based in-place quantization with multi-limb support    * *
  * ********************************************************************************** */

--- a/src/apyfixedarray.cc
+++ b/src/apyfixedarray.cc
@@ -1762,8 +1762,9 @@ APyFixedArray APyFixedArray::from_array(
 }
 
 /* ****************************************************************************** *
- *                       Static conversion from other types                       *
+ *                    Static methods for creating arrays                          *
  * ****************************************************************************** */
+
 APyFixedArray APyFixedArray::zeros(
     const nb::tuple& shape,
     std::optional<int> int_bits,

--- a/src/apyfixedarray.cc
+++ b/src/apyfixedarray.cc
@@ -1788,7 +1788,7 @@ APyFixedArray APyFixedArray::ones(
         = int_bits ? int_bits.value() : bits.value() - frac_bits.value();
     const int final_bits = bits ? bits.value() : int_bits.value() + frac_bits.value();
 
-    APyFixed fixed_one = ::decimal_one(final_bits, final_int_bits);
+    APyFixed fixed_one = one(final_bits, final_int_bits);
     return full(shape, fixed_one);
 }
 
@@ -1803,7 +1803,7 @@ APyFixedArray APyFixedArray::eye(
     const int final_int_bits
         = int_bits ? int_bits.value() : bits.value() - frac_bits.value();
     const int final_bits = bits ? bits.value() : int_bits.value() + frac_bits.value();
-    APyFixed fixed_one = ::decimal_one(final_bits, final_int_bits);
+    APyFixed fixed_one = one(final_bits, final_int_bits);
 
     // Use N for both dimensions if M is not provided
     nb::tuple shape = M ? nb::make_tuple(N, M.value()) : nb::make_tuple(N, N);

--- a/src/apyfixedarray.h
+++ b/src/apyfixedarray.h
@@ -318,6 +318,47 @@ public:
         std::optional<int> bits = std::nullopt
     );
 
+    /* ****************************************************************************** *
+     *                     Static methods for array initialization                    *
+     * ****************************************************************************** */
+
+    //! Create an `APyFixedArray` initialized with zeros
+    static APyFixedArray zeros(
+        const nb::tuple& shape,
+        std::optional<int> int_bits = std::nullopt,
+        std::optional<int> frac_bits = std::nullopt,
+        std::optional<int> bits = std::nullopt
+    );
+    //! Create an `APyFixedArray` initialized with ones
+    static APyFixedArray ones(
+        const nb::tuple& shape,
+        std::optional<int> int_bits = std::nullopt,
+        std::optional<int> frac_bits = std::nullopt,
+        std::optional<int> bits = std::nullopt
+    );
+
+    //! Create an `APyFixedArray` with ones on the diagonal and zeros elsewhere
+    static APyFixedArray
+    eye(const nb::int_& N,
+        std::optional<nb::int_> M = std::nullopt,
+        std::optional<int> int_bits = std::nullopt,
+        std::optional<int> frac_bits = std::nullopt,
+        std::optional<int> bits = std::nullopt);
+
+    //! Create a square `APyFixedArray` with ones on the diagonal and zeros elsewhere
+    static APyFixedArray identity(
+        const nb::int_& N,
+        std::optional<int> int_bits = std::nullopt,
+        std::optional<int> frac_bits = std::nullopt,
+        std::optional<int> bits = std::nullopt
+    );
+
+    //! Create an `APyFixedArray` initialized with a specified fill value
+    static APyFixedArray full(const nb::tuple& shape, const APyFixed& fill_value);
+
+    //! Create an `APyFixedArray` with a specified diagonal value
+    static APyFixedArray diagonal(const nb::tuple& shape, const APyFixed& fill_value);
+
 private:
     /* ****************************************************************************** *
      * *                          Private member functions                          * *

--- a/src/apyfixedarray_wrapper.cc
+++ b/src/apyfixedarray_wrapper.cc
@@ -1093,14 +1093,21 @@ void bind_fixed_array(nb::module_& m)
             R"pbdoc(
         Initializes an array with zeros.
 
-        Parameters:
-            shape (tuple): Shape of the array.
-            int_bits (optional): Number of integer bits.
-            frac_bits (optional): Number of fractional bits.
-            bits (optional): Total number of bits.
+        Parameters
+        ----------
+        shape : tuple
+            Shape of the array.
+        int_bits : int, optional
+            Number of integer bits. Default is None.
+        frac_bits : int, optional
+            Number of fractional bits. Default is None.
+        bits : int, optional
+            Total number of bits. Default is None.
 
-        Returns:
-            APyFixedArray: An array initialized with zeros.
+        Returns
+        -------
+        APyFixedArray
+            An array initialized with zeros.
     )pbdoc"
         )
         .def_static(
@@ -1113,14 +1120,21 @@ void bind_fixed_array(nb::module_& m)
             R"pbdoc(
         Initializes an array with ones.
 
-        Parameters:
-            shape (tuple): Shape of the array.
-            int_bits (optional): Number of integer bits.
-            frac_bits (optional): Number of fractional bits.
-            bits (optional): Total number of bits.
+        Parameters
+        ----------
+        shape : tuple
+            Shape of the array.
+        int_bits : int, optional
+            Number of integer bits. Default is None.
+        frac_bits : int, optional
+            Number of fractional bits. Default is None.
+        bits : int, optional
+            Total number of bits. Default is None.
 
-        Returns:
-            APyFixedArray: An array initialized with ones.
+        Returns
+        -------
+        APyFixedArray
+            An array initialized with ones.
     )pbdoc"
         )
         .def_static(
@@ -1132,17 +1146,25 @@ void bind_fixed_array(nb::module_& m)
             nb::arg("frac_bits") = nb::none(),
             nb::arg("bits") = nb::none(),
             R"pbdoc(
-        Initializes an array with the specified value on the diagonal.
+        Initializes an array with ones on the diagonal.
 
-        Parameters:
-            n : number of rows.
-            m (optional) : number of columns.
-            int_bits (optional): Number of integer bits.
-            frac_bits (optional): Number of fractional bits.
-            bits (optional): Total number of bits.
+        Parameters
+        ----------
+        n : int
+            Number of rows.
+        m : int, optional
+            Number of columns. Default is None.
+        int_bits : int, optional
+            Number of integer bits. Default is None.
+        frac_bits : int, optional
+            Number of fractional bits. Default is None.
+        bits : int, optional
+            Total number of bits. Default is None.
 
-        Returns:
-            APyFixedArray: An array with the specified value on the diagonal.
+        Returns
+        -------
+        APyFixedArray
+            An array with the specified value on the diagonal.
     )pbdoc"
         )
         .def_static(
@@ -1153,16 +1175,23 @@ void bind_fixed_array(nb::module_& m)
             nb::arg("frac_bits") = nb::none(),
             nb::arg("bits") = nb::none(),
             R"pbdoc(
-        Initializes an identity matrix with decimal one on the diagonal.
+        Initializes an identity matrix with ones on the diagonal.
 
-        Parameters:
-            n : Number of rows (and columns) in n x n output.
-            int_bits (optional): Number of integer bits.
-            frac_bits (optional): Number of fractional bits.
-            bits (optional): Total number of bits.
+        Parameters
+        ----------
+        n : int
+            Number of rows (and columns) in n x n output.
+        int_bits : int, optional
+            Number of integer bits. Default is None.
+        frac_bits : int, optional
+            Number of fractional bits. Default is None.
+        bits : int, optional
+            Total number of bits. Default is None.
 
-        Returns:
-            APyFixedArray: An identity matrix with decimal one on the diagonal.
+        Returns
+        -------
+        APyFixedArray
+            An identity matrix with ones on the diagonal.
     )pbdoc"
         )
         .def_static(
@@ -1173,12 +1202,17 @@ void bind_fixed_array(nb::module_& m)
             R"pbdoc(
         Initializes an array with the specified value.
 
-        Parameters:
-            shape (tuple): Shape of the array.
-            fill_value (APyFixed): Value to fill the array.
+        Parameters
+        ----------
+        shape : tuple
+            Shape of the array.
+        fill_value : APyFixed
+            Value to fill the array.
 
-        Returns:
-            APyFixedArray: An array filled with the specified value.
+        Returns
+        -------
+        APyFixedArray
+            An array filled with the specified value.
     )pbdoc"
         )
 

--- a/src/apyfixedarray_wrapper.cc
+++ b/src/apyfixedarray_wrapper.cc
@@ -302,27 +302,6 @@ void bind_fixed_array(nb::module_& m)
         :class:`APyFixedArray`
              )pbdoc")
 
-        .def("ravel", &APyFixedArray::ravel, R"pbdoc(
-        Return a copy of the array collapsed into one dimension. Same as flatten with
-        current memory-copy model.
-
-
-        Examples
-        --------
-        >>> from apytypes import APyFixedArray
-        >>> arr = APyFixedArray([[2, 3], [4, 5]], int_bits=2, frac_bits=1)
-        >>> arr.to_numpy()
-        array([[ 1. ,  1.5],
-               [-2. , -1.5]])
-
-        >>> arr.ravel().to_numpy()
-        array([ 1. ,  1.5, -2. , -1.5])
-
-        Returns
-        -------
-        :class:`APyFixedArray`
-             )pbdoc")
-
         .def("flatten", &APyFixedArray::flatten, R"pbdoc(
         Return a copy of the array collapsed into one dimension.
 

--- a/src/apyfixedarray_wrapper.cc
+++ b/src/apyfixedarray_wrapper.cc
@@ -302,6 +302,27 @@ void bind_fixed_array(nb::module_& m)
         :class:`APyFixedArray`
              )pbdoc")
 
+        .def("ravel", &APyFixedArray::ravel, R"pbdoc(
+        Return a copy of the array collapsed into one dimension. Same as flatten with
+        current memory-copy model.
+
+
+        Examples
+        --------
+        >>> from apytypes import APyFixedArray
+        >>> arr = APyFixedArray([[2, 3], [4, 5]], int_bits=2, frac_bits=1)
+        >>> arr.to_numpy()
+        array([[ 1. ,  1.5],
+               [-2. , -1.5]])
+
+        >>> arr.ravel().to_numpy()
+        array([ 1. ,  1.5, -2. , -1.5])
+
+        Returns
+        -------
+        :class:`APyFixedArray`
+             )pbdoc")
+
         .def("flatten", &APyFixedArray::flatten, R"pbdoc(
         Return a copy of the array collapsed into one dimension.
 
@@ -1082,6 +1103,104 @@ void bind_fixed_array(nb::module_& m)
             -------
             :class:`APyFixedArray`
             )pbdoc"
+        )
+        .def_static(
+            "zeros",
+            &APyFixedArray::zeros,
+            nb::arg("shape"),
+            nb::arg("int_bits") = nb::none(),
+            nb::arg("frac_bits") = nb::none(),
+            nb::arg("bits") = nb::none(),
+            R"pbdoc(
+        Initializes an array with zeros.
+
+        Parameters:
+            shape (tuple): Shape of the array.
+            int_bits (optional): Number of integer bits.
+            frac_bits (optional): Number of fractional bits.
+            bits (optional): Total number of bits.
+
+        Returns:
+            APyFixedArray: An array initialized with zeros.
+    )pbdoc"
+        )
+        .def_static(
+            "ones",
+            &APyFixedArray::ones,
+            nb::arg("shape"),
+            nb::arg("int_bits") = nb::none(),
+            nb::arg("frac_bits") = nb::none(),
+            nb::arg("bits") = nb::none(),
+            R"pbdoc(
+        Initializes an array with ones.
+
+        Parameters:
+            shape (tuple): Shape of the array.
+            int_bits (optional): Number of integer bits.
+            frac_bits (optional): Number of fractional bits.
+            bits (optional): Total number of bits.
+
+        Returns:
+            APyFixedArray: An array initialized with ones.
+    )pbdoc"
+        )
+        .def_static(
+            "eye",
+            &APyFixedArray::eye,
+            nb::arg("n"),
+            nb::arg("m") = nb::none(),
+            nb::arg("int_bits") = nb::none(),
+            nb::arg("frac_bits") = nb::none(),
+            nb::arg("bits") = nb::none(),
+            R"pbdoc(
+        Initializes an array with the specified value on the diagonal.
+
+        Parameters:
+            n : number of rows.
+            m (optional) : number of columns.
+            int_bits (optional): Number of integer bits.
+            frac_bits (optional): Number of fractional bits.
+            bits (optional): Total number of bits.
+
+        Returns:
+            APyFixedArray: An array with the specified value on the diagonal.
+    )pbdoc"
+        )
+        .def_static(
+            "identity",
+            &APyFixedArray::identity,
+            nb::arg("n"),
+            nb::arg("int_bits") = nb::none(),
+            nb::arg("frac_bits") = nb::none(),
+            nb::arg("bits") = nb::none(),
+            R"pbdoc(
+        Initializes an identity matrix with decimal one on the diagonal.
+
+        Parameters:
+            n : Number of rows (and columns) in n x n output.
+            int_bits (optional): Number of integer bits.
+            frac_bits (optional): Number of fractional bits.
+            bits (optional): Total number of bits.
+
+        Returns:
+            APyFixedArray: An identity matrix with decimal one on the diagonal.
+    )pbdoc"
+        )
+        .def_static(
+            "full",
+            &APyFixedArray::full,
+            nb::arg("shape"),
+            nb::arg("fill_value"),
+            R"pbdoc(
+        Initializes an array with the specified value.
+
+        Parameters:
+            shape (tuple): Shape of the array.
+            fill_value (APyFixed): Value to fill the array.
+
+        Returns:
+            APyFixedArray: An array filled with the specified value.
+    )pbdoc"
         )
 
         /*

--- a/src/apyfloat_util.h
+++ b/src/apyfloat_util.h
@@ -5,6 +5,8 @@
 #include "apyfixed_util.h"
 #include "apyfloat.h"
 #include "apytypes_common.h"
+#include <optional>
+#include <vector>
 
 /*!
  * Sizes of APyFloat datatypes
@@ -52,6 +54,18 @@ calc_bias(int new_exp_bits, int exp_bits1, exp_t bias1, int exp_bits2, exp_t bia
 exp_t calc_bias_general(
     int new_exp_bits, int exp_bits1, exp_t bias1, int exp_bits2, exp_t bias2
 );
+
+//! Get bit pattern for the value one
+static APY_INLINE APyFloat
+one(std::uint8_t exp_bits,
+    std::uint8_t man_bits,
+    std::optional<exp_t> bias = std::nullopt)
+{
+    APyFloat result(exp_bits, man_bits, bias.value_or(APyFloat::ieee_bias(exp_bits)));
+    APyFloatData data = { 0, result.get_bias(), 0 };
+    result.set_data(data);
+    return result;
+}
 
 //! Quantize mantissa
 APY_INLINE void quantize_mantissa(

--- a/src/apyfloatarray.h
+++ b/src/apyfloatarray.h
@@ -96,6 +96,43 @@ public:
     void _set_values_from_ndarray(const nanobind::ndarray<nanobind::c_contig>& ndarray);
 
     /* ****************************************************************************** *
+     *                     Static methods for array initialization                    *
+     * ****************************************************************************** */
+
+    static APyFloatArray zeros(
+        const nb::tuple& shape,
+        std::uint8_t exp_bits,
+        std::uint8_t man_bits,
+        std::optional<exp_t> bias = std::nullopt
+    );
+
+    static APyFloatArray ones(
+        const nb::tuple& shape,
+        std::uint8_t exp_bits,
+        std::uint8_t man_bits,
+        std::optional<exp_t> bias = std::nullopt
+    );
+
+    static APyFloatArray
+    eye(const nb::int_& N,
+        std::uint8_t exp_bits,
+        std::uint8_t man_bits,
+        std::optional<nb::int_> M,
+        std::optional<exp_t> bias = std::nullopt);
+
+    static APyFloatArray identity(
+        const nb::int_& N,
+        std::uint8_t exp_bits,
+        std::uint8_t man_bits,
+        std::optional<exp_t> bias = std::nullopt
+    );
+
+    //! Create an `APyFloatArray` initialized with a specified fill value
+    static APyFloatArray full(const nb::tuple& shape, const APyFloat& fill_value);
+
+    static APyFloatArray diagonal(const nb::tuple& shape, const APyFloat& fill_value);
+
+    /* ****************************************************************************** *
      * *                          Public member functions                           * *
      * ****************************************************************************** */
 

--- a/src/apyfloatarray_wrapper.cc
+++ b/src/apyfloatarray_wrapper.cc
@@ -513,14 +513,24 @@ void bind_float_array(nb::module_& m)
             nb::arg("man_bits"),
             nb::arg("bias") = std::nullopt,
             R"pbdoc(
-        Initializes an array with the specified value.
 
-        Parameters:
-            shape (tuple): Shape of the array.
-            fill_value (APyFloat): Value to fill the array.
+            Initializes an array with zeros.
 
-        Returns:
-            APyFixedArray: An array filled with the specified value.
+            Parameters
+            ----------
+            shape : tuple
+                Shape of the array.
+            exp_bits : int
+                Number of exponent bits.
+            man_bits : int
+                Number of mantissa bits.
+            bias : optional
+                Set bias. Default is None.
+
+            Returns
+            -------
+            APyFloatArray
+                An array filled with zeros.
     )pbdoc"
         )
         .def_static(
@@ -531,14 +541,23 @@ void bind_float_array(nb::module_& m)
             nb::arg("man_bits"),
             nb::arg("bias") = std::nullopt,
             R"pbdoc(
-        Initializes an array with the specified value.
+        Initializes an array with ones.
 
-        Parameters:
-            shape (tuple): Shape of the array.
-            fill_value (APyFloat): Value to fill the array.
+        Parameters
+        ----------
+        shape : tuple
+            Shape of the array.
+        exp_bits : int
+            Number of exponent bits.
+        man_bits : int
+            Number of mantissa bits.
+        bias : optional
+            Set bias. Default is None.
 
-        Returns:
-            APyFixedArray: An array filled with the specified value.
+        Returns
+        -------
+        APyFloatArray
+            An array filled with ones.
     )pbdoc"
         )
         .def_static(
@@ -550,14 +569,25 @@ void bind_float_array(nb::module_& m)
             nb::arg("m") = nb::none(),
             nb::arg("bias") = std::nullopt,
             R"pbdoc(
-        Initializes an array with the specified value.
+        Initializes an array with ones on the diagonal.
 
-        Parameters:
-            shape (tuple): Shape of the array.
-            fill_value (APyFloat): Value to fill the array.
+        Parameters
+        ----------
+        n : int
+            Number of rows (and columns) in the n x n output.
+        exp_bits : int
+            Number of exponent bits.
+        man_bits : int
+            Number of mantissa bits.
+        m : int, optional
+            Number of columns. Default is None, which results in an n x n output.
+        bias : optional
+            Set bias. Default is None.
 
-        Returns:
-            APyFixedArray: An array filled with the specified value.
+        Returns
+        -------
+        APyFloatArray
+            An array with the specified value on the diagonal.
     )pbdoc"
         )
         .def_static(
@@ -568,14 +598,23 @@ void bind_float_array(nb::module_& m)
             nb::arg("man_bits"),
             nb::arg("bias") = std::nullopt,
             R"pbdoc(
-        Initializes an array with the specified value.
+        Initializes an identity matrix with ones on the diagonal.
 
-        Parameters:
-            shape (tuple): Shape of the array.
-            fill_value (APyFloat): Value to fill the array.
+        Parameters
+        ----------
+        n : int
+            Number of rows (and columns) in the n x n output.
+        exp_bits : int
+            Number of exponent bits.
+        man_bits : int
+            Number of mantissa bits.
+        bias : optional
+            Set bias. Default is None.
 
-        Returns:
-            APyFixedArray: An array filled with the specified value.
+        Returns
+        -------
+        APyFloatArray
+            An identity matrix with ones on the diagonal.
     )pbdoc"
         )
         .def_static(
@@ -584,17 +623,21 @@ void bind_float_array(nb::module_& m)
             nb::arg("shape"),
             nb::arg("fill_value"),
             R"pbdoc(
-        Initializes an array with the specified value.
+        Initializes an array filled with the specified value.
 
-        Parameters:
-            shape (tuple): Shape of the array.
-            fill_value (APyFloat): Value to fill the array.
+        Parameters
+        ----------
+        shape : tuple
+            Shape of the array.
+        fill_value : APyFloat
+            Value to fill the array.
 
-        Returns:
-            APyFixedArray: An array filled with the specified value.
+        Returns
+        -------
+        APyFloatArray
+            An array filled with the specified value.
     )pbdoc"
         )
-
         /*
          * Dunder methods
          */

--- a/src/apyfloatarray_wrapper.cc
+++ b/src/apyfloatarray_wrapper.cc
@@ -505,6 +505,95 @@ void bind_float_array(nb::module_& m)
             :class:`APyFloatArray`
             )pbdoc"
         )
+        .def_static(
+            "zeros",
+            &APyFloatArray::zeros,
+            nb::arg("shape"),
+            nb::arg("exp_bits"),
+            nb::arg("man_bits"),
+            nb::arg("bias") = std::nullopt,
+            R"pbdoc(
+        Initializes an array with the specified value.
+
+        Parameters:
+            shape (tuple): Shape of the array.
+            fill_value (APyFloat): Value to fill the array.
+
+        Returns:
+            APyFixedArray: An array filled with the specified value.
+    )pbdoc"
+        )
+        .def_static(
+            "ones",
+            &APyFloatArray::ones,
+            nb::arg("shape"),
+            nb::arg("exp_bits"),
+            nb::arg("man_bits"),
+            nb::arg("bias") = std::nullopt,
+            R"pbdoc(
+        Initializes an array with the specified value.
+
+        Parameters:
+            shape (tuple): Shape of the array.
+            fill_value (APyFloat): Value to fill the array.
+
+        Returns:
+            APyFixedArray: An array filled with the specified value.
+    )pbdoc"
+        )
+        .def_static(
+            "eye",
+            &APyFloatArray::eye,
+            nb::arg("n"),
+            nb::arg("exp_bits"),
+            nb::arg("man_bits"),
+            nb::arg("m") = nb::none(),
+            nb::arg("bias") = std::nullopt,
+            R"pbdoc(
+        Initializes an array with the specified value.
+
+        Parameters:
+            shape (tuple): Shape of the array.
+            fill_value (APyFloat): Value to fill the array.
+
+        Returns:
+            APyFixedArray: An array filled with the specified value.
+    )pbdoc"
+        )
+        .def_static(
+            "identity",
+            &APyFloatArray::identity,
+            nb::arg("n"),
+            nb::arg("exp_bits"),
+            nb::arg("man_bits"),
+            nb::arg("bias") = std::nullopt,
+            R"pbdoc(
+        Initializes an array with the specified value.
+
+        Parameters:
+            shape (tuple): Shape of the array.
+            fill_value (APyFloat): Value to fill the array.
+
+        Returns:
+            APyFixedArray: An array filled with the specified value.
+    )pbdoc"
+        )
+        .def_static(
+            "full",
+            &APyFloatArray::full,
+            nb::arg("shape"),
+            nb::arg("fill_value"),
+            R"pbdoc(
+        Initializes an array with the specified value.
+
+        Parameters:
+            shape (tuple): Shape of the array.
+            fill_value (APyFloat): Value to fill the array.
+
+        Returns:
+            APyFixedArray: An array filled with the specified value.
+    )pbdoc"
+        )
 
         /*
          * Dunder methods

--- a/src/array_utils.h
+++ b/src/array_utils.h
@@ -63,6 +63,20 @@ shape_from_tuple(nb::tuple new_shape, size_t elem_count)
     return new_shape_vec;
 }
 
+static APY_INLINE std::vector<std::size_t> shape_from_tuple(nb::tuple new_shape)
+{
+    std::vector<std::size_t> new_shape_vec;
+    for (auto it = new_shape.begin(); it != new_shape.end(); ++it) {
+        int current_value = nb::cast<int>(*it);
+        if (current_value < 0) {
+            throw nb::value_error("Negative dimensions or are not allowed.");
+        } else {
+            new_shape_vec.push_back(static_cast<std::size_t>(current_value));
+        }
+    }
+    return new_shape_vec;
+}
+
 /**
  * @brief Converts the provided axes into a vector of positive indices.
  *


### PR DESCRIPTION
<!--
Thank you so much for your PR!
-->

# PR Summary
<!-- Please provide at least 1-2 sentences describing the pull request in detail
(Why is this change required?  What problem does it solve?) and link to relevant
issues and PRs.
-->
Added several basic array creation methods. If an integer or float is used for the full function, word lengths must be defined. For functions like ones, I removed the parameter for input data type (e.g., APyFloatArray). Instead, the user must specify exp_bits and mantissa_bits or int_bits and frac_bits to decide return type of array.

# PR Checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

- [x] "closes "from shape and value" in #485
- [x] new and changed code is tested
- [x] relevant changes added to [CHANGELOG.md](https://github.com/apytypes/apytypes/blob/main/CHANGELOG.md)
- [x] new functionality is documented
