### PR TITLE
`arange`: deduce array type based on arguments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- In `arange`, the array type can be deduced from its arguments if no bit-
+  specifiers are given.
+
 ### Fixed
 
 ### Changed

--- a/lib/apytypes/_array_functions.pyi
+++ b/lib/apytypes/_array_functions.pyi
@@ -18,13 +18,16 @@ def arange(
     * ``arange(start, stop)``: Values are generated within the half-open interval ``[start, stop)``.
     * ``arange(start, stop, step)``: Values are generated within the half-open interval ``[start, stop)``, with spacing between values given by ``step``.
 
+    If no bit-specifiers are given, the array type is deduced based on ``start``, ``stop``, and ``step``.
+    In this case, all APyTypes scalars must be of the same format.
+
     Parameters
     ----------
-    start : int, float
+    start : int, float, :class:`APyFloat`, :class:`APyFixed`
         Start number.
-    stop : int, optional
+    stop : int, float, :class:`APyFloat`, :class:`APyFixed`, optional
         Stop number.
-    step : int, float, optional
+    step : int, float, :class:`APyFloat`, :class:`APyFixed`, optional
         Step size in range.
     int_bits : int, optional
         Number of fixed-point integer bits.

--- a/lib/test/test_array_functions.py
+++ b/lib/test/test_array_functions.py
@@ -185,6 +185,13 @@ def test_eye(n, m, nums):
     check_eye(exp_bits=13, mantissa_bits=28)
     check_eye(exp_bits=16, mantissa_bits=5)
 
+    # Test raise
+    with pytest.raises(
+        ValueError,
+        match="Could not determine array type",
+    ):
+        eye((2, 2), int_bits=4, frac_bits=0, exp_bits=15)
+
 
 @pytest.mark.parametrize(
     "n, nums",
@@ -230,6 +237,13 @@ def test_identity(n, nums):
     check_identity(exp_bits=13, mantissa_bits=28)
     check_identity(exp_bits=16, mantissa_bits=5)
 
+    # Test raise
+    with pytest.raises(
+        ValueError,
+        match="Could not determine array type",
+    ):
+        identity(2, int_bits=4, frac_bits=0, exp_bits=15)
+
 
 @pytest.mark.parametrize("shape", [(i, j) for i in range(1, 5) for j in range(1, 5)])
 def test_zeros(shape):
@@ -268,6 +282,13 @@ def test_zeros(shape):
     check_zeros(exp_bits=13, mantissa_bits=28)
     check_zeros(exp_bits=13, mantissa_bits=0)
     check_zeros(exp_bits=16, mantissa_bits=5)
+
+    # Test raise
+    with pytest.raises(
+        ValueError,
+        match="Could not determine array type",
+    ):
+        zeros((2, 2), int_bits=4, frac_bits=0, exp_bits=15)
 
 
 def test_tuple_construction_raises():
@@ -366,6 +387,13 @@ def test_ones(shape):
     # Test cases for APyFloatArray
     check_ones(exp_bits=13, mantissa_bits=28)
     check_ones(exp_bits=16, mantissa_bits=5)
+
+    # Test raise
+    with pytest.raises(
+        ValueError,
+        match="Could not determine array type",
+    ):
+        ones((2, 2), int_bits=4, frac_bits=0, exp_bits=15)
 
 
 @pytest.mark.parametrize("shape", [(i, j) for i in range(1, 5) for j in range(1, 5)])
@@ -604,6 +632,18 @@ def test_arange():
         arange(
             APyFloat(0, 0, 0, 4, 4), APyFloat(0, 7, 0, 4, 4), APyFloat(0, 7, 0, 4, 4, 5)
         )
+
+    with pytest.raises(
+        ValueError,
+        match="Could not determine array type",
+    ):
+        arange(APyFloat(0, 0, 0, 4, 4), APyFloat(0, 7, 0, 4, 4), APyFixed(1, 4, 0))
+
+    with pytest.raises(
+        ValueError,
+        match="Could not determine array type",
+    ):
+        arange(APyFixed(1, 4, 0), 10, APyFloat(0, 7, 0, 4, 3))
 
     with pytest.raises(
         ValueError,

--- a/lib/test/test_array_functions.py
+++ b/lib/test/test_array_functions.py
@@ -573,6 +573,50 @@ def test_arange():
     ):
         arange("0", 10, 1, exp_bits=5, man_bits=10)
 
+    with pytest.raises(
+        ValueError,
+        match="Could not determine array type",
+    ):
+        arange(0, 10, 1)
+
+    with pytest.raises(
+        ValueError,
+        match="Could not determine array type",
+    ):
+        arange(0, 10, 1, exp_bits=5, man_bits=10, bits=10, int_bits=10)
+
+    with pytest.raises(
+        ValueError,
+        match="Could not determine array type",
+    ):
+        arange(APyFixed(1, 4, 0), 10, APyFixed(1, 4, 1))
+
+    with pytest.raises(
+        ValueError,
+        match="Could not determine array type",
+    ):
+        arange(APyFloat(0, 0, 0, 4, 4), APyFloat(0, 7, 0, 4, 3))
+
+    with pytest.raises(
+        ValueError,
+        match="Could not determine array type",
+    ):
+        arange(
+            APyFloat(0, 0, 0, 4, 4), APyFloat(0, 7, 0, 4, 4), APyFloat(0, 7, 0, 4, 4, 5)
+        )
+
+    with pytest.raises(
+        ValueError,
+        match="Could not determine array type",
+    ):
+        arange(10, exp_bits=5, man_bits=10, bits=20)
+
+    with pytest.raises(
+        ValueError,
+        match="Could not determine array type",
+    ):
+        arange(10, int_bits=5, frac_bits=10, bias=15)
+
     # Test basic functionality
     a = arange(10, int_bits=10, frac_bits=5)
     b = APyFixedArray.from_float(range(10), int_bits=10, frac_bits=5)
@@ -662,6 +706,87 @@ def test_arange():
         APyFloatArray.from_float(
             [2.0, 2.25, 2.5, 2.75, 3.0, 3.25, 3.5, 3.75], exp_bits=5, man_bits=5
         )
+    )
+
+    # Test deducing the array type when one input is given
+    a = arange(APyFixed.from_float(4, int_bits=5, frac_bits=0))
+    assert a.is_identical(APyFixedArray.from_float(range(4), int_bits=5, frac_bits=0))
+
+    a = arange(APyFloat.from_float(4, exp_bits=5, man_bits=4, bias=8))
+    assert a.is_identical(
+        APyFloatArray.from_float(range(4), exp_bits=5, man_bits=4, bias=8)
+    )
+
+    # Test deducing the array type when two inputs are given
+    a = arange(0, APyFixed.from_float(4, int_bits=5, frac_bits=0))
+    assert a.is_identical(APyFixedArray.from_float(range(4), int_bits=5, frac_bits=0))
+
+    a = arange(0, APyFloat.from_float(4, exp_bits=5, man_bits=4, bias=8))
+    assert a.is_identical(
+        APyFloatArray.from_float(range(4), exp_bits=5, man_bits=4, bias=8)
+    )
+
+    a = arange(
+        APyFixed(0, int_bits=5, frac_bits=0),
+        APyFixed.from_float(4, int_bits=5, frac_bits=0),
+    )
+    assert a.is_identical(APyFixedArray.from_float(range(4), int_bits=5, frac_bits=0))
+
+    a = arange(
+        APyFloat(0, 0, 0, exp_bits=5, man_bits=4, bias=8),
+        APyFloat.from_float(4, exp_bits=5, man_bits=4, bias=8),
+    )
+    assert a.is_identical(
+        APyFloatArray.from_float(range(4), exp_bits=5, man_bits=4, bias=8)
+    )
+
+    a = arange(APyFixed.from_float(0, int_bits=5, frac_bits=0), 4)
+    assert a.is_identical(APyFixedArray.from_float(range(4), int_bits=5, frac_bits=0))
+
+    a = arange(APyFloat.from_float(0, exp_bits=5, man_bits=4, bias=8), 4)
+    assert a.is_identical(
+        APyFloatArray.from_float(range(4), exp_bits=5, man_bits=4, bias=8)
+    )
+
+    # Test deducing the array type when three inputs are given
+    a = arange(0, 4, APyFixed.from_float(1, int_bits=5, frac_bits=0))
+    assert a.is_identical(APyFixedArray.from_float(range(4), int_bits=5, frac_bits=0))
+
+    a = arange(0, 4, APyFloat.from_float(1, exp_bits=5, man_bits=4, bias=8))
+    assert a.is_identical(
+        APyFloatArray.from_float(range(4), exp_bits=5, man_bits=4, bias=8)
+    )
+
+    a = arange(0, APyFixed.from_float(4, int_bits=5, frac_bits=0), 1)
+    assert a.is_identical(APyFixedArray.from_float(range(4), int_bits=5, frac_bits=0))
+
+    a = arange(0, APyFloat.from_float(4, exp_bits=5, man_bits=4, bias=8), 1)
+    assert a.is_identical(
+        APyFloatArray.from_float(range(4), exp_bits=5, man_bits=4, bias=8)
+    )
+
+    a = arange(APyFixed.from_float(0, int_bits=5, frac_bits=0), 4, 1)
+    assert a.is_identical(APyFixedArray.from_float(range(4), int_bits=5, frac_bits=0))
+
+    a = arange(APyFloat.from_float(0, exp_bits=5, man_bits=4, bias=8), 4, 1)
+    assert a.is_identical(
+        APyFloatArray.from_float(range(4), exp_bits=5, man_bits=4, bias=8)
+    )
+
+    a = arange(
+        APyFixed(0, int_bits=5, frac_bits=0),
+        APyFixed(4, int_bits=5, frac_bits=0),
+        APyFixed(1, int_bits=5, frac_bits=0),
+    )
+    assert a.is_identical(APyFixedArray.from_float(range(4), int_bits=5, frac_bits=0))
+
+    a = arange(
+        APyFloat(0, 0, 0, exp_bits=5, man_bits=4, bias=8),
+        APyFloat.from_float(4, exp_bits=5, man_bits=4, bias=8),
+        APyFloat(0, 8, 0, exp_bits=5, man_bits=4, bias=8),
+    )
+    assert a.is_identical(
+        APyFloatArray.from_float(range(4), exp_bits=5, man_bits=4, bias=8)
     )
 
     # Test quantization effects


### PR DESCRIPTION
<!--
Thank you so much for your PR!
-->

# PR Summary
<!-- Please provide at least 1-2 sentences describing the pull request in detail
(Why is this change required?  What problem does it solve?) and link to relevant
issues and PRs.
-->
Closes #518. If no bit-specifiers are given to `arange` the array type is deduced from `start`, `stop`, and `step`.

If the APyTypes scalars given are not of the same format, the array type will not be deduced. This behaviour is documented.
```Python
from apytypes import APyFixed, arange
arange(APyFixed(0, 4, 3), APyFixed(10, 8, 0), APyFixed(1, 2, 7))
# ValueError: Could not determine array type
```

# PR Checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

- [x] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] new and changed code is tested
- [x] relevant changes added to [CHANGELOG.md](https://github.com/apytypes/apytypes/blob/main/CHANGELOG.md)
- [x] new functionality is documented
