### PR TITLE
Move common APyArray functions to APyBuffer

### DIFF
--- a/src/apyfixedarray.cc
+++ b/src/apyfixedarray.cc
@@ -1,12 +1,23 @@
-#include "nanobind/nanobind.h"
-#include <nanobind/ndarray.h>
-#include <nanobind/stl/variant.h> // std::variant (with nanobind support)
-#include <variant>
-namespace nb = nanobind;
-
 // Python details. These should be included before standard header files:
 // https://docs.python.org/3/c-api/intro.html#include-files
 #include <Python.h> // PYLONG_BITS_IN_DIGIT, PyLongObject
+
+#include "apybuffer.h"
+#include "apyfixed.h"
+#include "apyfixed_util.h"
+#include "apyfixedarray.h"
+#include "apytypes_common.h"
+#include "apytypes_simd.h"
+#include "apytypes_util.h"
+#include "array_utils.h"
+#include "broadcast.h"
+#include "python_util.h"
+
+// Python object access through Nanobind
+#include <nanobind/nanobind.h>
+#include <nanobind/ndarray.h>
+#include <nanobind/stl/variant.h> // std::variant (with nanobind support)
+namespace nb = nanobind;
 
 // Standard header includes
 #include <algorithm> // std::copy, std::max, std::transform, etc...
@@ -18,19 +29,8 @@ namespace nb = nanobind;
 #include <sstream>   // std::stringstream
 #include <stdexcept> // std::length_error
 #include <string>    // std::string
+#include <variant>   // std::variant
 #include <vector>    // std::vector, std::swap
-
-#include "apybuffer.h"
-#include "apyfixed.h"
-#include "apyfixed_util.h"
-#include "apyfixedarray.h"
-#include "apyfixedarray_iterator.h"
-#include "apytypes_common.h"
-#include "apytypes_simd.h"
-#include "apytypes_util.h"
-#include "array_utils.h"
-#include "broadcast.h"
-#include "python_util.h"
 
 #include <fmt/format.h>
 
