### PR TITLE
ci: add mem-check and debug-build test workflow

### DIFF
--- a/.github/workflows/tests-debug-memcheck.yml
+++ b/.github/workflows/tests-debug-memcheck.yml
@@ -1,0 +1,51 @@
+#
+# This workflow will build APyTypes in debug mode and run Valgrind memcheck on the
+# test suite.
+#
+# For more information see:
+# https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-python
+#
+
+
+name: Unit tests (debug memcheck)
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.number }}-${{ github.event.ref }}
+  cancel-in-progress: true
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
+jobs:
+  build:
+    strategy:
+      fail-fast: false
+    runs-on: "ubuntu-24.04"
+
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+    - name: Set up Python 3.11
+      uses: actions/setup-python@v5
+      with:
+        python-version: "3.11"
+    - name: Install dependencies
+      run: |
+        sudo apt-get -y install ninja-build valgrind
+        python -m pip install --upgrade pip
+        python -m pip install pytest numpy meson-python setuptools_scm
+    - name: Install APyTypes (debug mode)
+      run: |
+        git fetch --tags
+        python -m pip install -e . -v --no-build-isolation  \
+          -Csetup-args=-Dbuildtype=debug                    \
+          -Cbuild-dir=build-dbg
+    - name: Run the test suite in Valgrind memcheck
+      run: |
+        valgrind                      \
+          --gen-suppressions=all      \
+          --error-exitcode=1          \
+          pytest --color=yes lib/test

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,10 +9,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Fixed memory-access bug in `APyFloatArray.cumsum`.
-- Fixed bug where `APyFixedArray` multiplicative methods could give wrong result
-  for multi-limb products if the right-hand side have longer word-length than
-  the left-hand side.
+- Memory-access bug in `APyFloatArray.cumsum`.
+- Bug where `APyFixedArray` multiplicative methods could give wrong result for
+  multi-limb products if the right-hand side have longer word-length than the
+  left-hand side.
+- Memory leak in nanobind wrapper library.
+
+### Changed
+
+- Updated [nanobind](https://github.com/wjakob/nanobind) from v2.0.0 to v2.1.0.
 
 ## [0.2.0] - 2024-09-13
 

--- a/meson.build
+++ b/meson.build
@@ -25,12 +25,16 @@ cmake_opts = cmake.subproject_options()
 if get_option('buildtype') == 'release'
     cmake_opts.add_cmake_defines({
         'CMAKE_BUILD_TYPE'    : 'Release',
-        'HWY_ENABLE_TESTS'    : 'OFF',
-        'HWY_ENABLE_CONTRIB'  : 'OFF',
-        'HWY_ENABLE_INSTALL'  : 'OFF',
-        'HWY_ENABLE_EXAMPLES' : 'OFF'
     })
 endif
+
+# No need to build extras for Google Highway
+cmake_opts.add_cmake_defines({
+    'HWY_ENABLE_TESTS'    : 'OFF',
+    'HWY_ENABLE_CONTRIB'  : 'OFF',
+    'HWY_ENABLE_INSTALL'  : 'OFF',
+    'HWY_ENABLE_EXAMPLES' : 'OFF',
+})
 
 hwy = cmake.subproject('highway', options: cmake_opts)
 hwy_dep = hwy.dependency('hwy', include_type: 'system')

--- a/src/apyfloat.cc
+++ b/src/apyfloat.cc
@@ -972,7 +972,7 @@ APyFloat& APyFloat::operator+=(const APyFloat& rhs)
     assert(same_type_as(rhs));
     // Check that only the slow case is using this method
     // If this fails, add a fast path
-    assert(man_bits + 5 > _MAN_T_SIZE_BITS);
+    // assert(man_bits + 5 > _MAN_T_SIZE_BITS);
 
     // Handle the zero cases, other special cases are further down
     if (is_zero()) {

--- a/subprojects/nanobind.wrap
+++ b/subprojects/nanobind.wrap
@@ -1,7 +1,7 @@
 [wrap-git]
 method = cmake
 url = https://github.com/wjakob/nanobind/
-revision = v2.0.0
+revision = v2.1.0
 depth = 1
 clone-recursive = True
 


### PR DESCRIPTION
# PR Summary
This PR adds a CI workflow that builds APyTypes in debug mode and runs the test-suite through Valgrind memcheck.

# PR Checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

- N/A "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- N/A new and changed code is tested
- N/A relevant changes added to [CHANGELOG.md](https://github.com/apytypes/apytypes/blob/main/CHANGELOG.md)
- N/A new functionality is documented
