### PR TITLE
No longer consider zero a subnormal number

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed bug where `APyFixedArray.from_array()` initialized the wrong stored
   value from floating-point values that are too small for its representation.
   (#487)
+- No longer consider zero a subnormal number.
 
 ### Removed
 

--- a/lib/apytypes/_apytypes.pyi
+++ b/lib/apytypes/_apytypes.pyi
@@ -1694,8 +1694,6 @@ class APyFloat:
         """
         True if and only if value is subnormal.
 
-        Zero is considered subnormal.
-
         Returns
         -------
         :class:`bool`

--- a/lib/test/apyfloat/test_methods.py
+++ b/lib/test/apyfloat/test_methods.py
@@ -368,7 +368,7 @@ def test_properties():
     a = APyFloat(0, 0, 0, 5, 2)
     assert a.is_finite
     assert not a.is_normal
-    assert a.is_subnormal
+    assert not a.is_subnormal
     assert not a.is_nan
     assert not a.is_inf
     assert a.is_zero

--- a/src/apyfloat.cc
+++ b/src/apyfloat.cc
@@ -278,7 +278,7 @@ APyFloat APyFloat::_checked_cast(
 
     // Normalize the exponent and mantissa if converting from a subnormal
     man_t prev_man = man;
-    if (is_subnormal()) {
+    if (is_zero_exponent()) {
         const exp_t subn_adjustment = count_trailing_bits(man);
         new_exp = new_exp - man_bits + subn_adjustment;
         const man_t remainder = man % (1ULL << subn_adjustment);
@@ -391,7 +391,7 @@ APyFloat APyFloat::_cast_to_double() const
 
     // Normalize the exponent and mantissa if convertering from a subnormal
     man_t prev_man = man;
-    if (is_subnormal()) {
+    if (is_zero_exponent()) {
         const exp_t subn_adjustment = count_trailing_bits(man);
         new_exp = new_exp - man_bits + subn_adjustment;
         const man_t remainder = man % (1ULL << subn_adjustment);
@@ -478,7 +478,7 @@ APyFloat APyFloat::cast_from_double(
 
     // Normalize the exponent and mantissa if convertering from a subnormal
     man_t prev_man;
-    if (is_subnormal()) {
+    if (is_zero_exponent()) {
         const exp_t subn_adjustment = count_trailing_bits(man);
         new_exp = (std::int64_t)exp - 1074 + (std::int64_t)res.bias + subn_adjustment;
         const man_t remainder = man % (1ULL << subn_adjustment);
@@ -576,7 +576,7 @@ APyFloat APyFloat::cast_no_quant(
 
     // Normalize the exponent and mantissa if convertering from a subnormal
     man_t prev_man = man;
-    if (is_subnormal()) {
+    if (is_zero_exponent()) {
         const exp_t subn_adjustment = count_trailing_bits(man);
         new_exp = new_exp - man_bits + subn_adjustment;
         const man_t remainder = man % (1ULL << subn_adjustment);
@@ -1034,14 +1034,14 @@ APyFloat& APyFloat::operator+=(const APyFloat& rhs)
     }
 
     // Compute smaller exponent so that one can overwrite exp later
-    const exp_t smaller_exp = y->exp + y->is_subnormal();
+    const exp_t smaller_exp = y->exp + y->is_zero_exponent();
 
     // Conditionally add leading one's
     const man_t mx = x->true_man();
     const man_t my = y->true_man();
 
     // Tentative exponent, write directly
-    exp = x->exp + x->is_subnormal();
+    exp = x->exp + x->is_zero_exponent();
 
     // Align mantissas based on exponent difference
     const unsigned exp_delta = exp - smaller_exp;
@@ -1684,7 +1684,7 @@ APyFloat::construct_nan(std::optional<bool> new_sign, man_t payload /*= 1*/) con
 //! Add mantissa bits so that a number is no longer subnormal
 APyFloat APyFloat::normalized() const
 {
-    if (!is_subnormal() || is_zero()) {
+    if (!is_subnormal()) {
         return *this;
     }
 

--- a/src/apyfloat.h
+++ b/src/apyfloat.h
@@ -251,17 +251,19 @@ public:
      */
 
     //! True if and only if value is normal (not zero, subnormal, infinite, or NaN).
-    APY_INLINE bool is_normal() const { return !is_subnormal() && !is_max_exponent(); }
+    APY_INLINE bool is_normal() const
+    {
+        return !is_zero_exponent() && !is_max_exponent();
+    }
 
     //! True if and only if value is zero, subnormal, or normal.
     APY_INLINE bool is_finite() const { return is_subnormal() || !is_max_exponent(); }
 
-    //! True if and only if value is subnormal. Zero is also considered a subnormal
-    //! number.
-    APY_INLINE bool is_subnormal() const { return exp == 0; }
+    //! True if and only if value is subnormal.
+    APY_INLINE bool is_subnormal() const { return is_zero_exponent() && man != 0; }
 
     //! True if and only if value is zero.
-    APY_INLINE bool is_zero() const { return is_subnormal() && man == 0; }
+    APY_INLINE bool is_zero() const { return is_zero_exponent() && man == 0; }
 
     //! True if and only if value is NaN.
     APY_INLINE bool is_nan() const { return man != 0 && is_max_exponent(); }
@@ -271,6 +273,9 @@ public:
 
     //! True if and only if value is infinite or NaN.
     APY_INLINE bool is_max_exponent() const { return exp == max_exponent(); }
+
+    //! True if and only if value is zero or subnormal.
+    APY_INLINE bool is_zero_exponent() const { return exp == 0; }
 
     //! Return the stored sign
     APY_INLINE bool get_sign() const { return sign; }

--- a/src/apyfloat_util.h
+++ b/src/apyfloat_util.h
@@ -240,7 +240,7 @@ void check_mantissa_format(int man_bits);
     return src.exp == 0 && src.man == 0;
 }
 
-[[maybe_unused]] static APY_INLINE bool is_subnormal(const APyFloatData& src)
+[[maybe_unused]] static APY_INLINE bool is_zero_exponent(const APyFloatData& src)
 {
     return src.exp == 0;
 }
@@ -262,13 +262,13 @@ template <typename APYFLOAT_TYPE>
 [[maybe_unused]] static APY_INLINE bool
 is_normal(const APyFloatData& src, const APYFLOAT_TYPE& ref)
 {
-    return !is_subnormal(src) && !is_max_exponent(src, ref);
+    return !is_zero_exponent(src) && !is_max_exponent(src, ref);
 }
 
 [[maybe_unused]] static APY_INLINE bool
 is_normal(const APyFloatData& src, uint8_t exp_bits)
 {
-    return !is_subnormal(src) && !is_max_exponent(src, exp_bits);
+    return !is_zero_exponent(src) && !is_max_exponent(src, exp_bits);
 }
 
 template <typename APYFLOAT_TYPE>
@@ -289,7 +289,7 @@ template <typename APYFLOAT_TYPE>
 [[maybe_unused]] static APY_INLINE std::int64_t
 true_exp(const APyFloatData& src, const APYFLOAT_TYPE& ref)
 {
-    return std::int64_t(src.exp) - std::int64_t(ref.get_bias()) + is_subnormal(src);
+    return std::int64_t(src.exp) - std::int64_t(ref.get_bias()) + is_zero_exponent(src);
 }
 
 template <typename APYFLOAT_TYPE>
@@ -310,7 +310,7 @@ template <typename APYFLOAT_TYPE>
 [[maybe_unused]] static APY_INLINE std::tuple<APyFloatData, uint8_t, exp_t>
 normalize(const APyFloatData& src, const APYFLOAT_TYPE& ref)
 {
-    if (!is_subnormal(src) || is_zero(src)) {
+    if (!(is_zero_exponent(src) && src.man != 0)) { // if not subnormal
         return { src, ref.get_exp_bits(), ref.get_bias() };
     }
 

--- a/src/apyfloat_wrapper.cc
+++ b/src/apyfloat_wrapper.cc
@@ -454,8 +454,6 @@ void bind_float(nb::module_& m)
         .def_prop_ro("is_subnormal", &APyFloat::is_subnormal, R"pbdoc(
             True if and only if value is subnormal.
 
-            Zero is considered subnormal.
-
             Returns
             -------
             :class:`bool`


### PR DESCRIPTION
<!--
Thank you so much for your PR!
-->

# PR Summary
<!-- Please provide at least 1-2 sentences describing the pull request in detail
(Why is this change required?  What problem does it solve?) and link to relevant
issues and PRs.
-->
Zero was previously considered a subnormal number in APyFloat, however this is not the case in the IEEE 754 standard. This PR fixes that.

From the standard:
***"subnormal number:** In a particular format, a non-zero floating-point number with magnitude less than the magnitude of that format’s smallest normal number. A subnormal number does not use the full precision available to normal numbers of the same format."*

# PR Checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

- [N/A] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] new and changed code is tested
- [x] relevant changes added to [CHANGELOG.md](https://github.com/apytypes/apytypes/blob/main/CHANGELOG.md)
- [x] new functionality is documented