@@ -75,9 +75,6 @@ APyFixedArray::APyFixedArray(
         _overflow_twos_complement(
             caster._data.begin(), caster._data.end(), _bits, _int_bits
         );
-        // caster._overflow_twos_complement(
-        //     caster._data.begin(), caster._data.end(), _bits, _int_bits
-        //);
         std::copy_n(
             caster._data.begin(),         // src
             _itemsize,                    // limbs to copy
@@ -1536,21 +1533,6 @@ APyFixedArray APyFixedArray::ravel() const
     // same as flatten as for now
     return this->flatten();
 }
-
-// The shape of the array
-nb::tuple APyFixedArray::python_get_shape() const
-{
-    nb::list result_list;
-    for (std::size_t i = 0; i < _shape.size(); i++) {
-        result_list.append(_shape[i]);
-    }
-    return nb::tuple(result_list);
-}
-
-// The dimension in the array
-size_t APyFixedArray::ndim() const noexcept { return _shape.size(); }
-
-size_t APyFixedArray::size() const noexcept { return _shape[0]; }
 
 APyFixedArray APyFixedArray::abs() const
 {

--- a/src/apyfixedarray.h
+++ b/src/apyfixedarray.h
@@ -5,15 +5,15 @@
 #ifndef _APYFIXED_ARRAY_H
 #define _APYFIXED_ARRAY_H
 
-#include <nanobind/nanobind.h>    // nanobind::object
-#include <nanobind/ndarray.h>     // nanobind::array_t
-#include <nanobind/stl/variant.h> // std::variant (with nanobind support)
-namespace nb = nanobind;
-
 #include "apybuffer.h"
 #include "apyfixed.h"
 #include "apytypes_common.h"
 #include "apytypes_util.h"
+
+#include <nanobind/nanobind.h>    // nanobind::object
+#include <nanobind/ndarray.h>     // nanobind::array_t
+#include <nanobind/stl/variant.h> // std::variant (with nanobind support)
+namespace nb = nanobind;
 
 #include <cstddef>  // std::size_t
 #include <limits>   // std::numeric_limits<>::is_iec559
@@ -242,12 +242,6 @@ public:
     //! Same as flatten as for now
     APyFixedArray ravel() const;
 
-    //! Shape of the array
-    nb::tuple python_get_shape() const;
-
-    //! Number of dimensions
-    size_t ndim() const noexcept;
-
     //! Number of bits
     APY_INLINE int bits() const noexcept { return _bits; }
 
@@ -277,9 +271,6 @@ public:
 
     //! Convert to a NumPy array
     nb::ndarray<nb::numpy, double> to_numpy() const;
-
-    //! Length of the array
-    size_t size() const noexcept;
 
     //! Elementwise absolute value
     APyFixedArray abs() const;

--- a/src/apyfloatarray.h
+++ b/src/apyfloatarray.h
@@ -1,6 +1,7 @@
 #ifndef _APYFLOAT_ARRAY_H
 #define _APYFLOAT_ARRAY_H
 
+#include "apybuffer.h"
 #include "apyfloat.h"
 #include "apytypes_common.h"
 #include <cstdint>
@@ -10,7 +11,7 @@
 #include <optional>
 #include <vector>
 
-class APyFloatArray {
+class APyFloatArray : public APyBuffer<APyFloatData> {
 public:
     //! Constructor taking a sequence of signs, biased exponents, and mantissas.
     //! If no bias is given, an IEEE-like bias will be used.
@@ -22,8 +23,7 @@ public:
         std::uint8_t man_bits,
         std::optional<exp_t> bias = std::nullopt
     );
-    //! Vector with values
-    std::vector<APyFloatData> data;
+
     //! Number of exponent bits
     std::uint8_t exp_bits;
     //! Number of mantissa bits
@@ -261,17 +261,6 @@ public:
     //! Return the bit width of the entire floating-point format.
     APY_INLINE std::uint8_t get_bits() const { return exp_bits + man_bits + 1; }
 
-    //! Shape of the array
-    nanobind::tuple python_get_shape() const;
-
-    //! Number of dimensions
-    size_t get_ndim() const;
-
-    //! Length of the array
-    size_t get_size() const;
-
-    const std::vector<std::size_t>& get_shape() const noexcept { return shape; }
-
     /*!
      * Test if two `APyFloatArray` objects are identical. Two `APyFloatArray` objects
      * are considered identical if, and only if:
@@ -363,8 +352,9 @@ public:
     cast_to_bfloat16(std::optional<QuantizationMode> quantization = std::nullopt) const;
 
 private:
-    //! Default constructor
-    APyFloatArray() = default;
+    //! Default constructor (not available)
+    APyFloatArray() = delete;
+
     //! Constructor specifying only the shape and format of the array
     APyFloatArray(
         const std::vector<std::size_t>& shape,
@@ -372,7 +362,6 @@ private:
         std::uint8_t man_bits,
         std::optional<exp_t> bias = std::nullopt
     );
-    std::vector<std::size_t> shape;
 
     /*!
      * Evaluate the inner between two vectors. This method assumes that the the shape

--- a/src/apyfloatarray_iterator.cc
+++ b/src/apyfloatarray_iterator.cc
@@ -15,7 +15,7 @@ APyFloatArrayIterator::APyFloatArrayIterator(const APyFloatArray& array, nb::obj
 
 std::variant<APyFloatArray, APyFloat> APyFloatArrayIterator::next()
 {
-    if (index == array.get_size())
+    if (index == array.size())
         throw nb::stop_iteration();
     return array.get_item_integer(index++);
 }

--- a/src/apyfloatarray_wrapper.cc
+++ b/src/apyfloatarray_wrapper.cc
@@ -301,7 +301,7 @@ void bind_float_array(nb::module_& m)
             :class:`tuple` of :class:`int`
             )pbdoc")
 
-        .def_prop_ro("ndim", &APyFloatArray::get_ndim, R"pbdoc(
+        .def_prop_ro("ndim", &APyFloatArray::ndim, R"pbdoc(
             Number of dimensions in the array.
 
             Returns
@@ -696,7 +696,7 @@ void bind_float_array(nb::module_& m)
          */
         .def("__matmul__", &APyFloatArray::matmul, nb::arg("rhs"))
         .def("__repr__", &APyFloatArray::repr)
-        .def("__len__", &APyFloatArray::get_size)
+        .def("__len__", &APyFloatArray::size)
 
         .def("is_identical", &APyFloatArray::is_identical, nb::arg("other"), R"pbdoc(
             Test if two :class:`APyFloatArray` objects are identical.

--- a/src/apytypes_util.h
+++ b/src/apytypes_util.h
@@ -1197,15 +1197,15 @@ get_conv_lengths(const std::string& mode, const APY_ARRAY& a, const APY_ARRAY& b
 {
     std::size_t len, n_left, n_right;
     if (mode == "full") {
-        len = a->get_shape()[0] + b->get_shape()[0] - 1;
-        n_left = b->get_shape()[0] - 1;
-        n_right = b->get_shape()[0] - 1;
+        len = a->shape()[0] + b->shape()[0] - 1;
+        n_left = b->shape()[0] - 1;
+        n_right = b->shape()[0] - 1;
     } else if (mode == "same") {
-        len = a->get_shape()[0];
-        n_left = b->get_shape()[0] / 2;
-        n_right = b->get_shape()[0] - n_left - 1;
+        len = a->shape()[0];
+        n_left = b->shape()[0] / 2;
+        n_right = b->shape()[0] - n_left - 1;
     } else if (mode == "valid") {
-        len = a->get_shape()[0] - b->get_shape()[0] + 1;
+        len = a->shape()[0] - b->shape()[0] + 1;
         n_left = 0;
         n_right = 0;
     } else {


### PR DESCRIPTION
# PR Summary
Related issue #504

* [ ] `transpose`
* [ ] `rehsape`
* [ ] `flatten`
* [ ] `ravel`
* [ ] `swapaxes` 
* [ ] `squeeze`
* [ ] `get_item` (+ family of helpers)
* [x] `size`
* [x] `ndim`
* [x] `python_get_shape`
* [ ] `broadcast_to`
* [ ] `broadcast_to_python`
* [ ] `identity`
* [ ] `eye`
* [ ] `diagonal`
* [ ] `full`
* [ ] `zeros`
* [ ] `ones`

# PR Checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

- [ ] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [ ] new and changed code is tested
- N/A relevant changes added to [CHANGELOG.md](https://github.com/apytypes/apytypes/blob/main/CHANGELOG.md)
- N/A new functionality is documented
