### PR TITLE
src: add complex-valued type `APyCFloat`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Complex-valued floating-point types:
+  - `APyCFloat`, a complex scalar floating-point type.
+
 ### Fixed
+
+- Rounding error with `QuantizationMode.JAM` using APyTypes floating-points if an
+  arithmetic result equals zero.
+- Bug in `APyFloat.__lt__` for comparison of floating-points of different
+  formats.
 
 ### Changed
 

--- a/docs/api/apycfloat.rst
+++ b/docs/api/apycfloat.rst
@@ -1,0 +1,46 @@
+``APyCFloat``
+=============
+
+.. autoclass:: apytypes.APyCFloat
+
+   Constructor
+   -----------
+
+   .. automethod:: __init__
+
+   Creation from other types
+   -------------------------
+
+   .. automethod:: from_complex
+
+   .. automethod:: from_float
+
+   Change word length
+   ------------------
+
+   .. automethod:: cast
+
+   Comparison
+   ----------
+
+   .. automethod:: is_identical
+
+   Properties
+   ----------
+
+   .. autoproperty:: real
+
+   .. autoproperty:: imag
+
+   .. autoproperty:: is_zero
+
+   Word length
+   ^^^^^^^^^^^
+
+   .. autoproperty:: bits
+
+   .. autoproperty:: exp_bits
+
+   .. autoproperty:: man_bits
+
+   .. autoproperty:: bias

--- a/docs/api/index.rst
+++ b/docs/api/index.rst
@@ -7,6 +7,7 @@
 
    apycfixed
    apycfixedarray
+   apycfloat
    apyfixed
    apyfixedarray
    apyfloat

--- a/lib/apytypes/__init__.py
+++ b/lib/apytypes/__init__.py
@@ -94,28 +94,29 @@ __all__ = [
 APyFloat.__doc__ = r"""
 Floating-point scalar with configurable format.
 
-The implementation is a generalization of the IEEE 754 standard, meaning that features like
-subnormals, infinities, and NaN, are still supported. The format is defined
-by the number of exponent and mantissa bits, and a non-negative bias. These fields are
-named :attr:`exp_bits`, :attr:`man_bits`, and :attr:`bias` respectively. Similar to the hardware
-representation of a floating-point number, the value is stored using three fields;
-a sign bit :attr:`sign`, a biased exponent :attr:`exp`, and an integral mantissa with a hidden one :attr:`man`.
-The value of a *normal* number would thus be
+The implementation is a generalization of the IEEE 754 standard, meaning that features
+like subnormals, infinities, and NaN, are still supported. The format is defined by the
+number of exponent and mantissa bits, and a non-negative bias. These fields are named
+:attr:`exp_bits`, :attr:`man_bits`, and :attr:`bias` respectively. Similar to the
+hardware representation of a floating-point number, the value is stored using three
+fields; a sign bit :attr:`sign`, a biased exponent :attr:`exp`, and an integral mantissa
+with a hidden one :attr:`man`. The value of a *normal* number would thus be
 
 .. math::
     (-1)^{\texttt{sign}} \times 2^{\texttt{exp} - \texttt{bias}} \times (1 + \texttt{man} \times 2^{\texttt{-man_bits}}).
 
-In general, if the bias is not explicitly given for a format :class:`APyFloat` will default to an IEEE-like bias
-using the formula
+In general, if the bias is not explicitly given for a format :class:`APyFloat` will
+default to an IEEE-like bias using the formula
 
 .. math::
     \texttt{bias} = 2^{\texttt{exp_bits - 1}} - 1.
 
 Arithmetic can be performed similarly to the operations of the built-in type
-:class:`float` in Python. The resulting word length from operations will be
-the same as the input operands' by quantizing to nearest number with ties to even (:class:`QuantizationMode.TIES_EVEN`).
-If the operands do not share the same format, the resulting
-bit widths of the exponent and mantissa field will be the maximum of its inputs:
+:class:`float` in Python. The resulting word length from operations will be the same as
+the input operands' by quantizing to nearest number with ties to even
+(:class:`QuantizationMode.TIES_EVEN`). If the operands do not share the same format, the
+resulting bit widths of the exponent and mantissa field will be the maximum of its
+inputs:
 
 Examples
 --------
@@ -137,9 +138,9 @@ Operands with different formats, result will have exp_bits=5, man_bits=4
 APyFloat(sign=0, exp=16, man=8, exp_bits=5, man_bits=4)
 
 If the operands of an arithmetic operation have IEEE-like biases, then the result will
-also have an IEEE-like bias -- based on the resulting number of exponent bits.
-To support operations with biases deviating from the standard, the bias of the resulting format
-is calculated as the "average" of the inputs' biases:
+also have an IEEE-like bias -- based on the resulting number of exponent bits. To
+support operations with biases deviating from the standard, the bias of the resulting
+format is calculated as the "average" of the inputs' biases:
 
 .. math::
     \texttt{bias}_3 = \frac{\left ( \left (\texttt{bias}_1 + 1 \right ) / 2^{\texttt{exp_bits}_1} + \left (\texttt{bias}_2 + 1 \right ) / 2^{\texttt{exp_bits}_2} \right ) \times 2^{\texttt{exp_bits}_3}}{2} - 1,
@@ -275,7 +276,11 @@ arithmetic operations. This ensures that overflow or quantization **never** occu
 unless explicitly instructed to by a user through the :func:`cast` method. The following
 table shows word lengths of elementary arithmetic operations.
 
-For complex-valued fixed-point formats, see :class:`APyCFixed`.
+
+.. note::
+    For real-valued fixed-point array formats, see :class:`APyFixedArray`. For \
+    complex-valued fixed-point formats, see :class:`APyCFixed` and
+    :class:`APyCFixedArray`.
 
 .. list-table:: Word-length of fixed-point arithmetic operations using
                 :class:`APyFixed`
@@ -317,7 +322,10 @@ and imaginary part share bit specifiers, and the overall number of bits in an
 :class:`APyCFixed` is :code:`2 * bits`. Only two of three bit specifers need to be set
 to uniquely determine the complete fixed-point format.
 
-For real-valued fixed-point formats, see :class:`APyFixed`.
+
+.. note::
+    For complex-valued fixed-point arrays, see :class:`APyCFixedArray`. For real-valued
+    fixed-point formats, see :class:`APyFixed` and :class:`APyFixedArray`.
 
 .. list-table:: Word-length of fixed-point arithmetic operations using
                 :class:`APyCFixed`
@@ -349,4 +357,15 @@ APyCFixedArray.__doc__ = r"""
 Class for configurable complex-valued array fixed-point formats.
 
 .. versionadded:: 0.3
+"""
+
+APyCFloat.__doc__ = r"""
+Class for configurable complex-valued scalar floating-point formats.
+
+.. versionadded:: 0.4
+
+.. note::
+    For real-valued floating-point formats, see :class:`APyFloat` and
+    :class:`APyFloatArray`.
+
 """

--- a/lib/apytypes/_apytypes.pyi
+++ b/lib/apytypes/_apytypes.pyi
@@ -21,7 +21,10 @@ class APyCFixed:
     :class:`APyCFixed` is :code:`2 * bits`. Only two of three bit specifers need to be set
     to uniquely determine the complete fixed-point format.
 
-    For real-valued fixed-point formats, see :class:`APyFixed`.
+
+    .. note::
+        For complex-valued fixed-point arrays, see :class:`APyCFixedArray`. For real-valued
+        fixed-point formats, see :class:`APyFixed` and :class:`APyFixedArray`.
 
     .. list-table:: Word-length of fixed-point arithmetic operations using
                     :class:`APyCFixed`
@@ -96,79 +99,79 @@ class APyCFixed:
     @overload
     def __add__(self, arg: APyCFixed, /) -> APyCFixed: ...
     @overload
-    def __add__(self, arg: int, /) -> APyCFixed: ...
+    def __add__(self, arg: int) -> APyCFixed: ...
     @overload
-    def __add__(self, arg: float, /) -> APyCFixed: ...
+    def __add__(self, arg: float) -> APyCFixed: ...
     @overload
-    def __add__(self, arg: complex, /) -> APyCFixed: ...
+    def __add__(self, arg: complex) -> APyCFixed: ...
     @overload
-    def __add__(self, arg: APyFixed, /) -> APyCFixed: ...
+    def __add__(self, arg: APyFixed) -> APyCFixed: ...
     @overload
     def __sub__(self, arg: APyCFixed, /) -> APyCFixed: ...
     @overload
-    def __sub__(self, arg: int, /) -> APyCFixed: ...
+    def __sub__(self, arg: int) -> APyCFixed: ...
     @overload
-    def __sub__(self, arg: float, /) -> APyCFixed: ...
+    def __sub__(self, arg: float) -> APyCFixed: ...
     @overload
-    def __sub__(self, arg: complex, /) -> APyCFixed: ...
+    def __sub__(self, arg: complex) -> APyCFixed: ...
     @overload
-    def __sub__(self, arg: APyFixed, /) -> APyCFixed: ...
+    def __sub__(self, arg: APyFixed) -> APyCFixed: ...
     @overload
     def __mul__(self, arg: APyCFixed, /) -> APyCFixed: ...
     @overload
-    def __mul__(self, arg: int, /) -> APyCFixed: ...
+    def __mul__(self, arg: int) -> APyCFixed: ...
     @overload
-    def __mul__(self, arg: float, /) -> APyCFixed: ...
+    def __mul__(self, arg: float) -> APyCFixed: ...
     @overload
-    def __mul__(self, arg: complex, /) -> APyCFixed: ...
+    def __mul__(self, arg: complex) -> APyCFixed: ...
     @overload
-    def __mul__(self, arg: APyFixed, /) -> APyCFixed: ...
+    def __mul__(self, arg: APyFixed) -> APyCFixed: ...
     @overload
     def __truediv__(self, arg: APyCFixed, /) -> APyCFixed: ...
     @overload
-    def __truediv__(self, arg: int, /) -> APyCFixed: ...
+    def __truediv__(self, arg: int) -> APyCFixed: ...
     @overload
-    def __truediv__(self, arg: float, /) -> APyCFixed: ...
+    def __truediv__(self, arg: float) -> APyCFixed: ...
     @overload
-    def __truediv__(self, arg: complex, /) -> APyCFixed: ...
+    def __truediv__(self, arg: complex) -> APyCFixed: ...
     @overload
-    def __truediv__(self, arg: APyFixed, /) -> APyCFixed: ...
+    def __truediv__(self, arg: APyFixed) -> APyCFixed: ...
     def __neg__(self) -> APyCFixed: ...
     def __pos__(self) -> APyCFixed: ...
     def __ilshift__(self, arg: int, /) -> APyCFixed: ...
     def __irshift__(self, arg: int, /) -> APyCFixed: ...
     @overload
-    def __radd__(self, arg: int, /) -> APyCFixed: ...
+    def __radd__(self, arg: int) -> APyCFixed: ...
     @overload
-    def __radd__(self, arg: float, /) -> APyCFixed: ...
+    def __radd__(self, arg: float) -> APyCFixed: ...
     @overload
-    def __radd__(self, arg: complex, /) -> APyCFixed: ...
+    def __radd__(self, arg: complex) -> APyCFixed: ...
     @overload
-    def __radd__(self, arg: APyFixed, /) -> APyCFixed: ...
+    def __radd__(self, arg: APyFixed) -> APyCFixed: ...
     @overload
-    def __rsub__(self, arg: int, /) -> APyCFixed: ...
+    def __rsub__(self, arg: int) -> APyCFixed: ...
     @overload
-    def __rsub__(self, arg: float, /) -> APyCFixed: ...
+    def __rsub__(self, arg: float) -> APyCFixed: ...
     @overload
-    def __rsub__(self, arg: complex, /) -> APyCFixed: ...
+    def __rsub__(self, arg: complex) -> APyCFixed: ...
     @overload
-    def __rsub__(self, arg: APyFixed, /) -> APyCFixed: ...
+    def __rsub__(self, arg: APyFixed) -> APyCFixed: ...
     @overload
-    def __rmul__(self, arg: int, /) -> APyCFixed: ...
+    def __rmul__(self, arg: int) -> APyCFixed: ...
     @overload
-    def __rmul__(self, arg: float, /) -> APyCFixed: ...
+    def __rmul__(self, arg: float) -> APyCFixed: ...
     @overload
-    def __rmul__(self, arg: complex, /) -> APyCFixed: ...
+    def __rmul__(self, arg: complex) -> APyCFixed: ...
     @overload
-    def __rmul__(self, arg: APyFixed, /) -> APyCFixed: ...
+    def __rmul__(self, arg: APyFixed) -> APyCFixed: ...
     @overload
-    def __rtruediv__(self, arg: int, /) -> APyCFixed: ...
+    def __rtruediv__(self, arg: int) -> APyCFixed: ...
     @overload
-    def __rtruediv__(self, arg: float, /) -> APyCFixed: ...
+    def __rtruediv__(self, arg: float) -> APyCFixed: ...
     @overload
-    def __rtruediv__(self, arg: complex, /) -> APyCFixed: ...
+    def __rtruediv__(self, arg: complex) -> APyCFixed: ...
     @overload
-    def __rtruediv__(self, arg: APyFixed, /) -> APyCFixed: ...
+    def __rtruediv__(self, arg: APyFixed) -> APyCFixed: ...
     def __invert__(self) -> APyCFixed: ...
     @property
     def real(self) -> APyFixed:
@@ -348,10 +351,13 @@ class APyCFixed:
         Create an :class:`APyCFixed` object from an :class:`int`, :class:`float`,
         :class:`complex`, :class:`APyFixed`, :class:`APyFloat`, or :class:`APyCFixed`.
 
-        .. note:: It is in all cases better to use :func:`~apytypes.APyCFixed.cast` to create an :class:`APyCFixed` from an :class:`APyCFixed`.
+        .. attention::
+            It is in all cases better to use :func:`~apytypes.APyCFixed.cast` to
+            create an :class:`APyCFixed` from an :class:`APyCFixed`.
 
-        The input is quantized using :class:`QuantizationMode.RND_INF` and overflow is handled using the :class:`OverflowMode.WRAP` mode.
-        Exactly two of the three bit-specifiers (`bits`, `int_bits`, `frac_bits`) must be set.
+        The input is quantized using :class:`QuantizationMode.RND_INF` and overflow
+        is handled using the :class:`OverflowMode.WRAP` mode. Exactly two of the
+        three bit-specifiers (`bits`, `int_bits`, `frac_bits`) must be set.
 
         Parameters
         ----------
@@ -390,10 +396,13 @@ class APyCFixed:
     ) -> APyCFixed:
         """
         Create an :class:`APyCFixed` object from an :class:`int`, :class:`float`,
-        :class:`complex`, :class:`APyFixed`, :class:`APyFloat`, or :class:`APyCFixed`.
-        This is an alias for :func:`~apytypes.APyCFixed.from_complex`, look there for more documentation.
+        :class:`complex`, :class:`APyFixed`, :class:`APyFloat`, or
+        :class:`APyCFixed`. This is an alias for
+        :func:`~apytypes.APyCFixed.from_complex`, look there for more documentation.
 
-        .. attention:: It is in all cases better to use :func:`~apytypes.APyCFixed.cast` to create an :class:`APyCFixed` from anpther :class:`APyCFixed`.
+        .. attention::
+            It is in all cases better to use :func:`~apytypes.APyCFixed.cast` to
+            create an :class:`APyCFixed` from anpther :class:`APyCFixed`.
 
         Parameters
         ----------
@@ -1119,10 +1128,13 @@ class APyCFixedArray:
         bits: int | None = None,
     ) -> APyCFixedArray:
         """
-        Create an :class:`APyCFixedArray` object from a sequence of :class:`int`, :class:`float`, :class:`complex`, :class:`APyFixed`, :class:`APyFloat`, or :class:`APyCFixed`.
+        Create an :class:`APyCFixedArray` object from a sequence of :class:`int`,
+        :class:`float`, :class:`complex`, :class:`APyFixed`, :class:`APyFloat`, or
+        :class:`APyCFixed`.
 
-        The input is quantized using :class:`QuantizationMode.RND_INF` and overflow is handled using the :class:`OverflowMode.WRAP` mode.
-        Exactly two of the three bit-specifiers (`bits`, `int_bits`, `frac_bits`) must be set.
+        The input is quantized using :class:`QuantizationMode.RND_INF` and overflow
+        is handled using the :class:`OverflowMode.WRAP` mode. Exactly two of the
+        three bit-specifiers (`bits`, `int_bits`, `frac_bits`) must be set.
 
         Using NumPy arrays as input is in general faster than e.g. lists.
 
@@ -1168,8 +1180,11 @@ class APyCFixedArray:
         bits: int | None = None,
     ) -> APyCFixedArray:
         """
-        Create an :class:`APyCFixedArray` object from a sequence of :class:`int`, :class:`float`, :class:`complex`, :class:`APyFixed`, :class:`APyFloat`, or :class:`APyCFixed`.
-        This is an alias for :func:`~apytypes.APyCFixedArray.from_complex`, look there for more documentation.
+        Create an :class:`APyCFixedArray` object from a sequence of :class:`int`,
+        :class:`float`, :class:`complex`, :class:`APyFixed`, :class:`APyFloat`, or
+        :class:`APyCFixed`. This is an alias for
+        :func:`~apytypes.APyCFixedArray.from_complex`, look there for more
+        documentation.
 
         Parameters
         ----------
@@ -1381,19 +1396,239 @@ class APyCFixedArray:
     def __array__(self) -> Annotated[ArrayLike, dict(dtype="complex128")]: ...
 
 class APyCFloat:
-    @staticmethod
-    def from_float(
-        value: object, exp_bits: int, man_bits: int, bias: int | None = None
-    ) -> APyCFloat:
-        """
-        Create an :class:`APyCFloat` object from an :class:`int` or :class:`float`.
+    """
+    Class for configurable complex-valued scalar floating-point formats.
 
-        The quantization mode used is :class:`QuantizationMode.TIES_EVEN`.
+    .. versionadded:: 0.4
+
+    .. note::
+        For real-valued floating-point formats, see :class:`APyFloat` and
+        :class:`APyFloatArray`.
+    """
+
+    @overload
+    def __init__(
+        self,
+        sign: bool | int,
+        exp: int,
+        man: int,
+        exp_bits: int,
+        man_bits: int,
+        bias: int | None = None,
+    ) -> None:
+        """
+        Create an :class:`APyCFloat` object and initialize its real part.
+
+        The imaginary part is zero initialized.
 
         Parameters
         ----------
-        value : :class:`int`, :class:`float`
-            Floating-point value to initialize from.
+        sign : :class:`bool` or :class:`int`
+            Sign of real part. `True`/non-zero equals negative.
+        exp : :class:`int`
+            Exponent of real part as stored, i.e., actual value + bias.
+        man : :class:`int`
+            Mantissa of the float as stored, i.e., without a hidden one.
+        exp_bits : :class:`int`
+            Number of exponent bits.
+        man_bits : :class:`int`
+            Number of mantissa bits.
+        bias : :class:`int`, optional
+            Exponent bias. If not provided, *bias* is ``2**exp_bits - 1``.
+
+        Returns
+        -------
+        :class:`APyCFloat`
+        """
+
+    @overload
+    def __init__(
+        self,
+        sign: tuple,
+        exp: tuple,
+        man: tuple,
+        exp_bits: int,
+        man_bits: int,
+        bias: int | None = None,
+    ) -> None:
+        """
+        Create an :class:`APyCFloat` object and initialize both real and imaginary
+        part.
+
+        Parameters
+        ----------
+        sign : :class:`tuple` of :class:`int` or :class:`bool`
+            Sign of real/imaginary parts. `True`/non-zero equals negative.
+        exp : :class:`tuple` of :class:`int`
+            Exponent of real/imaginary parts as stored, i.e., actual value + bias.
+        man : :class:`tuple` of :class:`int`
+            Mantissa of the real/imaginary parts as stored, i.e., without a hidden
+            one.
+        exp_bits : :class:`int`
+            Number of exponent bits.
+        man_bits : :class:`int`
+            Number of mantissa bits.
+        bias : :class:`int`, optional
+            Exponent bias. If not provided, *bias* is ``2**exp_bits - 1``.
+
+        Returns
+        -------
+        :class:`APyCFloat`
+        """
+
+    @overload
+    def __eq__(self, arg: APyCFloat, /) -> bool: ...
+    @overload
+    def __eq__(self, arg: APyFloat, /) -> bool: ...
+    @overload
+    def __eq__(self, arg: APyFixed, /) -> bool: ...
+    @overload
+    def __eq__(self, arg: APyCFixed, /) -> bool: ...
+    @overload
+    def __eq__(self, arg: float, /) -> bool: ...
+    @overload
+    def __ne__(self, arg: APyCFloat, /) -> bool: ...
+    @overload
+    def __ne__(self, arg: APyFloat, /) -> bool: ...
+    @overload
+    def __ne__(self, arg: APyFixed, /) -> bool: ...
+    @overload
+    def __ne__(self, arg: APyCFixed, /) -> bool: ...
+    @overload
+    def __ne__(self, arg: float, /) -> bool: ...
+    @overload
+    def __add__(self, arg: APyCFloat, /) -> APyCFloat: ...
+    @overload
+    def __add__(self, arg: int) -> APyCFloat: ...
+    @overload
+    def __add__(self, arg: APyFloat) -> APyCFloat: ...
+    @overload
+    def __add__(self, arg: APyFixed) -> APyCFloat: ...
+    @overload
+    def __add__(self, arg: APyCFixed) -> APyCFloat: ...
+    @overload
+    def __add__(self, arg: float) -> APyCFloat: ...
+    @overload
+    def __add__(self, arg: complex) -> APyCFloat: ...
+    @overload
+    def __sub__(self, arg: APyCFloat, /) -> APyCFloat: ...
+    @overload
+    def __sub__(self, arg: int) -> APyCFloat: ...
+    @overload
+    def __sub__(self, arg: APyFloat) -> APyCFloat: ...
+    @overload
+    def __sub__(self, arg: APyFixed) -> APyCFloat: ...
+    @overload
+    def __sub__(self, arg: APyCFixed) -> APyCFloat: ...
+    @overload
+    def __sub__(self, arg: float) -> APyCFloat: ...
+    @overload
+    def __sub__(self, arg: complex) -> APyCFloat: ...
+    @overload
+    def __mul__(self, arg: APyCFloat, /) -> APyCFloat: ...
+    @overload
+    def __mul__(self, arg: int) -> APyCFloat: ...
+    @overload
+    def __mul__(self, arg: APyFloat) -> APyCFloat: ...
+    @overload
+    def __mul__(self, arg: APyFixed) -> APyCFloat: ...
+    @overload
+    def __mul__(self, arg: APyCFixed) -> APyCFloat: ...
+    @overload
+    def __mul__(self, arg: float) -> APyCFloat: ...
+    @overload
+    def __mul__(self, arg: complex) -> APyCFloat: ...
+    @overload
+    def __truediv__(self, arg: APyCFloat, /) -> APyCFloat: ...
+    @overload
+    def __truediv__(self, arg: int) -> APyCFloat: ...
+    @overload
+    def __truediv__(self, arg: APyFloat) -> APyCFloat: ...
+    @overload
+    def __truediv__(self, arg: APyFixed) -> APyCFloat: ...
+    @overload
+    def __truediv__(self, arg: APyCFixed) -> APyCFloat: ...
+    @overload
+    def __truediv__(self, arg: float) -> APyCFloat: ...
+    @overload
+    def __truediv__(self, arg: complex) -> APyCFloat: ...
+    def __neg__(self) -> APyCFloat: ...
+    def __pos__(self) -> APyCFloat: ...
+    @overload
+    def __radd__(self, arg: int) -> APyCFloat: ...
+    @overload
+    def __radd__(self, arg: APyFloat) -> APyCFloat: ...
+    @overload
+    def __radd__(self, arg: APyFixed) -> APyCFloat: ...
+    @overload
+    def __radd__(self, arg: float) -> APyCFloat: ...
+    @overload
+    def __radd__(self, arg: complex) -> APyCFloat: ...
+    @overload
+    def __rsub__(self, arg: int) -> APyCFloat: ...
+    @overload
+    def __rsub__(self, arg: APyFloat) -> APyCFloat: ...
+    @overload
+    def __rsub__(self, arg: APyFixed) -> APyCFloat: ...
+    @overload
+    def __rsub__(self, arg: float) -> APyCFloat: ...
+    @overload
+    def __rsub__(self, arg: complex) -> APyCFloat: ...
+    @overload
+    def __rmul__(self, arg: int) -> APyCFloat: ...
+    @overload
+    def __rmul__(self, arg: APyFloat) -> APyCFloat: ...
+    @overload
+    def __rmul__(self, arg: APyFixed) -> APyCFloat: ...
+    @overload
+    def __rmul__(self, arg: float) -> APyCFloat: ...
+    @overload
+    def __rmul__(self, arg: complex) -> APyCFloat: ...
+    @overload
+    def __rtruediv__(self, arg: int) -> APyCFloat: ...
+    @overload
+    def __rtruediv__(self, arg: APyFloat) -> APyCFloat: ...
+    @overload
+    def __rtruediv__(self, arg: APyFixed) -> APyCFloat: ...
+    @overload
+    def __rtruediv__(self, arg: float) -> APyCFloat: ...
+    @overload
+    def __rtruediv__(self, arg: complex) -> APyCFloat: ...
+    @property
+    def real(self) -> APyFloat:
+        """
+        Real part.
+
+        Returns
+        -------
+        :class:`APyFixed`
+        """
+
+    @property
+    def imag(self) -> APyFloat:
+        """
+        Imaginary part.
+
+        Returns
+        -------
+        :class:`APyFixed`
+        """
+
+    @staticmethod
+    def from_complex(
+        value: object, exp_bits: int, man_bits: int, bias: int | None = None
+    ) -> APyCFloat:
+        """
+        Create an :class:`APyCFloat` object from an :class:`int`, :class:`float`, or
+        :class:`complex`.
+
+        The initialize floating-point value is the one closest to `value`. Ties are
+        rounded using :class:`QuantizationMode.TIES_EVEN`.
+
+        Parameters
+        ----------
+        value : :class:`complex`, :class:`float`, :class:`int`
+            Value to initialize from.
         exp_bits : :class:`int`
             Number of exponent bits.
         man_bits : :class:`int`
@@ -1404,11 +1639,12 @@ class APyCFloat:
         Examples
         --------
 
-        >>> from apytypes import APyCFloat
-
-        `a`, initialized from floating-point values.
-
-        >>> a = APyCFloat.from_float(1.35, exp_bits=10, man_bits=15)
+        >>> import apytypes as apy
+        >>> a = apy.APyCFloat.from_complex(1.375, exp_bits=10, man_bits=15)
+        >>> a
+        APyCFloat(sign=(0, 0), exp=(511, 0), man=(12288, 0), exp_bits=10, man_bits=15)
+        >>> str(a)
+        '(1.375+0j)'
 
         Returns
         -------
@@ -1416,7 +1652,152 @@ class APyCFloat:
 
         See also
         --------
-        from_bits
+        from_complex
+        """
+
+    @staticmethod
+    def from_float(
+        value: object, exp_bits: int, man_bits: int, bias: int | None = None
+    ) -> APyCFloat:
+        """
+        Create an :class:`APyCFloat` object from an :class:`int`, :class:`float`, or
+        :class:`complex`.
+
+        The initialize floating-point value is the one closest to `value`. Ties are
+        rounded using :class:`QuantizationMode.TIES_EVEN`.
+
+        Parameters
+        ----------
+        value : int, float, complex
+            Value to initialize from.
+        exp_bits : int
+            Number of exponent bits.
+        man_bits : int
+            Number of mantissa bits.
+        bias : int, optional
+            Exponent bias. If not provided, *bias* is ``2**exp_bits - 1``.
+
+        Examples
+        --------
+
+        >>> import apytypes as apy
+        >>> a = apy.APyCFloat.from_float(1.25, exp_bits=10, man_bits=15)
+        >>> a
+        APyCFloat(sign=(0, 0), exp=(511, 0), man=(8192, 0), exp_bits=10, man_bits=15)
+        >>> str(a)
+        '(1.25+0j)'
+
+        Returns
+        -------
+        :class:`APyCFloat`
+
+        See also
+        --------
+        from_complex
+        """
+
+    def __complex__(self) -> complex: ...
+    def __str__(self, base: int = 10) -> str: ...
+    def __repr__(self) -> str: ...
+    def cast(
+        self,
+        exp_bits: int | None = None,
+        man_bits: int | None = None,
+        bias: int | None = None,
+        quantization: QuantizationMode | None = None,
+    ) -> APyCFloat:
+        """
+        Change format of the complex-valued floating-point number.
+
+        This is the primary method for performing quantization when dealing with
+        APyTypes floating-point numbers.
+
+        Parameters
+        ----------
+        exp_bits : :class:`int`, optional
+            Number of exponent bits in the result.
+        man_bits : :class:`int`, optional
+            Number of mantissa bits in the result.
+        bias : :class:`int`, optional
+            Exponent bias. If not provided, *bias* is ``2**exp_bits - 1``.
+        quantization : :class:`QuantizationMode`, optional.
+            Quantization mode to use in this cast. If None, use the global
+            quantization mode.
+
+        Returns
+        -------
+        :class:`APyCFloat`
+        """
+
+    @property
+    def is_zero(self) -> bool:
+        """
+        True if, and only if, both the real and imaginary parts are zero.
+
+        Returns
+        -------
+        :class:`bool`
+        """
+
+    def is_identical(self, other: APyCFloat, ignore_zero_sign: bool = False) -> bool:
+        """
+        Test if two :py:class:`APyCFloat` objects are identical.
+
+        Two :py:class:`APyCFloat` objects are considered identical if, and only if,
+        they have the same sign, exponent, mantissa, and format.
+
+        Parameters
+        ----------
+        other : :class:`APyCFloat`
+            The floating-point object to test identicality against.
+
+        ignore_zero_sign : :class:`bool`, default: :code:`False`
+            If :code:`True`, plus and minus zero are considered identical. If
+            :code:`False`, plus and minus zero are considered different.
+
+        Returns
+        -------
+        :class:`bool`
+        """
+
+    @property
+    def man_bits(self) -> int:
+        """
+        Number of mantissa bits.
+
+        Returns
+        -------
+        :class:`int`
+        """
+
+    @property
+    def exp_bits(self) -> int:
+        """
+        Number of exponent bits.
+
+        Returns
+        -------
+        :class:`int`
+        """
+
+    @property
+    def bits(self) -> int:
+        """
+        Total number of bits.
+
+        Returns
+        -------
+        :class:`int`
+        """
+
+    @property
+    def bias(self) -> int:
+        """
+        Exponent bias.
+
+        Returns
+        -------
+        :class:`int`
         """
 
 class APyCFloatArray:
@@ -1460,7 +1841,11 @@ class APyFixed:
     unless explicitly instructed to by a user through the :func:`cast` method. The following
     table shows word lengths of elementary arithmetic operations.
 
-    For complex-valued fixed-point formats, see :class:`APyCFixed`.
+
+    .. note::
+        For real-valued fixed-point array formats, see :class:`APyFixedArray`. For \
+        complex-valued fixed-point formats, see :class:`APyCFixed` and
+        :class:`APyCFixedArray`.
 
     .. list-table:: Word-length of fixed-point arithmetic operations using
                     :class:`APyFixed`
@@ -1542,48 +1927,48 @@ class APyFixed:
     @overload
     def __add__(self, arg: APyFixed, /) -> APyFixed: ...
     @overload
-    def __add__(self, arg: int, /) -> APyFixed: ...
+    def __add__(self, arg: int) -> APyFixed: ...
     @overload
-    def __add__(self, arg: float, /) -> APyFixed: ...
+    def __add__(self, arg: float) -> APyFixed: ...
     @overload
     def __sub__(self, arg: APyFixed, /) -> APyFixed: ...
     @overload
-    def __sub__(self, arg: int, /) -> APyFixed: ...
+    def __sub__(self, arg: int) -> APyFixed: ...
     @overload
-    def __sub__(self, arg: float, /) -> APyFixed: ...
+    def __sub__(self, arg: float) -> APyFixed: ...
     @overload
     def __mul__(self, arg: APyFixed, /) -> APyFixed: ...
     @overload
-    def __mul__(self, arg: int, /) -> APyFixed: ...
+    def __mul__(self, arg: int) -> APyFixed: ...
     @overload
-    def __mul__(self, arg: float, /) -> APyFixed: ...
+    def __mul__(self, arg: float) -> APyFixed: ...
     @overload
     def __truediv__(self, arg: APyFixed, /) -> APyFixed: ...
     @overload
-    def __truediv__(self, arg: int, /) -> APyFixed: ...
+    def __truediv__(self, arg: int) -> APyFixed: ...
     @overload
-    def __truediv__(self, arg: float, /) -> APyFixed: ...
+    def __truediv__(self, arg: float) -> APyFixed: ...
     def __neg__(self) -> APyFixed: ...
     def __pos__(self) -> APyFixed: ...
     def __ilshift__(self, arg: int, /) -> APyFixed: ...
     def __irshift__(self, arg: int, /) -> APyFixed: ...
     def __invert__(self) -> APyFixed: ...
     @overload
-    def __radd__(self, arg: int, /) -> APyFixed: ...
+    def __radd__(self, arg: int) -> APyFixed: ...
     @overload
-    def __radd__(self, arg: float, /) -> APyFixed: ...
+    def __radd__(self, arg: float) -> APyFixed: ...
     @overload
-    def __rsub__(self, arg: int, /) -> APyFixed: ...
+    def __rsub__(self, arg: int) -> APyFixed: ...
     @overload
-    def __rsub__(self, arg: float, /) -> APyFixed: ...
+    def __rsub__(self, arg: float) -> APyFixed: ...
     @overload
-    def __rmul__(self, arg: int, /) -> APyFixed: ...
+    def __rmul__(self, arg: int) -> APyFixed: ...
     @overload
-    def __rmul__(self, arg: float, /) -> APyFixed: ...
+    def __rmul__(self, arg: float) -> APyFixed: ...
     @overload
-    def __rtruediv__(self, arg: int, /) -> APyFixed: ...
+    def __rtruediv__(self, arg: int) -> APyFixed: ...
     @overload
-    def __rtruediv__(self, arg: float, /) -> APyFixed: ...
+    def __rtruediv__(self, arg: float) -> APyFixed: ...
     def __pow__(self, arg: int, /) -> APyFixed: ...
     def to_bits(self) -> int:
         """
@@ -1786,12 +2171,16 @@ class APyFixed:
         bits: int | None = None,
     ) -> APyFixed:
         """
-        Create an :class:`APyFixed` object from an :class:`int`, :class:`float`, :class:`APyFixed`, or :class:`APyFloat`.
+        Create an :class:`APyFixed` object from an :class:`int`, :class:`float`,
+        :class:`APyFixed`, or :class:`APyFloat`.
 
-        .. attention:: It is in all cases better to use :func:`~apytypes.APyFixed.cast` to create an :class:`APyFixed` from another :class:`APyFixed`.
+        .. attention::
+            It is in all cases better to use :func:`~apytypes.APyFixed.cast` to
+            create an :class:`APyFixed` from another :class:`APyFixed`.
 
-        The input is quantized using :class:`QuantizationMode.RND_INF` and overflow is handled using the :class:`OverflowMode.WRAP` mode.
-        Exactly two of the three bit-specifiers (`bits`, `int_bits`, `frac_bits`) must be set.
+        The input is quantized using :class:`QuantizationMode.RND_INF` and overflow
+        is handled using the :class:`OverflowMode.WRAP` mode. Exactly two of the
+        three bit-specifiers (`bits`, `int_bits`, `frac_bits`) must be set.
 
         Parameters
         ----------
@@ -2964,28 +3353,29 @@ class APyFloat:
     r"""
     Floating-point scalar with configurable format.
 
-    The implementation is a generalization of the IEEE 754 standard, meaning that features like
-    subnormals, infinities, and NaN, are still supported. The format is defined
-    by the number of exponent and mantissa bits, and a non-negative bias. These fields are
-    named :attr:`exp_bits`, :attr:`man_bits`, and :attr:`bias` respectively. Similar to the hardware
-    representation of a floating-point number, the value is stored using three fields;
-    a sign bit :attr:`sign`, a biased exponent :attr:`exp`, and an integral mantissa with a hidden one :attr:`man`.
-    The value of a *normal* number would thus be
+    The implementation is a generalization of the IEEE 754 standard, meaning that features
+    like subnormals, infinities, and NaN, are still supported. The format is defined by the
+    number of exponent and mantissa bits, and a non-negative bias. These fields are named
+    :attr:`exp_bits`, :attr:`man_bits`, and :attr:`bias` respectively. Similar to the
+    hardware representation of a floating-point number, the value is stored using three
+    fields; a sign bit :attr:`sign`, a biased exponent :attr:`exp`, and an integral mantissa
+    with a hidden one :attr:`man`. The value of a *normal* number would thus be
 
     .. math::
         (-1)^{\texttt{sign}} \times 2^{\texttt{exp} - \texttt{bias}} \times (1 + \texttt{man} \times 2^{\texttt{-man_bits}}).
 
-    In general, if the bias is not explicitly given for a format :class:`APyFloat` will default to an IEEE-like bias
-    using the formula
+    In general, if the bias is not explicitly given for a format :class:`APyFloat` will
+    default to an IEEE-like bias using the formula
 
     .. math::
         \texttt{bias} = 2^{\texttt{exp_bits - 1}} - 1.
 
     Arithmetic can be performed similarly to the operations of the built-in type
-    :class:`float` in Python. The resulting word length from operations will be
-    the same as the input operands' by quantizing to nearest number with ties to even (:class:`QuantizationMode.TIES_EVEN`).
-    If the operands do not share the same format, the resulting
-    bit widths of the exponent and mantissa field will be the maximum of its inputs:
+    :class:`float` in Python. The resulting word length from operations will be the same as
+    the input operands' by quantizing to nearest number with ties to even
+    (:class:`QuantizationMode.TIES_EVEN`). If the operands do not share the same format, the
+    resulting bit widths of the exponent and mantissa field will be the maximum of its
+    inputs:
 
     Examples
     --------
@@ -3007,9 +3397,9 @@ class APyFloat:
     APyFloat(sign=0, exp=16, man=8, exp_bits=5, man_bits=4)
 
     If the operands of an arithmetic operation have IEEE-like biases, then the result will
-    also have an IEEE-like bias -- based on the resulting number of exponent bits.
-    To support operations with biases deviating from the standard, the bias of the resulting format
-    is calculated as the "average" of the inputs' biases:
+    also have an IEEE-like bias -- based on the resulting number of exponent bits. To
+    support operations with biases deviating from the standard, the bias of the resulting
+    format is calculated as the "average" of the inputs' biases:
 
     .. math::
         \texttt{bias}_3 = \frac{\left ( \left (\texttt{bias}_1 + 1 \right ) / 2^{\texttt{exp_bits}_1} + \left (\texttt{bias}_2 + 1 \right ) / 2^{\texttt{exp_bits}_2} \right ) \times 2^{\texttt{exp_bits}_3}}{2} - 1,
@@ -3034,7 +3424,8 @@ class APyFloat:
         Parameters
         ----------
         sign : :class:`bool` or int
-            The sign of the float. False/0 means positive. True/non-zero means negative.
+            The sign of the float. False/0 means positive. True/non-zero means
+            negative.
         exp : :class:`int`
             Exponent of the float as stored, i.e., actual value + bias.
         man : :class:`int`
@@ -3099,27 +3490,27 @@ class APyFloat:
     @overload
     def __add__(self, arg: APyFloat, /) -> APyFloat: ...
     @overload
-    def __add__(self, arg: int, /) -> APyFloat: ...
+    def __add__(self, arg: int) -> APyFloat: ...
     @overload
-    def __add__(self, arg: float, /) -> APyFloat: ...
+    def __add__(self, arg: float) -> APyFloat: ...
     @overload
     def __sub__(self, arg: APyFloat, /) -> APyFloat: ...
     @overload
-    def __sub__(self, arg: int, /) -> APyFloat: ...
+    def __sub__(self, arg: int) -> APyFloat: ...
     @overload
-    def __sub__(self, arg: float, /) -> APyFloat: ...
+    def __sub__(self, arg: float) -> APyFloat: ...
     @overload
     def __mul__(self, arg: APyFloat, /) -> APyFloat: ...
     @overload
-    def __mul__(self, arg: int, /) -> APyFloat: ...
+    def __mul__(self, arg: int) -> APyFloat: ...
     @overload
-    def __mul__(self, arg: float, /) -> APyFloat: ...
+    def __mul__(self, arg: float) -> APyFloat: ...
     @overload
     def __truediv__(self, arg: APyFloat, /) -> APyFloat: ...
     @overload
-    def __truediv__(self, arg: int, /) -> APyFloat: ...
+    def __truediv__(self, arg: int) -> APyFloat: ...
     @overload
-    def __truediv__(self, arg: float, /) -> APyFloat: ...
+    def __truediv__(self, arg: float) -> APyFloat: ...
     def __neg__(self) -> APyFloat: ...
     def __pos__(self) -> APyFloat: ...
     def __abs__(self) -> APyFloat: ...
@@ -3132,29 +3523,32 @@ class APyFloat:
     def __xor__(self, arg: APyFloat, /) -> APyFloat: ...
     def __invert__(self) -> APyFloat: ...
     @overload
-    def __radd__(self, arg: int, /) -> APyFloat: ...
+    def __radd__(self, arg: int) -> APyFloat: ...
     @overload
-    def __radd__(self, arg: float, /) -> APyFloat: ...
+    def __radd__(self, arg: float) -> APyFloat: ...
     @overload
-    def __rsub__(self, arg: int, /) -> APyFloat: ...
+    def __rsub__(self, arg: int) -> APyFloat: ...
     @overload
-    def __rsub__(self, arg: float, /) -> APyFloat: ...
+    def __rsub__(self, arg: float) -> APyFloat: ...
     @overload
-    def __rmul__(self, arg: int, /) -> APyFloat: ...
+    def __rmul__(self, arg: int) -> APyFloat: ...
     @overload
-    def __rmul__(self, arg: float, /) -> APyFloat: ...
+    def __rmul__(self, arg: float) -> APyFloat: ...
     @overload
-    def __rtruediv__(self, arg: int, /) -> APyFloat: ...
+    def __rtruediv__(self, arg: int) -> APyFloat: ...
     @overload
-    def __rtruediv__(self, arg: float, /) -> APyFloat: ...
+    def __rtruediv__(self, arg: float) -> APyFloat: ...
     @staticmethod
     def from_float(
         value: object, exp_bits: int, man_bits: int, bias: int | None = None
     ) -> APyFloat:
         """
-        Create an :class:`APyFloat` object from an :class:`int`, :class:`float`, :class:`APyFixed`, or :class:`APyFloat`.
+        Create an :class:`APyFloat` object from an :class:`int`, :class:`float`,
+        :class:`APyFixed`, or :class:`APyFloat`.
 
-        .. attention:: It is in all cases better to use :func:`~apytypes.APyFloat.cast` to create an :class:`APyFloat` from another :class:`APyFloat`.
+        .. attention::
+            It is in all cases better to use :func:`~apytypes.APyFloat.cast` to
+            create an :class:`APyFloat` from another :class:`APyFloat`.
 
         The quantization mode used is :class:`QuantizationMode.TIES_EVEN`.
 
@@ -3343,12 +3737,21 @@ class APyFloat:
         :class:`bool`
         """
 
-    def is_identical(self, other: APyFloat) -> bool:
+    def is_identical(self, other: APyFloat, ignore_zero_sign: bool = False) -> bool:
         """
         Test if two :py:class:`APyFloat` objects are identical.
 
-        Two :py:class:`APyFloat` objects are considered identical if, and only if,  they have
-        the same sign, exponent, mantissa, and format.
+        Two :py:class:`APyFloat` objects are considered identical if, and only if,
+        they have the same sign, exponent, mantissa, and format.
+
+        Parameters
+        ----------
+        other : :class:`APyFloat`
+            The floating-point object to test identicality against.
+
+        ignore_zero_sign : :class:`bool`, default: :code:`False`
+            If :code:`True`, plus and minus zero are considered identical. If
+            :code:`False`, plus and minus zero are considered different.
 
         Returns
         -------
@@ -3558,7 +3961,8 @@ class APyFloat:
 
     def next_up(self) -> APyFloat:
         """
-        Get the smallest floating-point number in the same format that compares greater.
+        Get the smallest floating-point number in the same format that compares
+        greater.
 
         See also
         --------
@@ -4060,7 +4464,7 @@ class APyFloatArray:
 
         Array `lhs` (2 x 3 matrix), initialized from floating-point values.
 
-        >>> lhs = APyFloatArray.from_float(
+        >>> lhs = apy.APyFloatArray.from_float(
         ...     [
         ...         [1.0, 2.0, 3.0],
         ...         [4.0, 5.0, 6.0],

--- a/lib/test/apycfloat/test_arithmetic.py
+++ b/lib/test/apycfloat/test_arithmetic.py
@@ -1,0 +1,396 @@
+from apytypes import APyCFloat, APyCFixed, APyFloat, APyFixed
+from itertools import product
+
+import pytest
+import platform
+
+
+def is_identical_or_nan(x: APyCFloat, y: APyCFloat):
+    """
+    Test if two :class:`APyCFloat` are identical or if they are NaN in the same fields:
+
+    Parameters
+    ----------
+    x: :class:`APyCFloat`
+        The first apytypes complex floating-point value.
+    y: :class:`APyCFloat`
+        The second apytypes complex floating-point value.
+    """
+    if x.real.is_nan or x.imag.is_nan or y.imag.is_nan or x.imag.is_nan:
+        if x.real.is_nan != y.real.is_nan or x.imag.is_nan != y.imag.is_nan:
+            return False
+        else:
+            real_eq = True if x.real.is_nan else x.real.is_identical(y.real)
+            imag_eq = True if x.imag.is_nan else x.imag.is_identical(y.imag)
+            return real_eq and imag_eq
+    else:
+        return x.is_identical(y)
+
+
+def complex_division_double_precision(z: complex, w: complex) -> complex:
+    """
+    Perform a complex-valued division of `complex` using the same method as in APyTypes.
+
+    On x86 platforms, this is identical to `z / w`, however, on ARM64-based systems, the
+    division algorithm used varies slightly. By comparing `APyCFloat` division results
+    to this complex-valued division function, we ensure consistent behaviour during
+    tests on various platforms.
+
+    The complex-valued algorithm used in APyTypes (and on x86-based Python systems) is
+    the following: Robert L. Smith, ``ALGORITHM 116 COMPLEX DIVISION''
+    https://dl.acm.org/doi/pdf/10.1145/368637.368661
+
+    Parameters
+    ----------
+    z: :class:`complex`
+        Complex-valued numerator.
+    w: :class:`complex`
+        Complex-valued denominator.
+    """
+    a, b, c, d = z.real, z.imag, w.real, w.imag
+    e, f = 0.0, 0.0
+    if abs(c) >= abs(d):
+        r = d / c
+        den = c + r * d
+        e = (a + b * r) / den
+        f = (b - a * r) / den
+    else:
+        r = c / d
+        den = d + r * c
+        e = (a * r + b) / den
+        f = (b * r - a) / den
+    return complex(e, f)
+
+
+@pytest.mark.float_div
+@pytest.mark.parametrize(
+    "num_val, den_val",
+    list(
+        product(
+            [
+                complex(re, im)
+                for (re, im) in product(
+                    [0.0, -0.0, 1.0, -1.0, float("inf"), float("-inf"), float("nan")],
+                    repeat=2,
+                )
+            ],
+            repeat=2,
+        )
+    ),
+)
+def test_div_recover_infs_and_nans(num_val: complex, den_val: complex):
+    # Division with zero
+    num = APyCFloat.from_complex(num_val, exp_bits=11, man_bits=52)
+    den = APyCFloat.from_complex(den_val, exp_bits=11, man_bits=52)
+    if not (den.is_zero):
+        assert is_identical_or_nan(
+            num / den,
+            APyCFloat.from_complex(num_val / den_val, exp_bits=11, man_bits=52),
+        )
+
+
+@pytest.mark.parametrize(
+    "num_real", [0.0, 1.0, -2.0, float("inf"), float("-inf"), float("nan")]
+)
+@pytest.mark.parametrize(
+    "num_imag", [0.0, 1.0, -2.0, float("inf"), float("-inf"), float("nan")]
+)
+@pytest.mark.parametrize("den_real", [0.0, -0.0])
+def test_div_with_zero(num_real: float, num_imag: float, den_real: float):
+    num = APyCFloat.from_complex(num_real + 1j * num_imag, exp_bits=11, man_bits=52)
+    den = APyCFloat.from_complex(den_real, exp_bits=11, man_bits=52)
+    res = num / den
+
+    if num.real.is_zero or num.real.is_nan:
+        assert res.real.is_nan
+    else:
+        assert res.real.is_inf and res.real.sign == (num.real.sign ^ den.real.sign)
+
+    if num.imag.is_zero or num.imag.is_nan:
+        assert res.imag.is_nan
+    else:
+        assert res.imag.is_inf and res.imag.sign == (num.imag.sign ^ den.real.sign)
+
+
+@pytest.mark.float_div
+@pytest.mark.parametrize("apyfloat", [APyCFloat])
+def test_div_mixed_bias_overflow(apyfloat: type[APyCFloat]):
+    """Test that a result can overflow to infinity due to a change in bias."""
+    x = apyfloat(sign=0, exp=21, man=0, exp_bits=5, man_bits=2, bias=5)
+    y = apyfloat(sign=0, exp=25, man=0, exp_bits=5, man_bits=2, bias=25)
+
+    # Divide with one
+    assert (_ := x / y).is_identical(
+        apyfloat(sign=(0, 0), exp=(31, 31), man=(0, 1), exp_bits=5, man_bits=2, bias=15)
+    )
+
+    # Divide with one but with larger bias difference
+    y = apyfloat(sign=0, exp=27, man=0, exp_bits=5, man_bits=2, bias=27)
+    assert (_ := x / y).is_identical(
+        apyfloat(sign=(0, 0), exp=(31, 31), man=(0, 1), exp_bits=5, man_bits=2, bias=16)
+    )
+
+
+@pytest.mark.float_div
+@pytest.mark.parametrize("apyfloat", [APyCFloat])
+def test_subnormal_quant_div(apyfloat: type[APyCFloat]):
+    """Subnormal becoming normal after quantization."""
+    res = apyfloat(sign=0, exp=1, man=1023, exp_bits=5, man_bits=10) / apyfloat(
+        sign=0, exp=16, man=0, exp_bits=5, man_bits=10
+    )
+    assert res.is_identical(apyfloat(sign=0, exp=1, man=0, exp_bits=5, man_bits=10))
+
+    # -2 / -8.98847e+307
+    res = apyfloat(
+        sign=1, exp=1023, man=4503599627370495, exp_bits=11, man_bits=52
+    ) / apyfloat(sign=1, exp=2046, man=0, exp_bits=11, man_bits=52)
+    assert res.is_identical(
+        apyfloat(sign=(0, 1), exp=(1, 0), man=(0, 0), exp_bits=11, man_bits=52)
+    )
+
+
+@pytest.mark.float_div
+@pytest.mark.parametrize("x", [0.0 + 0.0j, 1.0 - 3.0j, -7.25 + 3.5j])
+@pytest.mark.parametrize("y", [-2.25 + 0.0j, 0.5 - 125.25j, 72.0 - 99.875j, 0.0 + 2.5j])
+def test_div_double_precision(x: complex, y: complex):
+    lhs = APyCFloat.from_complex(x, 11, 52)
+    rhs = APyCFloat.from_complex(y, 11, 52)
+    py_res = complex_division_double_precision(x, y)
+    assert is_identical_or_nan(lhs / rhs, APyCFloat.from_complex(py_res, 11, 52))
+
+    # Also test the division reference function on suitable machines...
+    if any(platform.machine() == p for p in ("AMD64", "x86_64", "x86")):
+        assert py_res == x / y
+
+
+@pytest.mark.float_mul
+@pytest.mark.parametrize("x", [0.0 + 0.0j, 1.0 - 3.0j, -7.25 + 3.5j])
+@pytest.mark.parametrize("y", [-2.25 + 0.0j, 0.5 - 125.25j, 72.0 - 99.875j, 0.0 + 2.5j])
+def test_mul_double_precision(x: complex, y: complex):
+    lhs = APyCFloat.from_complex(x, 11, 52)
+    rhs = APyCFloat.from_complex(y, 11, 52)
+    assert is_identical_or_nan(lhs * rhs, APyCFloat.from_complex(x * y, 11, 52))
+
+
+@pytest.mark.float_div
+@pytest.mark.parametrize("x", [0.0 + 0.0j, 1.0 - 3.0j, -7.25 + 3.5j])
+@pytest.mark.parametrize("y", [-2.25 + 0.0j, 0.5 - 125.25j, 72.0 - 99.875j, 0.0 + 2.5j])
+def test_add_double_precision(x: complex, y: complex):
+    lhs = APyCFloat.from_complex(x, 11, 52)
+    rhs = APyCFloat.from_complex(y, 11, 52)
+    assert is_identical_or_nan(lhs + rhs, APyCFloat.from_complex(x + y, 11, 52))
+
+
+@pytest.mark.float_div
+@pytest.mark.parametrize("x", [0.0 + 0.0j, 1.0 - 3.0j, -7.25 + 3.5j])
+@pytest.mark.parametrize("y", [-2.25 + 0.0j, 0.5 - 125.25j, 72.0 - 99.875j, 0.0 + 2.5j])
+def test_sub_double_precision(x: complex, y: complex):
+    lhs = APyCFloat.from_complex(x, 11, 52)
+    rhs = APyCFloat.from_complex(y, 11, 52)
+    assert is_identical_or_nan(lhs - rhs, APyCFloat.from_complex(x - y, 11, 52))
+
+
+@pytest.mark.parametrize("exp_bits", [5, 11, 30])
+@pytest.mark.parametrize("man_bits", [10, 35, 52])
+@pytest.mark.parametrize(
+    "a_val, b_val",
+    product(
+        [0.0 + 0.0j, -1.0 + 0.0j, -0.0 - 1.0j, 3.0625 - 1.25j, -(2 ** (-4)) + 247.25j],
+        repeat=2,
+    ),
+)
+def test_arithmetic_with_python_complex(
+    exp_bits: int,
+    man_bits: int,
+    a_val: complex,
+    b_val: complex,
+):
+    a = APyCFloat.from_complex(a_val, exp_bits=exp_bits, man_bits=man_bits)
+    b = complex(b_val)
+    assert (a + b).is_identical(
+        APyCFloat.from_complex(a_val + b_val, exp_bits, man_bits)
+    )
+    assert (a - b).is_identical(
+        APyCFloat.from_complex(a_val - b_val, exp_bits, man_bits)
+    )
+    assert (b + a).is_identical(
+        APyCFloat.from_complex(b_val + a_val, exp_bits, man_bits)
+    )
+    assert (b - a).is_identical(
+        APyCFloat.from_complex(b_val - a_val, exp_bits, man_bits)
+    )
+    if exp_bits == 11 and man_bits == 52:
+        assert (a * b).is_identical(
+            APyCFloat.from_complex(a_val * b_val, exp_bits, man_bits)
+        )
+        assert (b * a).is_identical(
+            APyCFloat.from_complex(b_val * a_val, exp_bits, man_bits)
+        )
+        if b != 0:
+            assert (a / b).is_identical(
+                APyCFloat.from_complex(
+                    complex_division_double_precision(a_val, b_val), exp_bits, man_bits
+                )
+            )
+        if a != 0:
+            assert (b / a).is_identical(
+                APyCFloat.from_complex(
+                    complex_division_double_precision(b_val, a_val), exp_bits, man_bits
+                )
+            )
+
+
+@pytest.mark.parametrize("exp_bits", [5, 11, 30])
+@pytest.mark.parametrize("man_bits", [10, 35, 52])
+@pytest.mark.parametrize(
+    "a_val",
+    [0.0 + 0.0j, -1.0 + 0.0j, -0.0 - 1.0j, 3.0625 - 1.25j, -(2 ** (-4)) + 247.25j],
+)
+@pytest.mark.parametrize("b_val", [0.0, -1.0, 3.0625, -(2**-7), 1234.0625])
+def test_arithmetic_with_python_float(
+    exp_bits: int,
+    man_bits: int,
+    a_val: complex,
+    b_val: float,
+):
+    a = APyCFloat.from_complex(a_val, exp_bits=exp_bits, man_bits=man_bits)
+    b = float(b_val)
+    assert (a + b).is_identical(
+        APyCFloat.from_complex(a_val + b_val, exp_bits, man_bits)
+    )
+    assert (a - b).is_identical(
+        APyCFloat.from_complex(a_val - b_val, exp_bits, man_bits)
+    )
+    assert (b + a).is_identical(
+        APyCFloat.from_complex(b_val + a_val, exp_bits, man_bits)
+    )
+    assert (b - a).is_identical(
+        APyCFloat.from_complex(b_val - a_val, exp_bits, man_bits), ignore_zero_sign=True
+    )
+    if exp_bits == 11 and man_bits == 52:
+        assert (a * b).is_identical(
+            APyCFloat.from_complex(a_val * complex(b_val), exp_bits, man_bits)
+        )
+        assert (b * a).is_identical(
+            APyCFloat.from_complex(b_val * complex(a_val), exp_bits, man_bits),
+            ignore_zero_sign=True,
+        )
+        if b != 0:
+            assert (a / b).is_identical(
+                APyCFloat.from_complex(
+                    complex_division_double_precision(a_val, b_val), exp_bits, man_bits
+                )
+            )
+        if a != 0:
+            assert (b / a).is_identical(
+                APyCFloat.from_complex(
+                    complex_division_double_precision(b_val, a_val), exp_bits, man_bits
+                )
+            )
+
+
+@pytest.mark.parametrize("exp_bits", [5, 11, 30])
+@pytest.mark.parametrize("man_bits", [10, 35, 52])
+@pytest.mark.parametrize(
+    "a_val",
+    [0.0 + 0.0j, -1.0 + 0.0j, -0.0 - 1.0j, 3.0625 - 1.25j, -(2 ** (-4)) + 247.25j],
+)
+@pytest.mark.parametrize("b_val", [0.0, -1.0, 3.0625, -(2**-7), 1234.0625])
+def test_arithmetic_with_apyfloat(
+    exp_bits: int,
+    man_bits: int,
+    a_val: complex,
+    b_val: float,
+):
+    a = APyCFloat.from_complex(a_val, exp_bits=exp_bits, man_bits=man_bits)
+    b = APyFloat.from_float(b_val, exp_bits=exp_bits, man_bits=man_bits)
+    assert (a + b).is_identical(
+        APyCFloat.from_complex(a_val + b_val, exp_bits, man_bits)
+    )
+    assert (a - b).is_identical(
+        APyCFloat.from_complex(a_val - b_val, exp_bits, man_bits)
+    )
+    assert (b + a).is_identical(
+        APyCFloat.from_complex(b_val + a_val, exp_bits, man_bits)
+    )
+    assert (b - a).is_identical(
+        APyCFloat.from_complex(b_val - a_val, exp_bits, man_bits), ignore_zero_sign=True
+    )
+    if exp_bits == 11 and man_bits == 52:
+        assert (a * b).is_identical(
+            APyCFloat.from_complex(a_val * complex(b_val), exp_bits, man_bits)
+        )
+        assert (b * a).is_identical(
+            APyCFloat.from_complex(b_val * complex(a_val), exp_bits, man_bits),
+            ignore_zero_sign=True,
+        )
+        if b != 0:
+            assert (a / b).is_identical(
+                APyCFloat.from_complex(
+                    complex_division_double_precision(a_val, b_val), exp_bits, man_bits
+                )
+            )
+        if a != 0:
+            assert (b / a).is_identical(
+                APyCFloat.from_complex(
+                    complex_division_double_precision(b_val, a_val), exp_bits, man_bits
+                )
+            )
+
+
+@pytest.mark.parametrize("exp_bits", [5, 11, 30])
+@pytest.mark.parametrize("man_bits", [10, 35, 52])
+@pytest.mark.parametrize(
+    "a_val, b_val",
+    product(
+        [0.0 + 0.0j, -1.0 + 0.0j, -0.0 - 1.0j, 3.0625 - 1.25j, -(2 ** (-4)) + 247.25j],
+        repeat=2,
+    ),
+)
+def test_arithmetic_with_apycfixed(
+    exp_bits: int,
+    man_bits: int,
+    a_val: complex,
+    b_val: complex,
+):
+    a = APyCFloat.from_complex(a_val, exp_bits=exp_bits, man_bits=man_bits)
+    b = APyCFixed.from_complex(b_val, int_bits=10, frac_bits=30)
+    assert (a + b) == APyCFloat.from_complex(a_val + b_val, exp_bits, man_bits)
+    assert (a - b) == APyCFloat.from_complex(a_val - b_val, exp_bits, man_bits)
+    assert (b + a) == APyCFloat.from_complex(b_val + a_val, exp_bits, man_bits)
+    assert (b - a) == APyCFloat.from_complex(b_val - a_val, exp_bits, man_bits)
+    if exp_bits == 11 and man_bits == 52:
+        assert (a * b) == APyCFloat.from_complex(a_val * b_val, exp_bits, man_bits)
+        assert (b * a) == APyCFloat.from_complex(b_val * a_val, exp_bits, man_bits)
+        if b != 0:
+            assert (a / b) == APyCFloat.from_complex(
+                complex_division_double_precision(a_val, b_val), exp_bits, man_bits
+            )
+
+
+@pytest.mark.parametrize("exp_bits", [5, 11, 30])
+@pytest.mark.parametrize("man_bits", [10, 35, 52])
+@pytest.mark.parametrize(
+    "a_val",
+    [0.0 + 0.0j, -1.0 + 0.0j, -0.0 - 1.0j, 3.0625 - 1.25j, -(2 ** (-4)) + 247.25j],
+)
+@pytest.mark.parametrize("b_val", [0.0, -1.0, 3.0625, -(2**-7), 1234.0625])
+def test_arithmetic_with_apyfixed(
+    exp_bits: int,
+    man_bits: int,
+    a_val: complex,
+    b_val: float,
+):
+    a = APyCFloat.from_complex(a_val, exp_bits=exp_bits, man_bits=man_bits)
+    b = APyFixed.from_float(b_val, int_bits=12, frac_bits=30)
+    assert (a + b) == APyCFloat.from_complex(a_val + b_val, exp_bits, man_bits)
+    assert (a - b) == APyCFloat.from_complex(a_val - b_val, exp_bits, man_bits)
+    assert (b + a) == APyCFloat.from_complex(b_val + a_val, exp_bits, man_bits)
+    assert (b - a) == APyCFloat.from_complex(b_val - a_val, exp_bits, man_bits)
+    if exp_bits == 11 and man_bits == 52:
+        assert (a * b) == APyCFloat.from_complex(a_val * b_val, exp_bits, man_bits)
+        assert (b * a) == APyCFloat.from_complex(b_val * a_val, exp_bits, man_bits)
+        if b != 0:
+            assert (a / b) == APyCFloat.from_complex(
+                complex_division_double_precision(a_val, b_val), exp_bits, man_bits
+            )

--- a/lib/test/apycfloat/test_comparisons.py
+++ b/lib/test/apycfloat/test_comparisons.py
@@ -1,0 +1,182 @@
+import pytest
+from apytypes import APyFixed, APyCFloat, APyCFixed, APyFloat
+from itertools import product
+
+
+@pytest.mark.float_comp
+def test_comparisons_with_floats():
+    a = APyCFloat.from_float(0.5, 3, 3)
+    assert not a == 0.0
+    assert not -a == 0.0
+    assert a != 0.0
+    assert -a != 0.0
+
+    assert a == 0.5
+    assert not -a == 0.5
+    assert not a != 0.5
+    assert -a != 0.5
+
+    a = APyCFloat.from_float(0.0, 3, 3)
+    assert a == 0.0
+    assert -a == 0.0
+    assert not a != 0.0
+    assert not -a != 0.0
+
+
+@pytest.mark.float_comp
+def test_comparisons_with_apyfixed():
+    a = APyCFloat.from_float(2.5, 5, 5)
+    b = APyFixed.from_float(5, 5, 5)
+    assert a != b
+    assert a == (b >> 1)
+
+    assert not (
+        APyCFloat.from_float(float("inf"), 4, 3) == APyFixed.from_float(1000, 16, 16)
+    )
+    assert not (
+        APyCFloat.from_float(float("nan"), 4, 3) == APyFixed.from_float(1000, 16, 16)
+    )
+    assert APyCFloat.from_float(float("nan"), 4, 3) != APyFixed.from_float(1000, 16, 16)
+    assert APyCFloat.from_float(float("inf"), 4, 3) != APyFixed.from_float(1000, 16, 16)
+
+
+@pytest.mark.float_comp
+@pytest.mark.parametrize(
+    "flp",
+    [
+        APyCFloat.from_complex(complex(0), exp_bits=15, man_bits=20),
+        APyCFloat.from_complex(complex(-1j), exp_bits=4, man_bits=19),
+        APyCFloat.from_complex(complex(-3.25), exp_bits=7, man_bits=17),
+        APyCFloat.from_complex(complex(3.25 - 5.125j), exp_bits=20, man_bits=50),
+        APyCFloat.from_complex(float("inf") + 0j, exp_bits=15, man_bits=51),
+        APyCFloat.from_complex(0 + float("inf") * 1j, exp_bits=10, man_bits=52),
+    ],
+)
+@pytest.mark.parametrize(
+    "fxp",
+    [
+        APyCFixed.from_complex(complex(0), int_bits=15, frac_bits=15),
+        APyCFixed.from_complex(complex(-1j), int_bits=10, frac_bits=0),
+        APyCFixed.from_complex(complex(-3.25), int_bits=7, frac_bits=250),
+        APyCFixed.from_complex(complex(3.25 - 5.125j), int_bits=19, frac_bits=5000),
+    ],
+)
+def test_comparisons_with_apycfixed(flp: APyCFloat, fxp: APyCFixed):
+    a = complex(flp)
+    b = complex(fxp)
+    assert (a == b) ^ (not flp == fxp)
+    assert (a != b) ^ (not flp != fxp)
+
+
+@pytest.mark.float_comp
+@pytest.mark.parametrize(
+    "cflp",
+    [
+        APyCFloat.from_complex(complex(0), exp_bits=15, man_bits=20),
+        APyCFloat.from_complex(complex(-1j), exp_bits=4, man_bits=19),
+        APyCFloat.from_complex(complex(-3.25), exp_bits=7, man_bits=17),
+        APyCFloat.from_complex(complex(3.25 - 5.125j), exp_bits=20, man_bits=50),
+        APyCFloat.from_complex(float("inf") + 0j, exp_bits=15, man_bits=51),
+        APyCFloat.from_complex(0 + float("inf") * 1j, exp_bits=10, man_bits=52),
+    ],
+)
+@pytest.mark.parametrize(
+    "flp",
+    [
+        APyFloat.from_float(0, exp_bits=10, man_bits=30),
+        APyFloat.from_float(-1, exp_bits=9, man_bits=10),
+        APyFloat.from_float(-3.25, exp_bits=7, man_bits=10),
+        APyFloat.from_float(3.25, exp_bits=20, man_bits=50),
+        APyFloat.from_float(float("inf"), exp_bits=15, man_bits=51),
+    ],
+)
+def test_comparisons_with_apyfloat(cflp: APyCFloat, flp: APyFloat):
+    a = complex(cflp)
+    b = float(flp)
+    assert (a == b) ^ (not cflp == flp)
+    assert (a != b) ^ (not cflp != flp)
+
+
+@pytest.mark.float_comp
+@pytest.mark.float_special
+def test_inf_comparison():
+    assert APyCFloat.from_float(float("inf"), 5, 5) == APyCFloat.from_float(
+        float("inf"), 5, 5
+    )
+    assert APyCFloat.from_float(float("inf"), 5, 5) == APyCFloat.from_float(
+        float("inf"), 3, 2
+    )
+    assert APyCFloat.from_float(float("inf"), 5, 5) != APyCFloat.from_float(
+        float("-inf"), 5, 5
+    )
+
+
+@pytest.mark.float_comp
+@pytest.mark.parametrize("a_sign", product([0, 1], repeat=2))
+@pytest.mark.parametrize("b_sign", product([0, 1], repeat=2))
+def test_signed_zero_comparison(a_sign: tuple[int, int], b_sign: tuple[int, int]):
+    a = APyCFloat(a_sign, (0, 0), (0, 0), 5, 10)
+    b = APyCFloat(b_sign, (0, 0), (0, 0), 5, 10)
+    assert a == b
+    assert not (a != b)
+    assert b == a
+    assert not (b != a)
+
+
+@pytest.mark.float_comp
+def test_mixed_bias_comparisons():
+    """Comparisons where all fields are different."""
+    # x and y are equal
+    x = APyCFloat(sign=0, exp=5, man=1, exp_bits=5, man_bits=2, bias=5)
+    y = APyCFloat(sign=0, exp=25, man=1, exp_bits=5, man_bits=2, bias=25)
+    assert x == y
+    assert not x != y
+
+    # Two normal numbers but y is smaller
+    y = APyCFloat(sign=0, exp=5, man=1, exp_bits=5, man_bits=2, bias=6)
+    assert not x == y
+    assert x != y
+
+    # Two equal subnormal numbers
+    x = APyCFloat(sign=0, exp=0, man=1, exp_bits=5, man_bits=2, bias=5)
+    y = APyCFloat(sign=0, exp=0, man=2, exp_bits=5, man_bits=2, bias=6)
+    assert x == y
+    assert not x != y
+
+    # Two subnormal numbers but y is slightly larger
+    y = APyCFloat(sign=0, exp=0, man=3, exp_bits=5, man_bits=2, bias=6)
+    assert not x == y
+    assert x != y
+
+    # Subnormal number equal to normal number
+    x = APyCFloat(sign=0, exp=0, man=1, exp_bits=5, man_bits=2, bias=5)
+    y = APyCFloat(sign=0, exp=1, man=0, exp_bits=5, man_bits=2, bias=7)
+    assert x == y
+    assert not x != y
+
+
+@pytest.mark.float_comp
+def test_mixed_format_comparisons():
+    """Comparisons with mixed formats."""
+    # x and y are equal
+    x = APyCFloat(sign=0, exp=5, man=2, exp_bits=4, man_bits=3, bias=5)
+    y = APyCFloat(sign=0, exp=25, man=1, exp_bits=5, man_bits=2, bias=25)
+    assert x == y
+    assert not x != y
+
+    # Two normal numbers but y is smaller
+    y = APyCFloat(sign=0, exp=7, man=3, exp_bits=5, man_bits=5, bias=8)
+    assert not x == y
+    assert x != y
+
+    # Two equal subnormal numbers
+    x = APyCFloat(sign=0, exp=0, man=1, exp_bits=5, man_bits=2, bias=5)
+    y = APyCFloat(sign=0, exp=0, man=4, exp_bits=4, man_bits=3, bias=6)
+    assert x == y
+    assert not x != y
+
+    # Two subnormal numbers but y is slightly larger
+    x = APyCFloat(sign=0, exp=0, man=1, exp_bits=5, man_bits=2, bias=5)
+    y = APyCFloat(sign=0, exp=0, man=5, exp_bits=4, man_bits=3, bias=6)
+    assert not x == y
+    assert x != y

--- a/lib/test/apycfloat/test_constructors.py
+++ b/lib/test/apycfloat/test_constructors.py
@@ -1,0 +1,91 @@
+from apytypes import APyCFloat, APyCFixed
+
+import pytest
+
+
+def test_constructor_raises():
+    # Does not throw
+    _ = APyCFloat(sign=(0, 1), exp=(7, 7), man=(9, 8), man_bits=7, exp_bits=6)
+    _ = APyCFloat(sign=(0,), exp=(7,), man=(9,), man_bits=7, exp_bits=6)
+    _ = APyCFloat((0, 1), (7, 7), (9, 8), 7, 6)
+    _ = APyCFloat((0,), (7,), (9,), 7, 6)
+
+    with pytest.raises(ValueError, match=r"APyCFloat\.__init__: different sized"):
+        _ = APyCFloat(sign=(1,), exp=(7, 7), man=(9, 8), man_bits=7, exp_bits=6)
+    with pytest.raises(ValueError, match=r"APyCFloat\.__init__: different sized"):
+        _ = APyCFloat(sign=(0, 1), exp=(7,), man=(9, 8), man_bits=7, exp_bits=6)
+    with pytest.raises(ValueError, match=r"APyCFloat\.__init__: different sized"):
+        _ = APyCFloat(sign=(0, 1), exp=(7, 7), man=(9,), man_bits=7, exp_bits=6)
+
+    with pytest.raises(ValueError, match=r"APyCFloat\.__init__: less than one element"):
+        _ = APyCFloat(sign=tuple(), exp=tuple(), man=tuple(), man_bits=7, exp_bits=6)
+
+    with pytest.raises(ValueError, match=r"APyCFloat\.__init__: more than two"):
+        _ = APyCFloat(
+            sign=(0, 1, 3), exp=(4, 4, 3), man=(3, 5, 7), man_bits=7, exp_bits=6
+        )
+
+    with pytest.raises(ValueError, match=r"APyCFloat\.__init__: sign is non-bool"):
+        _ = APyCFloat(sign=(0.0, 1), exp=(7, 7), man=(9, 8), man_bits=7, exp_bits=6)
+    with pytest.raises(ValueError, match=r"APyCFloat\.__init__: exponent is non-int"):
+        _ = APyCFloat(sign=(0, 1), exp=(7.0, 7), man=(9, 8), man_bits=7, exp_bits=6)
+    with pytest.raises(ValueError, match=r"APyCFloat\.__init__: mantissa is non-int"):
+        _ = APyCFloat(sign=(0, 1), exp=(7, 7), man=(9.0, 8), man_bits=7, exp_bits=6)
+    with pytest.raises(ValueError, match=r"APyCFloat\.__init__: sign is non-bool"):
+        _ = APyCFloat(sign=(0, 1.0), exp=(7, 7), man=(9, 8), man_bits=7, exp_bits=6)
+    with pytest.raises(ValueError, match=r"APyCFloat\.__init__: exponent is non-int"):
+        _ = APyCFloat(sign=(0, 1), exp=(7, 7.0), man=(9, 8), man_bits=7, exp_bits=6)
+    with pytest.raises(ValueError, match=r"APyCFloat\.__init__: mantissa is non-int"):
+        _ = APyCFloat(sign=(0, 1), exp=(7, 7), man=(9, 8.0), man_bits=7, exp_bits=6)
+
+    with pytest.raises(ValueError, match=r"Non supported type: "):
+        _ = APyCFloat.from_complex("hello", man_bits=10, exp_bits=8)
+
+    # These should not throw exceptions
+    _ = APyCFloat(sign=(0, 0), exp=(5, 5), man=(3, 3), exp_bits=8, man_bits=9)
+    _ = APyCFloat(sign=(1, 1), exp=(5, 5), man=(3, 3), exp_bits=8, man_bits=9)
+    _ = APyCFloat(sign=(False, False), exp=(5, 5), man=(3, 3), exp_bits=8, man_bits=9)
+    _ = APyCFloat(sign=(True, True), exp=(5, 5), man=(3, 3), exp_bits=8, man_bits=9)
+    _ = APyCFloat(sign=(0, False), exp=(5, 5), man=(3, 3), exp_bits=8, man_bits=9)
+    _ = APyCFloat(sign=(1, True), exp=(5, 5), man=(3, 3), exp_bits=8, man_bits=9)
+    _ = APyCFloat(sign=(False, 0), exp=(5, 5), man=(3, 3), exp_bits=8, man_bits=9)
+    _ = APyCFloat(sign=(True, 1), exp=(5, 5), man=(3, 3), exp_bits=8, man_bits=9)
+    _ = APyCFloat(sign=(True, 1), exp=(5, 5), man=(3, 3), exp_bits=8, man_bits=9)
+    _ = APyCFloat(sign=1, exp=5, man=3, exp_bits=8, man_bits=9)
+    _ = APyCFloat(sign=0, exp=5, man=3, exp_bits=8, man_bits=9)
+    _ = APyCFloat(sign=True, exp=5, man=3, exp_bits=8, man_bits=9)
+    _ = APyCFloat(sign=False, exp=5, man=3, exp_bits=8, man_bits=9)
+    _ = APyCFloat((0, 0), (5, 5), (3, 3), 8, 9)
+    _ = APyCFloat((1, 1), (5, 5), (3, 3), 8, 9)
+    _ = APyCFloat((False, False), (5, 5), (3, 3), 8, 9)
+    _ = APyCFloat((True, True), (5, 5), (3, 3), 8, 9)
+    _ = APyCFloat((0, False), (5, 5), (3, 3), 8, 9)
+    _ = APyCFloat((1, True), (5, 5), (3, 3), 8, 9)
+    _ = APyCFloat((False, 0), (5, 5), (3, 3), 8, 9)
+    _ = APyCFloat((True, 1), (5, 5), (3, 3), 8, 9)
+    _ = APyCFloat((True, 1), (5, 5), (3, 3), 8, 9)
+    _ = APyCFloat(1, 5, 3, 8, 9)
+    _ = APyCFloat(0, 5, 3, 8, 9)
+    _ = APyCFloat(True, 5, 3, 8, 9)
+    _ = APyCFloat(False, 5, 3, 8, 9)
+
+
+def test_from_complex():
+    assert APyCFloat.from_complex(0.0 + 0.0j, exp_bits=10, man_bits=10).is_identical(
+        APyCFloat(0, 0, 0, exp_bits=10, man_bits=10)
+    )
+    assert APyCFloat.from_complex(1.0 + 0.0j, exp_bits=10, man_bits=10).is_identical(
+        APyCFloat(0, 2**9 - 1, 0, exp_bits=10, man_bits=10)
+    )
+    assert APyCFloat.from_complex(1.0 - 2.0j, exp_bits=10, man_bits=10).is_identical(
+        APyCFloat((0, 1), (2**9 - 1, 2**9), (0, 0), exp_bits=10, man_bits=10)
+    )
+    assert APyCFloat.from_complex(3.0, exp_bits=10, man_bits=8).is_identical(
+        APyCFloat((0, 0), (2**9, 0), (2**7, 0), exp_bits=10, man_bits=8)
+    )
+    assert APyCFloat.from_complex(-4, exp_bits=10, man_bits=8).is_identical(
+        APyCFloat((True, 0), (2**9 + 1, 0), (0, 0), exp_bits=10, man_bits=8)
+    )
+    assert APyCFloat.from_complex(
+        APyCFixed.from_complex(-4, int_bits=10, frac_bits=8), exp_bits=10, man_bits=8
+    ).is_identical(APyCFloat((True, 0), (2**9 + 1, 0), (0, 0), exp_bits=10, man_bits=8))

--- a/lib/test/apycfloat/test_methods.py
+++ b/lib/test/apycfloat/test_methods.py
@@ -1,0 +1,178 @@
+from apytypes import APyCFloat, APyFloat
+from itertools import product
+
+
+import pytest
+
+
+def test_not_implemented():
+    _ = APyCFloat.from_complex(1.0, exp_bits=10, man_bits=20).__str__(base=10)
+
+    with pytest.raises(ValueError, match=r"APyCFloat::to_string_hex()"):
+        _ = APyCFloat.from_complex(1.0, exp_bits=10, man_bits=20).__str__(base=16)
+    with pytest.raises(ValueError, match=r"APyCFloat::to_string_oct()"):
+        _ = APyCFloat.from_complex(1.0, exp_bits=10, man_bits=20).__str__(base=8)
+    with pytest.raises(ValueError, match=r"APyCFloat::to_string\(base=17\): base is"):
+        _ = APyCFloat.from_complex(1.0, exp_bits=10, man_bits=20).__str__(base=17)
+
+
+@pytest.mark.parametrize("exp_bits", [5, 10, 11, 17])
+@pytest.mark.parametrize("man_bits", [11, 17, 20])
+@pytest.mark.parametrize("bias", [None, 17, 20])
+def test_bit_specifiers(exp_bits: int, man_bits: int, bias: int):
+    a = APyCFloat(0, 0, 0, exp_bits=exp_bits, man_bits=man_bits, bias=bias)
+    assert a.exp_bits == exp_bits
+    assert a.man_bits == man_bits
+    assert a.bias == (2 ** (exp_bits - 1) - 1) if bias is None else bias
+    assert a.bits == exp_bits + man_bits + 1
+
+
+@pytest.mark.parametrize("exp_bits", [5, 7, 11])
+@pytest.mark.parametrize("man_bits", [11, 13])
+@pytest.mark.parametrize("value", [0.0, -1.0j, 3.25j, -4.125, -4.125 + 3.25j])
+@pytest.mark.parametrize("ignore_zero_sign", [False, True])
+def test_is_identical(
+    exp_bits: int, man_bits: int, value: complex, ignore_zero_sign: bool
+):
+    my_float = APyCFloat.from_complex(value, exp_bits, man_bits)
+    a = APyCFloat.from_complex(0.0, exp_bits=7, man_bits=13)
+    b = APyCFloat.from_complex(0.0 + 3.25j, exp_bits=11, man_bits=11)
+    c = APyCFloat.from_complex(-4.125 + 0j, exp_bits=7, man_bits=11)
+    d = APyCFloat.from_complex(-4.125 + 3.25j, exp_bits=5, man_bits=13)
+
+    is_a: bool = value == 0.0 and exp_bits == 7 and man_bits == 13
+    is_b: bool = value == 3.25j and exp_bits == 11 and man_bits == 11
+    is_c: bool = value == -4.125 + 0j and exp_bits == 7 and man_bits == 11
+    is_d: bool = value == -4.125 + 3.25j and exp_bits == 5 and man_bits == 13
+    assert not (is_a ^ my_float.is_identical(a, ignore_zero_sign=ignore_zero_sign))
+    assert not (is_b ^ my_float.is_identical(b, ignore_zero_sign=ignore_zero_sign))
+    assert not (is_c ^ my_float.is_identical(c, ignore_zero_sign=ignore_zero_sign))
+    assert not (is_d ^ my_float.is_identical(d, ignore_zero_sign=ignore_zero_sign))
+
+
+@pytest.mark.parametrize("exp_bits", [5, 7, 11])
+@pytest.mark.parametrize("man_bits", [11, 13])
+@pytest.mark.parametrize("value", [0.0, -1.0j, 3.25j, -4.125, -4.125 + 3.25j])
+def test_comparison(exp_bits: int, man_bits: int, value: complex):
+    my_float = APyCFloat.from_complex(value, exp_bits, man_bits)
+    a = APyCFloat.from_complex(0.0, exp_bits=7, man_bits=13)
+    b = APyCFloat.from_complex(0.0 + 3.25j, exp_bits=11, man_bits=11)
+    c = APyCFloat.from_complex(-4.125 + 0j, exp_bits=7, man_bits=11)
+    d = APyCFloat.from_complex(-4.125 + 3.25j, exp_bits=5, man_bits=13)
+
+    equal_a: bool = value == 0.0
+    equal_b: bool = value == 3.25j
+    equal_c: bool = value == -4.125 + 0j
+    equal_d: bool = value == -4.125 + 3.25j
+    assert not (equal_a ^ (my_float == a)) and equal_a ^ (my_float != a)
+    assert not (equal_b ^ (my_float == b)) and equal_b ^ (my_float != b)
+    assert not (equal_c ^ (my_float == c)) and equal_c ^ (my_float != c)
+    assert not (equal_d ^ (my_float == d)) and equal_d ^ (my_float != d)
+
+
+def test_to_complex():
+    assert (
+        complex(APyCFloat((0, 0), exp=(0, 0), man=(0, 0), exp_bits=5, man_bits=5))
+        == 0 + 0j
+    )
+    assert (
+        complex(APyCFloat((1, 0), exp=(15, 0), man=(0, 0), exp_bits=5, man_bits=5))
+        == -1 + 0j
+    )
+    assert (
+        complex(APyCFloat((0, 0), exp=(15, 0), man=(8, 0), exp_bits=5, man_bits=5))
+        == 1.25 + 0j
+    )
+    assert (
+        complex(APyCFloat((1, 0), exp=(15, 0), man=(16, 0), exp_bits=5, man_bits=5))
+        == -1.5 + 0j
+    )
+    assert (
+        complex(APyCFloat((0, 1), exp=(0, 17), man=(0, 0), exp_bits=5, man_bits=5))
+        == 0 - 4j
+    )
+    assert (
+        complex(APyCFloat((0, 0), exp=(0, 17), man=(0, 2), exp_bits=5, man_bits=5))
+        == 0 + 4.25j
+    )
+    assert (
+        complex(APyCFloat((0, 1), exp=(14, 18), man=(8, 0), exp_bits=5, man_bits=5))
+        == 0.625 - 8j
+    )
+    assert (
+        complex(APyCFloat((0, 0), exp=(15, 18), man=(16, 0), exp_bits=5, man_bits=5))
+        == 1.5 + 8j
+    )
+
+
+@pytest.mark.parametrize("exp_bits", [5, 11])
+@pytest.mark.parametrize("man_bits", [11, 13])
+@pytest.mark.parametrize("sign", [(0, 0), (0, 1), (1, 1)])
+@pytest.mark.parametrize("exp", [(0, 0), (0, 17), (5, 9)])
+@pytest.mark.parametrize("man", [(0, 0), (13, 0), (5, 9)])
+@pytest.mark.parametrize("bias", [None, 27])
+def test_repr(
+    exp_bits: int,
+    man_bits: int,
+    bias: int | None,
+    sign: tuple[int, int],
+    exp: tuple[int, int],
+    man: tuple[int, int],
+):
+    a = APyCFloat(
+        sign=sign, exp=exp, man=man, exp_bits=exp_bits, man_bits=man_bits, bias=bias
+    )
+
+    repr_bias = "" if bias is None else f", bias={bias}"
+    repr_val = f"sign={sign}, exp={exp}, man={man}"
+    repr_bit_spec = f"exp_bits={exp_bits}, man_bits={man_bits}"
+
+    assert repr(a) == f"APyCFloat({repr_val}, {repr_bit_spec}{repr_bias})"
+
+
+def test_str():
+    assert (
+        str(APyCFloat((0, 0), exp=(0, 0), man=(0, 0), exp_bits=5, man_bits=5))
+        == "(0+0j)"
+    )
+    assert (
+        str(
+            APyCFloat((1, 0), exp=(63, 64), man=(2**18, 2**18), exp_bits=7, man_bits=19)
+        )
+        == "(-1.5+3j)"
+    )
+    assert (
+        str(
+            APyCFloat((1, 7), exp=(60, 61), man=(2**17, 2**16), exp_bits=7, man_bits=19)
+        )
+        == "(-0.15625-0.28125j)"
+    )
+    assert str(APyCFloat.from_float(complex("nan+nanj"), 7, 7)) == "(nan+nanj)"
+    assert str(APyCFloat.from_float(complex("nan-nanj"), 7, 7)) == "(nan+nanj)"
+    assert str(APyCFloat.from_float(complex("-nan+nanj"), 7, 7)) == "(nan+nanj)"
+    assert str(APyCFloat.from_float(complex("-nan-nanj"), 7, 7)) == "(nan+nanj)"
+
+
+@pytest.mark.parametrize("exp_bits", product([5, 11], repeat=2))
+@pytest.mark.parametrize("man_bits", product([11, 30, 51], repeat=2))
+@pytest.mark.parametrize("bias", product([None, 14], repeat=2))
+@pytest.mark.parametrize(
+    "value", (0.0, -0.0, 4.5, -62.0625, float("-inf"), -(2**11), 2**-11)
+)
+def test_from_apyfloat(
+    exp_bits: tuple[int, int],
+    man_bits: tuple[int, int],
+    bias: tuple[int | None, int | None],
+    value: float,
+):
+    a = APyFloat.from_float(
+        value, exp_bits=exp_bits[0], man_bits=man_bits[0], bias=bias[0]
+    )
+    b = APyCFloat.from_float(
+        a, exp_bits=exp_bits[1], man_bits=man_bits[1], bias=bias[1]
+    )
+    assert b.is_identical(
+        APyCFloat.from_float(
+            value, exp_bits=exp_bits[1], man_bits=man_bits[1], bias=bias[1]
+        )
+    )

--- a/lib/test/apycfloat/test_rounding.py
+++ b/lib/test/apycfloat/test_rounding.py
@@ -1,0 +1,24 @@
+from apytypes import APyCFloat, APyFloatQuantizationContext, QuantizationMode
+
+import pytest
+
+
+@pytest.mark.parametrize("apyfloat", [APyCFloat])
+def test_issue_245(apyfloat: type[APyCFloat]):
+    # Test that jamming bit *is* applied even when operands are zero
+    # https://github.com/apytypes/apytypes/issues/245
+    with APyFloatQuantizationContext(QuantizationMode.JAM):
+        res = apyfloat(0, 15, 0, 5, 2) + apyfloat(0, 0, 0, 5, 2)
+        assert res.is_identical(apyfloat((0, 0), (15, 0), (1, 1), 5, 2))
+
+    with APyFloatQuantizationContext(QuantizationMode.JAM):
+        res = apyfloat(0, 15, 0, 5, 2) - apyfloat(0, 0, 0, 5, 2)
+        assert res.is_identical(apyfloat((0, 0), (15, 0), (1, 1), 5, 2))
+
+    with APyFloatQuantizationContext(QuantizationMode.JAM):
+        res = apyfloat(0, 15, 0, 5, 2) * apyfloat(0, 0, 0, 5, 2)
+        assert res.is_identical(apyfloat((0, 0), (0, 0), (1, 1), 5, 2))
+
+    with APyFloatQuantizationContext(QuantizationMode.JAM):
+        res = apyfloat(0, 0, 0, 5, 2) / apyfloat(0, 15, 0, 5, 2)
+        assert res.is_identical(apyfloat((0, 0), (0, 0), (1, 1), 5, 2))

--- a/lib/test/apyfixed/test_arithmetic.py
+++ b/lib/test/apyfixed/test_arithmetic.py
@@ -4,61 +4,53 @@ import math
 import pytest
 
 
-@pytest.mark.parametrize("fixed_type", [APyFixed, APyCFixed])
-def test_arithmetic_operations(fixed_type):
-    a = fixed_type.from_float(-1.25, int_bits=2, frac_bits=4)
-    b = fixed_type.from_float(0.75, int_bits=2, frac_bits=3)
+@pytest.mark.parametrize("apyfixed", [APyFixed, APyCFixed])
+def test_arithmetic_operations(apyfixed: type[APyCFixed]):
+    a = apyfixed.from_float(-1.25, int_bits=2, frac_bits=4)
+    b = apyfixed.from_float(0.75, int_bits=2, frac_bits=3)
 
-    cb = fixed_type == APyCFixed  # Complex multiplication result in one extra `int_bit`
+    cb = apyfixed == APyCFixed  # Complex multiplication result in one extra `int_bit`
     assert (a * b).is_identical(
-        fixed_type.from_float(-0.9375, int_bits=4 + cb, frac_bits=7)
+        apyfixed.from_float(-0.9375, int_bits=4 + cb, frac_bits=7)
     )
     assert not (
-        (a * b).is_identical(
-            fixed_type.from_float(-0.9375, int_bits=4 + cb, frac_bits=5)
-        )
+        (a * b).is_identical(apyfixed.from_float(-0.9375, int_bits=4 + cb, frac_bits=5))
     )
-    assert (a + b).is_identical(fixed_type.from_float(-0.5, int_bits=3, frac_bits=4))
-    assert (b + a).is_identical(fixed_type.from_float(-0.5, int_bits=3, frac_bits=4))
-    assert (a - b).is_identical(fixed_type.from_float(-2, int_bits=3, frac_bits=4))
-    assert (b - a).is_identical(fixed_type.from_float(2, int_bits=3, frac_bits=4))
-    assert (a / b).is_identical(
-        fixed_type.from_float(-1.65625, int_bits=6, frac_bits=6)
-    )
-    assert (b / a).is_identical(
-        fixed_type.from_float(-0.59375, int_bits=7, frac_bits=5)
-    )
+    assert (a + b).is_identical(apyfixed.from_float(-0.5, int_bits=3, frac_bits=4))
+    assert (b + a).is_identical(apyfixed.from_float(-0.5, int_bits=3, frac_bits=4))
+    assert (a - b).is_identical(apyfixed.from_float(-2, int_bits=3, frac_bits=4))
+    assert (b - a).is_identical(apyfixed.from_float(2, int_bits=3, frac_bits=4))
+    assert (a / b).is_identical(apyfixed.from_float(-1.65625, int_bits=6, frac_bits=6))
+    assert (b / a).is_identical(apyfixed.from_float(-0.59375, int_bits=7, frac_bits=5))
 
     # Division-by-zero throws a ZeroDivisionError
     with pytest.raises(ZeroDivisionError, match="fixed-point division by zero"):
-        _ = fixed_type.from_float(1.0, 10, 10) / fixed_type.from_float(0.0, 10, 10)
+        _ = apyfixed.from_float(1.0, 10, 10) / apyfixed.from_float(0.0, 10, 10)
 
 
-@pytest.mark.parametrize("fixed_type", [APyFixed, APyCFixed])
-def test_overflow_twos_complement(fixed_type):
-    assert fixed_type(1 << 127, 1, 127) == -1.0
-    assert fixed_type(1 << 126, 1, 127) == 0.5
-    assert fixed_type(0xFFFFFFFF0 << 92, 1, 95) == 0.0
-    assert fixed_type(0xFFFFFFFF8 << 92, 1, 95) == -1.0
-    assert fixed_type(0xFFFFFFFF4 << 92, 1, 95) == 0.5
+@pytest.mark.parametrize("apyfixed", [APyFixed, APyCFixed])
+def test_overflow_twos_complement(apyfixed: type[APyCFixed]):
+    assert apyfixed(1 << 127, 1, 127) == -1.0
+    assert apyfixed(1 << 126, 1, 127) == 0.5
+    assert apyfixed(0xFFFFFFFF0 << 92, 1, 95) == 0.0
+    assert apyfixed(0xFFFFFFFF8 << 92, 1, 95) == -1.0
+    assert apyfixed(0xFFFFFFFF4 << 92, 1, 95) == 0.5
 
 
-@pytest.mark.parametrize("fixed_type", [APyFixed, APyCFixed])
-def test_binary_comparison_orderless(fixed_type):
+@pytest.mark.parametrize("apyfixed", [APyFixed, APyCFixed])
+def test_binary_comparison_orderless(apyfixed: type[APyCFixed]):
     assert not (
-        fixed_type.from_float(0.0, 256, 128) == fixed_type.from_float(1.0, 256, 128)
+        apyfixed.from_float(0.0, 256, 128) == apyfixed.from_float(1.0, 256, 128)
     )
-    assert fixed_type.from_float(0.0, 256, 128) != fixed_type.from_float(1.0, 256, 128)
-    assert fixed_type.from_float(1.0, 256, 128) == fixed_type.from_float(1.0, 256, 128)
+    assert apyfixed.from_float(0.0, 256, 128) != apyfixed.from_float(1.0, 256, 128)
+    assert apyfixed.from_float(1.0, 256, 128) == apyfixed.from_float(1.0, 256, 128)
     assert not (
-        fixed_type.from_float(1.0, 256, 128) != fixed_type.from_float(1.0, 140, 128)
+        apyfixed.from_float(1.0, 256, 128) != apyfixed.from_float(1.0, 140, 128)
     )
     assert not (
-        fixed_type.from_float(-1.0, 256, 128) == fixed_type.from_float(-3.0, 140, 128)
+        apyfixed.from_float(-1.0, 256, 128) == apyfixed.from_float(-3.0, 140, 128)
     )
-    assert fixed_type.from_float(-1.0, 256, 128) != fixed_type.from_float(
-        -3.0, 256, 128
-    )
+    assert apyfixed.from_float(-1.0, 256, 128) != apyfixed.from_float(-3.0, 256, 128)
 
 
 def test_binary_comparison_total_order():
@@ -84,47 +76,45 @@ def test_binary_comparison_total_order():
     assert APyFixed.from_float(-1.0, 256, 128) >= APyFixed.from_float(-3.0, 256, 128)
 
 
-@pytest.mark.parametrize("scalar_type", [int, float])
-@pytest.mark.parametrize("fixed_type", [APyFixed, APyCFixed])
-def test_float_and_int_comparison_orderless(scalar_type, fixed_type):
-    assert not fixed_type.from_float(0.0, 256, 128) == scalar_type(1.0)
-    assert fixed_type.from_float(0.0, 256, 128) != scalar_type(1.0)
+@pytest.mark.parametrize("py_type", [int, float])
+@pytest.mark.parametrize("apyfixed", [APyFixed, APyCFixed])
+def test_float_and_int_comparison_orderless(
+    py_type: type[float], apyfixed: type[APyCFixed]
+):
+    assert not apyfixed.from_float(0.0, 256, 128) == py_type(1.0)
+    assert apyfixed.from_float(0.0, 256, 128) != py_type(1.0)
 
-    assert fixed_type.from_float(1.0, 256, 128) == scalar_type(1.0)
-    assert not fixed_type.from_float(1.0, 256, 128) != scalar_type(1.0)
+    assert apyfixed.from_float(1.0, 256, 128) == py_type(1.0)
+    assert not apyfixed.from_float(1.0, 256, 128) != py_type(1.0)
 
-    assert not fixed_type.from_float(-1.0, 256, 128) == scalar_type(-3.0)
-    assert fixed_type.from_float(-1.0, 256, 128) != scalar_type(-3.0)
-
-
-@pytest.mark.parametrize("scalar_type", [int, float])
-def test_float_and_int_comparison_total_order(scalar_type):
-    assert not APyFixed.from_float(1.0, 256, 128) < scalar_type(1.0)
-    assert APyFixed.from_float(1.0, 256, 128) <= scalar_type(1.0)
-    assert not APyFixed.from_float(1.0, 256, 128) > scalar_type(1.0)
-    assert APyFixed.from_float(1.0, 256, 128) >= scalar_type(1.0)
-
-    assert not APyFixed.from_float(-1.0, 256, 128) < scalar_type(-3.0)
-    assert not APyFixed.from_float(-1.0, 256, 128) <= scalar_type(-3.0)
-    assert APyFixed.from_float(-1.0, 256, 128) > scalar_type(-3.0)
-    assert APyFixed.from_float(-1.0, 256, 128) >= scalar_type(-3.0)
-
-    assert APyFixed.from_float(0.0, 256, 128) < scalar_type(1.0)
-    assert APyFixed.from_float(0.0, 256, 128) <= scalar_type(1.0)
-    assert not APyFixed.from_float(0.0, 256, 128) > scalar_type(1.0)
-    assert not APyFixed.from_float(0.0, 256, 128) >= scalar_type(1.0)
+    assert not apyfixed.from_float(-1.0, 256, 128) == py_type(-3.0)
+    assert apyfixed.from_float(-1.0, 256, 128) != py_type(-3.0)
 
 
-@pytest.mark.parametrize("fixed_type", [APyFixed, APyCFixed])
-def test_narrow_add_sub(fixed_type):
+@pytest.mark.parametrize("py_type", [int, float])
+def test_float_and_int_comparison_total_order(py_type: type[float]):
+    assert not APyFixed.from_float(1.0, 256, 128) < py_type(1.0)
+    assert APyFixed.from_float(1.0, 256, 128) <= py_type(1.0)
+    assert not APyFixed.from_float(1.0, 256, 128) > py_type(1.0)
+    assert APyFixed.from_float(1.0, 256, 128) >= py_type(1.0)
+
+    assert not APyFixed.from_float(-1.0, 256, 128) < py_type(-3.0)
+    assert not APyFixed.from_float(-1.0, 256, 128) <= py_type(-3.0)
+    assert APyFixed.from_float(-1.0, 256, 128) > py_type(-3.0)
+    assert APyFixed.from_float(-1.0, 256, 128) >= py_type(-3.0)
+
+    assert APyFixed.from_float(0.0, 256, 128) < py_type(1.0)
+    assert APyFixed.from_float(0.0, 256, 128) <= py_type(1.0)
+    assert not APyFixed.from_float(0.0, 256, 128) > py_type(1.0)
+    assert not APyFixed.from_float(0.0, 256, 128) >= py_type(1.0)
+
+
+@pytest.mark.parametrize("apyfixed", [APyFixed, APyCFixed])
+def test_narrow_add_sub(apyfixed: type[APyCFixed]):
     for a_bits in range(10, 30):
         for b_bits in range(10, 30):
-            a = fixed_type.from_float(
-                a_bits + b_bits, bits=a_bits + 20, int_bits=b_bits
-            )
-            b = fixed_type.from_float(
-                a_bits + b_bits, bits=b_bits + 20, int_bits=a_bits
-            )
+            a = apyfixed.from_float(a_bits + b_bits, bits=a_bits + 20, int_bits=b_bits)
+            b = apyfixed.from_float(a_bits + b_bits, bits=b_bits + 20, int_bits=a_bits)
             assert a + b == float(2 * (a_bits + b_bits))
             assert a - b == 0.0
             assert a * b == float(a_bits + b_bits) ** 2
@@ -241,52 +231,52 @@ def test_wide_operations_special_cases():
     )
 
 
-@pytest.mark.parametrize("fixed_type", [APyFixed, APyCFixed])
-def test_mixed_width_operations(fixed_type):
+@pytest.mark.parametrize("apyfixed", [APyFixed, APyCFixed])
+def test_mixed_width_operations(apyfixed: type[APyCFixed]):
     """
     Tests for mixed-width operations additions and subtractions
     """
-    fx_a = fixed_type(1779, int_bits=8, frac_bits=8)
-    fx_b = fixed_type(17777779, int_bits=80, frac_bits=20)
-    assert (fx_a + fx_b).is_identical(fixed_type(25064563, bits=101, int_bits=81))
+    fx_a = apyfixed(1779, int_bits=8, frac_bits=8)
+    fx_b = apyfixed(17777779, int_bits=80, frac_bits=20)
+    assert (fx_a + fx_b).is_identical(apyfixed(25064563, bits=101, int_bits=81))
     assert (fx_b + fx_a).is_identical(fx_a + fx_b)
 
-    cb = fixed_type == APyCFixed  # Complex multiplication result in one extra `int_bit`
+    cb = apyfixed == APyCFixed  # Complex multiplication result in one extra `int_bit`
     assert (fx_a * fx_b).is_identical(
-        fixed_type(31626668841, bits=116 + cb, int_bits=88 + cb)
+        apyfixed(31626668841, bits=116 + cb, int_bits=88 + cb)
     )
     assert (fx_b * fx_a).is_identical(fx_a * fx_b)
 
     assert (fx_a / fx_b).is_identical(
-        fixed_type(126852202280499724136667184, bits=117, int_bits=29)
+        apyfixed(126852202280499724136667184, bits=117, int_bits=29)
     )
-    assert (fx_b / fx_a).is_identical(fixed_type(654909794, bits=117, int_bits=89))
-    assert (fx_a / fx_a).is_identical(fixed_type(65536, bits=33, int_bits=17))
+    assert (fx_b / fx_a).is_identical(apyfixed(654909794, bits=117, int_bits=89))
+    assert (fx_a / fx_a).is_identical(apyfixed(65536, bits=33, int_bits=17))
     assert (fx_b / fx_b).is_identical(
-        fixed_type(1267650600228229401496703205376, bits=201, int_bits=101)
+        apyfixed(1267650600228229401496703205376, bits=201, int_bits=101)
     )
 
 
-@pytest.mark.parametrize("fixed_type", [APyFixed, APyCFixed])
-def test_negative_fractional_bits_operations(fixed_type):
+@pytest.mark.parametrize("apyfixed", [APyFixed, APyCFixed])
+def test_negative_fractional_bits_operations(apyfixed: type[APyCFixed]):
     """
     Tests for mixed-width operations additions and subtractions
     """
-    fx_a = fixed_type(1779, int_bits=20, frac_bits=-4)
-    fx_b = fixed_type(1779, int_bits=30, frac_bits=-14)
-    s = fixed_type(1823475, bits=27, int_bits=31)
+    fx_a = apyfixed(1779, int_bits=20, frac_bits=-4)
+    fx_b = apyfixed(1779, int_bits=30, frac_bits=-14)
+    s = apyfixed(1823475, bits=27, int_bits=31)
     assert (fx_a + fx_b).is_identical(s)
     assert (fx_b + fx_a).is_identical(s)
 
-    cb = fixed_type == APyCFixed  # Complex multiplication result in one extra `int_bit`
-    p = fixed_type(3164841, bits=32 + cb, int_bits=50 + cb)
+    cb = apyfixed == APyCFixed  # Complex multiplication result in one extra `int_bit`
+    p = apyfixed(3164841, bits=32 + cb, int_bits=50 + cb)
     assert (fx_a * fx_b).is_identical(p)
     assert (fx_b * fx_a).is_identical(p)
 
-    assert (fx_a / fx_b).is_identical(fixed_type(65536, bits=33, int_bits=7))
-    assert (fx_b / fx_a).is_identical(fixed_type(65536, bits=33, int_bits=27))
-    assert (fx_a / fx_a).is_identical(fixed_type(65536, bits=33, int_bits=17))
-    assert (fx_b / fx_b).is_identical(fixed_type(65536, bits=33, int_bits=17))
+    assert (fx_a / fx_b).is_identical(apyfixed(65536, bits=33, int_bits=7))
+    assert (fx_b / fx_a).is_identical(apyfixed(65536, bits=33, int_bits=27))
+    assert (fx_a / fx_a).is_identical(apyfixed(65536, bits=33, int_bits=17))
+    assert (fx_b / fx_b).is_identical(apyfixed(65536, bits=33, int_bits=17))
 
 
 def test_unary_minus():
@@ -652,28 +642,28 @@ def test_pow():
 
 
 @pytest.mark.parametrize("bits", range(13, 90))
-def test_addition_different_wordlengths(bits):
+def test_addition_different_wordlengths(bits: int):
     a = APyFixed(3, bits=bits, int_bits=7)
     b = APyFixed(18, bits=bits, int_bits=7)
     assert (a + b).is_identical(APyFixed(21, bits=bits + 1, int_bits=8))
 
 
 @pytest.mark.parametrize("bits", range(13, 90))
-def test_addition_different_wordlengths_different_fracbits(bits):
+def test_addition_different_wordlengths_different_fracbits(bits: int):
     a = APyFixed(3, bits=bits, int_bits=8)
     b = APyFixed(18, bits=bits, int_bits=6)
     assert (a + b).is_identical(APyFixed(30, bits=bits + 3, int_bits=9))
 
 
 @pytest.mark.parametrize("bits", range(13, 90))
-def test_multiplication_different_wordlengths(bits):
+def test_multiplication_different_wordlengths(bits: int):
     a = APyFixed(3, bits=bits, int_bits=7)
     b = APyFixed(18, bits=bits, int_bits=7)
     assert (a * b).is_identical(APyFixed(54, bits=2 * bits, int_bits=14))
 
 
 @pytest.mark.parametrize("bits", range(13, 90))
-def test_multiplicatio_different_wordlengths_different_fracbits(bits):
+def test_multiplicatio_different_wordlengths_different_fracbits(bits: int):
     a = APyFixed(3, bits=bits, int_bits=8)
     b = APyFixed(18, bits=bits, int_bits=6)
     assert (a * b).is_identical(APyFixed(54, bits=2 * bits, int_bits=14))

--- a/lib/test/apyfloat/run_berkeley_cases.py
+++ b/lib/test/apyfloat/run_berkeley_cases.py
@@ -1,9 +1,11 @@
 """
-This is a script for running tests from Berkeley TestFloat.
-Note, in order to use the script one must have the binary testfloat_gen in PATH.
-The arguments are much like the arguments to testfloat_gen which one can read more about here: http://www.jhauser.us/arithmetic/TestFloat-3/doc/testfloat_gen.html
+This is a script for running tests from Berkeley TestFloat. Note, in order to use the
+script one must have the binary testfloat_gen in PATH. The arguments are much like the
+arguments to testfloat_gen which one can read more about here:
+http://www.jhauser.us/arithmetic/TestFloat-3/doc/testfloat_gen.html
 
-Information about how to use the script can be found by running "python run_berkeley_cases.py -h".
+Information about how to use the script can be found by running "python
+run_berkeley_cases.py -h".
 """
 
 import argparse
@@ -27,8 +29,9 @@ TEST_DIR = "./berkeley_tests/"
 
 def read_test_cases(testfile: str):
     """
-    Get a generator of test cases [operand, operand, reference]. The items only contains bit patterns,
-    so the floating-point format and operation must be known by the caller.
+    Get a generator of test cases [operand, operand, reference]. The items only contains
+    bit patterns, so the floating-point format and operation must be known by the
+    caller.
     """
     with open(testfile) as file:
         # Interpret each line as a set of hexadecimal integers. Last column with exception flags is ignored.
@@ -45,11 +48,13 @@ def generate_berkeley_test(
     filename: str = None,
 ) -> None:
     """
-    operation: Can be an arithmetic operation such 'f16_add' or f64_mul, or a conversation like 'ui32_to_f16' or 'f64_to_f16'.
-    quantization: Can be any of the quantization modes listed in the IEEE-754 standard, and jamming.
-    level: Can be either 1 or 2. With level 2 more test cases are generated, with better coverage.
+    operation: Can be an arithmetic operation such 'f16_add' or f64_mul, or a
+    conversation like 'ui32_to_f16' or 'f64_to_f16'. quantization: Can be any of the
+    quantization modes listed in the IEEE-754 standard, and jamming. level: Can be
+    either 1 or 2. With level 2 more test cases are generated, with better coverage.
     seed:
-    For more information visit: http://www.jhauser.us/arithmetic/TestFloat-3/doc/testfloat_gen.html
+    For more information see:
+    http://www.jhauser.us/arithmetic/TestFloat-3/doc/testfloat_gen.html
     """
     quant_arg = translate_quant_mode_berkeley_arg(quantization)
 
@@ -71,7 +76,10 @@ def generate_berkeley_test(
 
 
 def parse_format(format: str) -> tuple:
-    """Take a format as a string and return a tuple of the corresponding exponent and mantissa bits."""
+    """
+    Take a format as a string and return a tuple of the corresponding exponent and
+    mantissa bits.
+    """
     match format:
         case "f16":
             return (5, 10)
@@ -332,7 +340,8 @@ def print_summary(summary, output_file: str, seed: int, level: int) -> None:
     )
 
 
-# Solution from: https://stackoverflow.com/questions/3173320/text-progress-bar-in-terminal-with-block-characters
+# Solution from:
+# https://stackoverflow.com/questions/3173320/text-progress-bar-in-terminal-with-block-characters
 def printProgressBar(
     iteration,
     total,

--- a/lib/test/apyfloat/test_arithmetic.py
+++ b/lib/test/apyfloat/test_arithmetic.py
@@ -1,347 +1,372 @@
 from itertools import permutations as perm
 import math
 import pytest
-from apytypes import APyFloat
+from apytypes import APyFloat, APyCFloat
+
+
+def real_is_nan(fp: APyFloat | APyCFloat) -> bool:
+    """
+    Test if an `APyFloat` is NaN, or if the real part of an `APyCFloat` is NaN.
+
+    Parameters
+    ----------
+    fp : :class:`APyFloat` or :class:`APyCFloat`
+        The APyTypes floating-point number.
+    """
+    return fp.real.is_nan if isinstance(fp, APyCFloat) else fp.is_nan
+
+
+def real_is_inf(fp: APyFloat | APyCFloat) -> bool:
+    """
+    Test if an `APyFloat` is inf, or if the real part of an `APyCFloat` is inf.
+
+    Parameters
+    ----------
+    fp : :class:`APyFloat` or :class:`APyCFloat`
+        The APyTypes floating-point number.
+    """
+    return fp.real.is_inf if isinstance(fp, APyCFloat) else fp.is_inf
 
 
 # Negation
-@pytest.mark.parametrize("sign", ["-", ""])
-@pytest.mark.parametrize(
-    "float_s", ["13", "0.0", pytest.param("inf", marks=pytest.mark.float_special)]
-)
-def test_negation(float_s, sign):
-    float_s = sign + float_s
-    assert float(eval(f'-APyFloat.from_float(float("{float_s}"), 5, 5)')) == -float(
-        float_s
-    )
+@pytest.mark.parametrize("apyfloat, py_type", [(APyFloat, float), (APyCFloat, complex)])
+@pytest.mark.parametrize("val", [0.0, -0.0, -13.0, 13.0, float("inf"), float("-inf")])
+def test_negation(apyfloat: type[APyCFloat], py_type: type[complex], val: float):
+    assert py_type(-apyfloat.from_float(val, 5, 5)) == -val
 
 
 # Abs
-@pytest.mark.parametrize("sign", ["-", ""])
-@pytest.mark.parametrize(
-    "float_s", ["13", "0.0", pytest.param("inf", marks=pytest.mark.float_special)]
-)
-def test_abs(float_s, sign):
-    float_s = sign + float_s
-    assert float(eval(f'abs(APyFloat.from_float(float("{float_s}"), 5, 5))')) == abs(
-        float(float_s)
-    )
+@pytest.mark.parametrize("val", [0.0, -0.0, -13.0, 13.0, float("inf"), float("-inf")])
+def test_abs(val: float):
+    assert float(abs(APyFloat.from_float(val, 5, 5))) == abs(float(val))
 
 
 # Addition
 @pytest.mark.float_add
-@pytest.mark.parametrize("exp", list(perm(["5", "6", "10"], 2)))
-@pytest.mark.parametrize("man", list(perm(["5", "6", "10"], 2)))
-@pytest.mark.parametrize("sign", list(set(perm(["-", "-", "", ""], 2))))
-@pytest.mark.parametrize("lhs,rhs", list(perm(["2.75", "2.5", "16.5", "0"], 2)))
-def test_add_representable(exp, man, sign, lhs, rhs):
-    """Test additions where the operands and the result is exactly representable by the formats."""
-    expr = None
-    f = float(eval(f"{sign[0]}{lhs} + {sign[1]}{rhs}"))
-    e = max(int(exp[0]), int(exp[1]))
-    m = max(int(man[0]), int(man[1]))
-    print(repr(APyFloat.from_float(f, e, m)))
-    assert float(
-        eval(
-            expr
-            := f"APyFloat.from_float({sign[0]}{lhs}, {exp[0]}, {man[0]}) + APyFloat.from_float({sign[1]}{rhs}, {exp[1]}, {man[1]})"
-        )
-    ) == (float(eval(f"{sign[0]}{lhs} + {sign[1]}{rhs}")))
-    res = eval(expr)
-    assert res.exp_bits == max(int(exp[0]), int(exp[1]))
-    assert res.man_bits == max(int(man[0]), int(man[1]))
+@pytest.mark.parametrize("apyfloat, py_type", [(APyFloat, float), (APyCFloat, complex)])
+@pytest.mark.parametrize("exp_bits", list(perm([5, 6, 21], 2)))
+@pytest.mark.parametrize("man_bits", list(perm([5, 6, 61], 2)))
+@pytest.mark.parametrize("lhs, rhs", list(perm([-2.75, 2.75, -2.5, 2.5, 16.5, 0], 2)))
+def test_add_representable(
+    apyfloat: type[APyCFloat],
+    py_type: type[complex],
+    exp_bits: list[int],
+    man_bits: list[int],
+    lhs: float,
+    rhs: float,
+):
+    """
+    Test additions where the operands and the result is exactly representable by the
+    formats.
+    """
+    apy_lhs = apyfloat.from_float(lhs, exp_bits=exp_bits[0], man_bits=man_bits[0])
+    apy_rhs = apyfloat.from_float(rhs, exp_bits=exp_bits[1], man_bits=man_bits[1])
+    assert py_type(apy_lhs + apy_rhs) == py_type(lhs + rhs)
+    assert (apy_lhs + apy_rhs).exp_bits == max(exp_bits[0], exp_bits[1])
+    assert (apy_lhs + apy_rhs).man_bits == max(man_bits[0], man_bits[1])
 
 
 @pytest.mark.float_add
-def test_add_overflow():
+@pytest.mark.parametrize("apyfloat", [APyFloat, APyCFloat])
+def test_add_overflow(apyfloat: type[APyCFloat]):
     """Test that an addition can overflow."""
-    # To positive infinity
-    res = APyFloat(0, 30, 3, 5, 2) + APyFloat(0, 30, 3, 5, 2)
-    assert res.is_inf
+    res = apyfloat(0, 30, 3, 5, 2) + apyfloat(0, 30, 3, 5, 2)
+    assert res == apyfloat(0, 31, 0, 5, 2)
 
     # To negative infinity
-    res = APyFloat(1, 30, 3, 5, 2) + APyFloat(1, 30, 3, 5, 2)
-    assert res.is_inf
+    res = apyfloat(1, 30, 3, 5, 2) + apyfloat(1, 30, 3, 5, 2)
+    assert res == apyfloat(1, 31, 0, 5, 2)
 
     # Overflow to infinity after quantization
-    res = APyFloat(0, 30, 3, 5, 2) + APyFloat(0, 27, 0, 5, 2)
-    assert res.is_inf
+    res = apyfloat(0, 30, 3, 5, 2) + apyfloat(0, 27, 0, 5, 2)
+    assert res == apyfloat(0, 31, 0, 5, 2)
 
 
 @pytest.mark.float_add
-def test_add_subnormals():
+@pytest.mark.parametrize("apyfloat", [APyFloat, APyCFloat])
+def test_add_subnormals(apyfloat: type[APyCFloat]):
     # Add two subnormal numbers
-    res = APyFloat(0, 0, 1, 5, 3) + APyFloat(0, 0, 2, 5, 3)
-    assert res.is_identical(APyFloat(0, 0, 3, 5, 3))
+    res = apyfloat(0, 0, 1, 5, 3) + apyfloat(0, 0, 2, 5, 3)
+    assert res.is_identical(apyfloat(0, 0, 3, 5, 3))
 
     # Addition of subnormal numbers resulting in normal number
-    res = APyFloat(0, 0, 7, 5, 3) + APyFloat(0, 0, 1, 5, 3)
-    assert res.is_identical(APyFloat(0, 1, 0, 5, 3))
+    res = apyfloat(0, 0, 7, 5, 3) + apyfloat(0, 0, 1, 5, 3)
+    assert res.is_identical(apyfloat(0, 1, 0, 5, 3))
 
     # Add subnormal to normal number
-    res = APyFloat(0, 0, 1, 4, 3) + APyFloat(0, 1, 0, 4, 3)
-    assert res.is_identical(APyFloat(0, 1, 1, 4, 3))
+    res = apyfloat(0, 0, 1, 4, 3) + apyfloat(0, 1, 0, 4, 3)
+    assert res.is_identical(apyfloat(0, 1, 1, 4, 3))
 
     # Add subnormal to big normal number
-    res = APyFloat(0, 0, 1, 4, 3) + APyFloat(0, 7, 0, 4, 3)
-    assert res.is_identical(APyFloat(0, 7, 0, 4, 3))
+    res = apyfloat(0, 0, 1, 4, 3) + apyfloat(0, 7, 0, 4, 3)
+    assert res.is_identical(apyfloat(0, 7, 0, 4, 3))
 
 
 @pytest.mark.float_add
-@pytest.mark.parametrize("num", [APyFloat(0, 17, 123, 5, 7), APyFloat(0, 0, 123, 5, 7)])
-def test_add_zero(num):
-    assert (num + APyFloat(0, 0, 0, 5, 7)).is_identical(num)
-    assert (APyFloat(0, 0, 0, 5, 7) + num).is_identical(num)
+@pytest.mark.parametrize("apyfloat", [APyFloat, APyCFloat])
+@pytest.mark.parametrize("exp", [0, 3, 14, 17])
+@pytest.mark.parametrize("man", [0, 14, 123])
+def test_add_zero(apyfloat: type[APyCFloat], exp: int, man: int):
+    num = apyfloat(0, exp, man, exp_bits=5, man_bits=7)
+    zero = apyfloat(0, 0, 0, 5, 7)
+    assert (_ := num + zero).is_identical(num)
+    assert (_ := zero + num).is_identical(num)
+
+
+@pytest.mark.parametrize("apyfloat", [APyFloat, APyCFloat])
+@pytest.mark.parametrize("man", [0, 24, 123])
+@pytest.mark.parametrize("exp", [0, 3, 14])
+@pytest.mark.parametrize("sign", [False, True])
+def test_add_inf(apyfloat: type[APyCFloat], man: int, exp: int, sign: bool):
+    num = apyfloat(sign, exp, man, exp_bits=5, man_bits=7)
+    inf = apyfloat(0, 0x1F, 0, exp_bits=5, man_bits=7)
+    min_inf = apyfloat(0, 0x1F, 0, exp_bits=5, man_bits=7)
+    assert (_ := num + inf).is_identical(inf)
+    assert (_ := inf + num).is_identical(inf)
+    assert (_ := min_inf + num).is_identical(min_inf)
+    assert (_ := num + min_inf).is_identical(min_inf)
 
 
 @pytest.mark.float_add
-@pytest.mark.parametrize(
-    "num",
-    [
-        APyFloat(0, 17, 123, 5, 7),
-        APyFloat(0, 0, 123, 5, 7),
-        APyFloat(1, 17, 123, 5, 7),
-        APyFloat(1, 0, 123, 5, 7),
-        APyFloat(0, 7, 23, 4, 5),
-        APyFloat(1, 7, 23, 4, 5),
-    ],
-)
-def test_add_inf(num):
-    assert (num + APyFloat(0, 0x1F, 0, 5, 7)).is_identical(APyFloat(0, 0x1F, 0, 5, 7))
-    assert (APyFloat(0, 0x1F, 0, 5, 7) + num).is_identical(APyFloat(0, 0x1F, 0, 5, 7))
+@pytest.mark.parametrize("apyfloat", [APyFloat, APyCFloat])
+@pytest.mark.parametrize("man", [0, 24, 123])
+@pytest.mark.parametrize("exp", [0, 3, 14])
+@pytest.mark.parametrize("sign", [False, True])
+def test_add_nan(apyfloat: type[APyCFloat], man: int, exp: int, sign: bool):
+    num = apyfloat(sign, exp, man, exp_bits=5, man_bits=7)
+    nan = apyfloat(sign, 0x1F, 1, exp_bits=5, man_bits=7)
+    assert real_is_nan(_ := num + nan)
+    assert real_is_nan(_ := nan + num)
 
 
 @pytest.mark.float_add
-@pytest.mark.parametrize("num", [APyFloat(0, 17, 123, 5, 7), APyFloat(0, 0, 123, 5, 7)])
-def test_add_nan(num):
-    assert (num + APyFloat(0, 0x1F, 1, 5, 7)).is_nan
-    assert (APyFloat(0, 0x1F, 1, 5, 7) + num).is_nan
-
-
-@pytest.mark.float_add
-def test_add_inf_nan():
+@pytest.mark.parametrize("apyfloat", [APyFloat, APyCFloat])
+def test_add_inf_nan(apyfloat: type[APyCFloat]):
     # Infinity with NaN
-    assert (APyFloat(0, 0x1F, 0, 5, 7) + APyFloat(0, 0x1F, 1, 5, 7)).is_nan
-    assert (APyFloat(0, 0x1F, 1, 5, 7) + APyFloat(0, 0x1F, 0, 5, 7)).is_nan
+    for s1, s2 in ((0, 0), (0, 1), (1, 0), (1, 1)):
+        assert real_is_nan(apyfloat(s1, 0x1F, 0, 5, 7) + apyfloat(s2, 0x1F, 1, 5, 7))
+        assert real_is_nan(apyfloat(s1, 0x1F, 1, 5, 7) + apyfloat(s2, 0x1F, 0, 5, 7))
 
     # Infinity with infinity
-    assert (APyFloat(0, 0x1F, 0, 5, 7) + APyFloat(0, 0x1F, 0, 5, 7)).is_identical(
-        APyFloat(0, 0x1F, 0, 5, 7)
-    )
+    inf = apyfloat(0, 0x1F, 0, 5, 7)
+    assert (inf + inf).is_identical(inf)
+    assert real_is_nan(inf + -inf)
+    assert real_is_nan(-inf + inf)
+    assert (-inf + -inf).is_identical(-inf)
 
     # NaN with NaN
-    assert (APyFloat(0, 0x1F, 1, 5, 7) + APyFloat(0, 0x1F, 1, 5, 7)).is_nan
+    nan = apyfloat(0, 0x1F, 1, 5, 7)
+    assert real_is_nan(nan + nan)
 
 
 @pytest.mark.float_sub
-def test_sub_mixed_bias():
+@pytest.mark.parametrize("apyfloat", [APyFloat, APyCFloat])
+def test_sub_mixed_bias(apyfloat: type[APyCFloat]):
     # Test that the implementation doesn't do "x.cast() - y.cast()"
-    x = APyFloat(sign=0, exp=30, man=0, exp_bits=5, man_bits=2, bias=14)
-    y = APyFloat(sign=0, exp=30, man=0, exp_bits=5, man_bits=2, bias=16)
+    x = apyfloat(sign=0, exp=30, man=0, exp_bits=5, man_bits=2, bias=14)
+    y = apyfloat(sign=0, exp=30, man=0, exp_bits=5, man_bits=2, bias=16)
     assert (_ := x - y).is_identical(
-        APyFloat(sign=0, exp=30, man=2, exp_bits=5, man_bits=2, bias=15)
+        apyfloat(sign=0, exp=30, man=2, exp_bits=5, man_bits=2, bias=15)
     )
 
     # Test subtraction when two numbers are equal but with different formats
-    x = APyFloat(sign=0, exp=14, man=0, exp_bits=5, man_bits=2, bias=14)
-    y = APyFloat(sign=0, exp=21, man=0, exp_bits=5, man_bits=2, bias=21)
+    x = apyfloat(sign=0, exp=14, man=0, exp_bits=5, man_bits=2, bias=14)
+    y = apyfloat(sign=0, exp=21, man=0, exp_bits=5, man_bits=2, bias=21)
     assert (_ := x - y).is_identical(
-        APyFloat(sign=0, exp=0, man=0, exp_bits=5, man_bits=2, bias=17)
+        apyfloat(sign=0, exp=0, man=0, exp_bits=5, man_bits=2, bias=17)
     )
 
 
 @pytest.mark.float_add
-def test_add_mixed_bias_overflow():
+@pytest.mark.parametrize("apyfloat", [APyFloat, APyCFloat])
+def test_add_mixed_bias_overflow(apyfloat: type[APyCFloat]):
     """Test that a result can overflow to infinity due to a change in bias."""
-    x = APyFloat(sign=0, exp=21, man=0, exp_bits=5, man_bits=2, bias=5)
-    y = APyFloat(sign=0, exp=0, man=0, exp_bits=5, man_bits=2, bias=25)
+    x = apyfloat(sign=0, exp=21, man=0, exp_bits=5, man_bits=2, bias=5)
+    y = apyfloat(sign=0, exp=0, man=0, exp_bits=5, man_bits=2, bias=25)
 
     # Add with zero
     assert (_ := x + y).is_identical(
-        APyFloat(sign=0, exp=31, man=0, exp_bits=5, man_bits=2, bias=15)
+        apyfloat(sign=0, exp=31, man=0, exp_bits=5, man_bits=2, bias=15)
     )
 
     # Add with zero but with larger bias difference
-    y = APyFloat(sign=0, exp=0, man=0, exp_bits=5, man_bits=2, bias=27)
+    y = apyfloat(sign=0, exp=0, man=0, exp_bits=5, man_bits=2, bias=27)
     assert (_ := x + y).is_identical(
-        APyFloat(sign=0, exp=31, man=0, exp_bits=5, man_bits=2, bias=16)
+        apyfloat(sign=0, exp=31, man=0, exp_bits=5, man_bits=2, bias=16)
     )
 
     # Add with small normal number
-    y = APyFloat(sign=0, exp=1, man=1, exp_bits=5, man_bits=2, bias=28)
+    y = apyfloat(sign=0, exp=1, man=1, exp_bits=5, man_bits=2, bias=28)
     assert (_ := x + y).is_identical(
-        APyFloat(sign=0, exp=31, man=0, exp_bits=5, man_bits=2, bias=16)
+        apyfloat(sign=0, exp=31, man=0, exp_bits=5, man_bits=2, bias=16)
     )
 
     # Add with subnormal number
-    y = APyFloat(sign=0, exp=0, man=1, exp_bits=5, man_bits=2, bias=28)
+    y = apyfloat(sign=0, exp=0, man=1, exp_bits=5, man_bits=2, bias=28)
     assert (_ := x + y).is_identical(
-        APyFloat(sign=0, exp=31, man=0, exp_bits=5, man_bits=2, bias=16)
+        apyfloat(sign=0, exp=31, man=0, exp_bits=5, man_bits=2, bias=16)
     )
 
 
 @pytest.mark.float_add
-def test_add_double():
-    """Some tests for sanity checking addition with binary64. This uses the faster path."""
+@pytest.mark.parametrize("apyfloat", [APyFloat, APyCFloat])
+def test_add_double(apyfloat: type[APyCFloat]):
+    """
+    Some tests for sanity checking addition with binary64. This uses the faster path.
+    """
 
     # 2.5 + 24.5 = 27.0
-    x = APyFloat(sign=0, exp=1024, man=0x4000000000000, exp_bits=11, man_bits=52)
-    y = APyFloat(sign=0, exp=1027, man=0x8400000000000, exp_bits=11, man_bits=52)
+    x = apyfloat(sign=0, exp=1024, man=0x4000000000000, exp_bits=11, man_bits=52)
+    y = apyfloat(sign=0, exp=1027, man=0x8400000000000, exp_bits=11, man_bits=52)
     res = x + y
     assert res.is_identical(
-        APyFloat(sign=0, exp=1027, man=0xAC00000000000, exp_bits=11, man_bits=52)
+        apyfloat(sign=0, exp=1027, man=0xAC00000000000, exp_bits=11, man_bits=52)
     )
 
     # Add two subnormals
-    x = APyFloat(sign=0, exp=0, man=23, exp_bits=11, man_bits=61)
-    y = APyFloat(sign=0, exp=0, man=71, exp_bits=11, man_bits=61)
+    x = apyfloat(sign=0, exp=0, man=23, exp_bits=11, man_bits=61)
+    y = apyfloat(sign=0, exp=0, man=71, exp_bits=11, man_bits=61)
     res = x + y
-    assert res.is_identical(APyFloat(sign=0, exp=0, man=94, exp_bits=11, man_bits=61))
+    assert res.is_identical(apyfloat(sign=0, exp=0, man=94, exp_bits=11, man_bits=61))
 
     # Mixed formats. 1.75 + (-5) = -3.25
-    x = APyFloat(sign=0, exp=7, man=6, exp_bits=4, man_bits=3)
-    y = APyFloat(sign=1, exp=1025, man=0x4000000000000, exp_bits=11, man_bits=52)
+    x = apyfloat(sign=0, exp=7, man=6, exp_bits=4, man_bits=3)
+    y = apyfloat(sign=1, exp=1025, man=0x4000000000000, exp_bits=11, man_bits=52)
     res = x + y
     assert res.is_identical(
-        APyFloat(sign=1, exp=1024, man=0xA000000000000, exp_bits=11, man_bits=52)
+        apyfloat(sign=1, exp=1024, man=0xA000000000000, exp_bits=11, man_bits=52)
     )
 
     # 1.234324 + 5.21343 = 6.447754
-    # These numbers cannot be represented exactly but should be performed as the following
-    x = APyFloat(0, 1023, 0x3BFCA85CAAFBC, 11, 52)
-    y = APyFloat(0, 1025, 0x4DA8D64D7F0ED, 11, 52)
+    # These numbers cannot be represented exactly but should be performed as the
+    # following
+    x = apyfloat(0, 1023, 0x3BFCA85CAAFBC, 11, 52)
+    y = apyfloat(0, 1025, 0x4DA8D64D7F0ED, 11, 52)
     res = x + y
-    assert res.is_identical(APyFloat(0, 1025, 0x9CA80064A9CDC, 11, 52))
+    assert res.is_identical(apyfloat(0, 1025, 0x9CA80064A9CDC, 11, 52))
 
 
 @pytest.mark.float_add
-def test_long_add():
+@pytest.mark.parametrize("apyfloat", [APyFloat, APyCFloat])
+def test_long_add(apyfloat: type[APyCFloat]):
     """Some tests for sanity checking addition with longer formats."""
     # 2.5 + 24.5 = 27.0
-    x = APyFloat(sign=0, exp=1024, man=0x4000000000000 << 8, exp_bits=11, man_bits=60)
-    y = APyFloat(sign=0, exp=1027, man=0x8400000000000 << 8, exp_bits=11, man_bits=60)
+    x = apyfloat(sign=0, exp=1024, man=0x4000000000000 << 8, exp_bits=11, man_bits=60)
+    y = apyfloat(sign=0, exp=1027, man=0x8400000000000 << 8, exp_bits=11, man_bits=60)
     res = x + y
     assert res.is_identical(
-        APyFloat(sign=0, exp=1027, man=0xAC00000000000 << 8, exp_bits=11, man_bits=60)
+        apyfloat(sign=0, exp=1027, man=0xAC00000000000 << 8, exp_bits=11, man_bits=60)
     )
 
     # Add two subnormals
-    x = APyFloat(sign=0, exp=0, man=23, exp_bits=11, man_bits=61)
-    y = APyFloat(sign=0, exp=0, man=71, exp_bits=11, man_bits=61)
+    x = apyfloat(sign=0, exp=0, man=23, exp_bits=11, man_bits=61)
+    y = apyfloat(sign=0, exp=0, man=71, exp_bits=11, man_bits=61)
     res = x + y
-    assert res.is_identical(APyFloat(sign=0, exp=0, man=94, exp_bits=11, man_bits=61))
+    assert res.is_identical(apyfloat(sign=0, exp=0, man=94, exp_bits=11, man_bits=61))
 
     # Add two subnormals that becomes a normal number
-    x = APyFloat(sign=0, exp=0, man=(1 << 61) - 1, exp_bits=11, man_bits=61)
-    y = APyFloat(sign=0, exp=0, man=1, exp_bits=11, man_bits=61)
+    x = apyfloat(sign=0, exp=0, man=(1 << 61) - 1, exp_bits=11, man_bits=61)
+    y = apyfloat(sign=0, exp=0, man=1, exp_bits=11, man_bits=61)
     res = x + y
-    assert res.is_identical(APyFloat(sign=0, exp=1, man=0, exp_bits=11, man_bits=61))
+    assert res.is_identical(apyfloat(sign=0, exp=1, man=0, exp_bits=11, man_bits=61))
 
     # Mixed formats. 1.75 + (-5) = -3.25
-    x = APyFloat(sign=0, exp=7, man=6, exp_bits=4, man_bits=3)
-    y = APyFloat(sign=1, exp=1025, man=0x4000000000000 << 8, exp_bits=11, man_bits=60)
+    x = apyfloat(sign=0, exp=7, man=6, exp_bits=4, man_bits=3)
+    y = apyfloat(sign=1, exp=1025, man=0x4000000000000 << 8, exp_bits=11, man_bits=60)
     res = x + y
     assert res.is_identical(
-        APyFloat(sign=1, exp=1024, man=0xA000000000000 << 8, exp_bits=11, man_bits=60)
+        apyfloat(sign=1, exp=1024, man=0xA000000000000 << 8, exp_bits=11, man_bits=60)
     )
 
     # 1.234324 + 5.21343 = 6.447754
     # These numbers cannot be represented exactly but should be performed as the following
-    x = APyFloat(0, 1023, 0x3BFCA85CAAFBC << 8, 11, 60)
-    y = APyFloat(0, 1025, 0x4DA8D64D7F0ED << 8, 11, 60)
+    x = apyfloat(0, 1023, 0x3BFCA85CAAFBC << 8, 11, 60)
+    y = apyfloat(0, 1025, 0x4DA8D64D7F0ED << 8, 11, 60)
     res = x + y
-    assert res.is_identical(APyFloat(0, 1025, 0x9CA80064A9CDC << 8, 11, 60))
+    assert res.is_identical(apyfloat(0, 1025, 0x9CA80064A9CDC << 8, 11, 60))
 
     # Test carry from addition of mantissas
-    x = APyFloat(0, 1023, 1 << 59, 11, 60)
+    x = apyfloat(0, 1023, 1 << 59, 11, 60)
     res = x + x
-    assert res.is_identical(APyFloat(0, 1024, 1 << 59, 11, 60))
+    assert res.is_identical(apyfloat(0, 1024, 1 << 59, 11, 60))
 
     # Test carry from addition of mantissas can overflow to infinity
-    x = APyFloat(0, 2046, 1 << 59, 11, 60)
-    y = APyFloat(0, 2046, 1 << 59, 11, 60)
+    x = apyfloat(0, 2046, 1 << 59, 11, 60)
+    y = apyfloat(0, 2046, 1 << 59, 11, 60)
     res = x + y
-    assert res.is_identical(APyFloat(0, 2047, 0, 11, 60))
+    assert res.is_identical(apyfloat(0, 2047, 0, 11, 60))
 
     # Test carry from quantization
-    x = APyFloat(0, 1023, (1 << 60) - 1, 11, 60)
-    y = APyFloat(0, 1023 - 61, 0, 11, 60)  # Tie break
+    x = apyfloat(0, 1023, (1 << 60) - 1, 11, 60)
+    y = apyfloat(0, 1023 - 61, 0, 11, 60)  # Tie break
     res = x + y
-    assert res.is_identical(APyFloat(0, 1024, 0, 11, 60))
+    assert res.is_identical(apyfloat(0, 1024, 0, 11, 60))
 
     # Test carry from quantization can overflow to infinity
-    x = APyFloat(0, 2046, (1 << 60) - 1, 11, 60)
-    y = APyFloat(0, 2046 - 61, 0, 11, 60)  # Tie break
+    x = apyfloat(0, 2046, (1 << 60) - 1, 11, 60)
+    y = apyfloat(0, 2046 - 61, 0, 11, 60)  # Tie break
     res = x + y
-    assert res.is_identical(APyFloat(0, 2047, 0, 11, 60))
+    assert res.is_identical(apyfloat(0, 2047, 0, 11, 60))
 
     # Test subtracting infinities
-    x = APyFloat(0, 2047, 0, 11, 60)
-    y = APyFloat(1, 2047, 0, 11, 60)
+    x = apyfloat(0, 2047, 0, 11, 60)
+    y = apyfloat(1, 2047, 0, 11, 60)
     res = x + y
-    assert res.is_nan
+    assert real_is_nan(res)
 
     # Test subtracting two equal numbers
-    x = APyFloat(0, 1046, 1232143, 11, 60)
-    y = APyFloat(1, 1046, 1232143, 11, 60)
+    x = apyfloat(0, 1046, 1232143, 11, 60)
+    y = apyfloat(1, 1046, 1232143, 11, 60)
     res = x + y
-    assert res.is_identical(APyFloat(0, 0, 0, 11, 60))
+    assert res.is_identical(apyfloat(0, 0, 0, 11, 60))
 
 
 # Subtraction
-# Because subtraction is implemented as 'a+(-b)', the tests for addition will also cover subtraction,
-# but we still do some tests using the subtraction operator to make sure it's not broken.
+# Because subtraction is implemented as 'a+(-b)', the tests for addition will also cover
+# subtraction, but we still do some tests using the subtraction operator to make sure
+# it's not broken.
 @pytest.mark.float_sub
-@pytest.mark.parametrize(
-    "lhs,rhs",
-    list(perm(["APyFloat.from_float(2.75, 6, 5)", "APyFloat.from_float(2.5, 5, 7)"])),
-)
-def test_sub_same_exp(lhs, rhs):
-    # Subtract two numbers that have the same exponent
-    expr = None
-    assert float(eval(expr := f"{lhs} - {rhs}")) == (
-        0.25 if float(eval(lhs)) == 2.75 else -0.25
-    )
-    res = eval(expr)
-    assert res.exp_bits == 6
-    assert res.man_bits == 7
+@pytest.mark.parametrize("apyfloat", [APyFloat, APyCFloat])
+@pytest.mark.parametrize("val1", [0, 1.0, -1.0, 3.75, -3.75])
+@pytest.mark.parametrize("val2", [0, 1.0, -1.0, 3.75, -3.75])
+def test_sub_same_exp(apyfloat: type[APyCFloat], val1: float, val2: float):
+    fp1 = apyfloat.from_float(val1, 6, 5)
+    fp2 = apyfloat.from_float(val2, 5, 7)
+    assert (fp1 - fp2).is_identical(apyfloat.from_float(val1 - val2, 6, 7))
+    assert (fp2 - fp1).is_identical(apyfloat.from_float(val2 - val1, 6, 7))
 
 
 @pytest.mark.float_sub
-@pytest.mark.parametrize(
-    "lhs,rhs",
-    list(perm(["APyFloat.from_float(4, 9, 5)", "APyFloat.from_float(16, 5, 12)"])),
-)
-def test_sub_diff_exp(lhs, rhs):
-    # Subtract two numbers that have different exponent
-    expr = None
-    assert float(eval(expr := f"{lhs} - {rhs}")) == (
-        -12 if float(eval(lhs)) == 4 else 12
-    )
-    res = eval(expr)
-    assert res.exp_bits == 9
-    assert res.man_bits == 12
+@pytest.mark.parametrize("apyfloat", [APyFloat, APyCFloat])
+@pytest.mark.parametrize("val1", [0, 1.0, -1.0, 3.75, -3.75])
+@pytest.mark.parametrize("val2", [0, 1.0, -1.0, 3.75, -3.75])
+def test_sub_diff_exp(apyfloat: type[APyCFloat], val1: float, val2: float):
+    fp1 = apyfloat.from_float(val1, 9, 5)
+    fp2 = apyfloat.from_float(val2, 5, 12)
+    assert (fp1 - fp2).is_identical(apyfloat.from_float(val1 - val2, 9, 12))
+    assert (fp2 - fp1).is_identical(apyfloat.from_float(val2 - val1, 9, 12))
 
 
 @pytest.mark.float_sub
+@pytest.mark.parametrize("apyfloat", [APyFloat, APyCFloat])
 @pytest.mark.parametrize("t", [0, 2])
-def test_sub_large_exponent_diff(t):
+def test_sub_large_exponent_diff(apyfloat: type[APyCFloat], t: int):
     # 't' is used to test the case where the word lengths don't match
 
     # Exponent difference larger than 64
     b = 127
-    lhs = APyFloat(sign=0, exp=2, man=6193994, exp_bits=8, man_bits=23)
-    rhs = APyFloat(sign=1, exp=142 + t, man=65471, exp_bits=8, man_bits=23, bias=b + t)
-    ref = APyFloat(
+    lhs = apyfloat(sign=0, exp=2, man=6193994, exp_bits=8, man_bits=23)
+    rhs = apyfloat(sign=1, exp=142 + t, man=65471, exp_bits=8, man_bits=23, bias=b + t)
+    ref = apyfloat(
         sign=1, exp=142 + t // 2, man=65471, exp_bits=8, man_bits=23, bias=b + t // 2
     )
     res = lhs + rhs
     assert res.is_identical(ref)
 
     # Exponent difference equal to 64
-    lhs = APyFloat(sign=1, exp=191, man=983040, exp_bits=8, man_bits=23)
-    rhs = APyFloat(sign=1, exp=127 + t, man=57343, exp_bits=8, man_bits=23, bias=b + t)
-    ref = APyFloat(
+    lhs = apyfloat(sign=1, exp=191, man=983040, exp_bits=8, man_bits=23)
+    rhs = apyfloat(sign=1, exp=127 + t, man=57343, exp_bits=8, man_bits=23, bias=b + t)
+    ref = apyfloat(
         sign=1, exp=191 + t // 2, man=983040, exp_bits=8, man_bits=23, bias=b + t // 2
     )
     res = lhs + rhs
@@ -349,157 +374,182 @@ def test_sub_large_exponent_diff(t):
 
 
 @pytest.mark.float_sub
-def test_sub_diff_sign():
+@pytest.mark.parametrize("apyfloat", [APyFloat, APyCFloat])
+def test_sub_diff_sign(apyfloat: type[APyCFloat]):
     # Subtract two numbers that have different sign
     # 12 - -4
-    res = APyFloat(0, 258, 8, 9, 4) - APyFloat(1, 17, 0, 5, 14)
-    assert res.is_identical(APyFloat(0, 259, 0, 9, 14))
+    res = apyfloat(0, 258, 8, 9, 4) - apyfloat(1, 17, 0, 5, 14)
+    assert res.is_identical(apyfloat(0, 259, 0, 9, 14))
 
     # -4 - 12
-    res = APyFloat(1, 17, 0, 5, 14) - APyFloat(0, 258, 8, 9, 4)
-    assert res.is_identical(APyFloat(1, 259, 0, 9, 14))
+    res = apyfloat(1, 17, 0, 5, 14) - apyfloat(0, 258, 8, 9, 4)
+    assert res.is_identical(apyfloat(1, 259, 0, 9, 14))
 
 
 @pytest.mark.float_sub
-def test_sub_res_zero():
+@pytest.mark.parametrize("apyfloat", [APyFloat, APyCFloat])
+def test_sub_res_zero(apyfloat: type[APyCFloat]):
     # 12 - 12, same format
-    res = APyFloat(0, 258, 8, 9, 4) - APyFloat(0, 258, 8, 9, 4)
-    assert res.is_identical(APyFloat(0, 0, 0, 9, 4))
+    res = apyfloat(0, 258, 8, 9, 4) - apyfloat(0, 258, 8, 9, 4)
+    assert res.is_identical(apyfloat(0, 0, 0, 9, 4))
 
     # 12 - 12, different format
-    res = APyFloat(0, 258, 4, 9, 3) - APyFloat(0, 258, 8, 9, 4)
-    assert res.is_identical(APyFloat(0, 0, 0, 9, 4))
+    res = apyfloat(0, 258, 4, 9, 3) - apyfloat(0, 258, 8, 9, 4)
+    assert res.is_identical(apyfloat(0, 0, 0, 9, 4))
 
 
 @pytest.mark.float_sub
-def test_sub_overflow():
+@pytest.mark.parametrize("apyfloat", [APyFloat, APyCFloat])
+def test_sub_overflow(apyfloat: type[APyCFloat]):
     """Test that a subtraction can overflow."""
-    assert (APyFloat(1, 0b11110, 1, 5, 2) - APyFloat(0, 0b11110, 3, 5, 3)).is_inf
+    assert real_is_inf(apyfloat(1, 0b11110, 1, 5, 2) - apyfloat(0, 0b11110, 3, 5, 3))
 
 
 @pytest.mark.float_add
-def test_sub_subnormals():
+@pytest.mark.parametrize("apyfloat", [APyFloat, APyCFloat])
+def test_sub_subnormals(apyfloat: type[APyCFloat]):
     # Subtract two subnormal numbers
-    res = APyFloat(0, 0, 1, 5, 3) - APyFloat(0, 0, 2, 5, 3)
-    assert res.is_identical(APyFloat(1, 0, 1, 5, 3))
+    res = apyfloat(0, 0, 1, 5, 3) - apyfloat(0, 0, 2, 5, 3)
+    assert res.is_identical(apyfloat(1, 0, 1, 5, 3))
 
     # Subtraction of subnormal numbers resulting in normal number
-    res = APyFloat(1, 0, 7, 5, 3) - APyFloat(0, 0, 1, 5, 3)
-    assert res.is_identical(APyFloat(1, 1, 0, 5, 3))
+    res = apyfloat(1, 0, 7, 5, 3) - apyfloat(0, 0, 1, 5, 3)
+    assert res.is_identical(apyfloat(1, 1, 0, 5, 3))
 
     # Subtract subnormal from normal number
-    res = APyFloat(0, 1, 0, 4, 3) - APyFloat(0, 0, 1, 4, 3)
-    assert res.is_identical(APyFloat(0, 0, 7, 4, 3))
+    res = apyfloat(0, 1, 0, 4, 3) - apyfloat(0, 0, 1, 4, 3)
+    assert res.is_identical(apyfloat(0, 0, 7, 4, 3))
 
     # Subtract subnormal from big normal number
-    res = APyFloat(0, 7, 0, 4, 3) - APyFloat(0, 0, 1, 4, 3)
-    assert res.is_identical(APyFloat(0, 7, 0, 4, 3))
+    res = apyfloat(0, 7, 0, 4, 3) - apyfloat(0, 0, 1, 4, 3)
+    assert res.is_identical(apyfloat(0, 7, 0, 4, 3))
 
 
 @pytest.mark.float_sub
-@pytest.mark.parametrize("num", [APyFloat(0, 17, 123, 5, 7), APyFloat(0, 0, 123, 5, 7)])
-def test_sub_zero(num):
-    assert (num - APyFloat(0, 0, 0, 5, 7)).is_identical(num)
-    assert (APyFloat(0, 0, 0, 5, 7) - num).is_identical(-num)
+@pytest.mark.parametrize("apyfloat", [APyFloat, APyCFloat])
+@pytest.mark.parametrize("exp", [0, 17])
+def test_sub_zero(apyfloat: type[APyCFloat], exp: int):
+    num = apyfloat(0, exp, 123, 5, 7)
+    zero = apyfloat(0, 0, 0, 5, 7)
+    assert (num - zero) == num
+    assert (zero - num) == -num
+
+
+@pytest.mark.parametrize("apyfloat", [APyFloat, APyCFloat])
+@pytest.mark.parametrize("sign", [False, True])
+@pytest.mark.parametrize("exp", [0, 17])
+@pytest.mark.parametrize("man", [0, 123])
+@pytest.mark.parametrize("exp_bits", [5, 4])
+@pytest.mark.parametrize("man_bits", [6, 7])
+@pytest.mark.float_sub
+def test_sub_inf(
+    apyfloat: type[APyCFloat],
+    sign: bool,
+    exp: int,
+    man: int,
+    exp_bits: int,
+    man_bits: int,
+):
+    num = apyfloat(sign, exp, man, exp_bits=exp_bits, man_bits=man_bits)
+    inf = apyfloat(0, 0x1F, 0, exp_bits=5, man_bits=7)
+    assert (num - inf) == -inf
+    assert (inf - num).is_identical(inf)
+    assert (num - -inf).is_identical(inf)
+    assert (-inf - num).is_identical(-inf)
 
 
 @pytest.mark.float_sub
-@pytest.mark.parametrize(
-    "num",
-    [
-        APyFloat(0, 17, 123, 5, 7),
-        APyFloat(0, 0, 123, 5, 7),
-        APyFloat(1, 17, 123, 5, 7),
-        APyFloat(1, 0, 123, 5, 7),
-        APyFloat(0, 7, 23, 4, 6),
-        APyFloat(0, 0, 23, 4, 6),
-    ],
-)
-def test_sub_inf(num):
-    assert (num - APyFloat(0, 0x1F, 0, 5, 7)).is_identical(APyFloat(1, 0x1F, 0, 5, 7))
-    assert (APyFloat(0, 0x1F, 0, 5, 7) - num).is_identical(APyFloat(0, 0x1F, 0, 5, 7))
+@pytest.mark.parametrize("apyfloat", [APyFloat, APyCFloat])
+@pytest.mark.parametrize("sign", [False, True])
+@pytest.mark.parametrize("exp", [0, 17])
+@pytest.mark.parametrize("man", [0, 123])
+@pytest.mark.parametrize("exp_bits", [5, 4])
+@pytest.mark.parametrize("man_bits", [6, 7])
+def test_sub_nan(
+    apyfloat: type[APyCFloat],
+    sign: bool,
+    exp: int,
+    man: int,
+    exp_bits: int,
+    man_bits: int,
+):
+    num = apyfloat(sign, exp, man, exp_bits=exp_bits, man_bits=man_bits)
+    nan = apyfloat(0, 0x1F, 1, exp_bits=5, man_bits=7)
+    assert real_is_nan(num - nan)
+    assert real_is_nan(nan - num)
 
 
 @pytest.mark.float_sub
-@pytest.mark.parametrize("num", [APyFloat(0, 17, 123, 5, 7), APyFloat(0, 0, 123, 5, 7)])
-def test_sub_nan(num):
-    assert (num - APyFloat(0, 0x1F, 1, 5, 7)).is_nan
-    assert (APyFloat(0, 0x1F, 1, 5, 7) - num).is_nan
-
-
-@pytest.mark.float_sub
-def test_sub_inf_nan():
+@pytest.mark.parametrize("apyfloat", [APyFloat, APyCFloat])
+def test_sub_inf_nan(apyfloat: type[APyCFloat]):
     # Infinity with NaN
-    assert (APyFloat(0, 0x1F, 0, 5, 7) - APyFloat(0, 0x1F, 1, 5, 7)).is_nan
-    assert (APyFloat(0, 0x1F, 1, 5, 7) - APyFloat(0, 0x1F, 0, 5, 7)).is_nan
-    assert (
-        APyFloat(0, 0x1F, 1, 5, 8) - APyFloat(0, 0x1F, 0, 5, 7)
-    ).is_nan  # Different format
+    assert real_is_nan(apyfloat(0, 0x1F, 0, 5, 7) - apyfloat(0, 0x1F, 1, 5, 7))
+    assert real_is_nan(apyfloat(0, 0x1F, 1, 5, 7) - apyfloat(0, 0x1F, 0, 5, 7))
+    assert real_is_nan(apyfloat(0, 0x1F, 1, 5, 8) - apyfloat(0, 0x1F, 0, 5, 7))
 
     # Infinity with infinity
-    assert (APyFloat(0, 0x1F, 0, 5, 7) - APyFloat(0, 0x1F, 0, 5, 7)).is_nan
-    assert (
-        APyFloat(0, 0x1F, 0, 5, 5) - APyFloat(0, 0x1F, 0, 5, 7)
-    ).is_nan  # Different format
+    assert real_is_nan(apyfloat(0, 0x1F, 0, 5, 7) - apyfloat(0, 0x1F, 0, 5, 7))
+    assert real_is_nan(apyfloat(0, 0x1F, 0, 5, 5) - apyfloat(0, 0x1F, 0, 5, 7))
 
     # NaN with NaN
-    assert (APyFloat(0, 0x1F, 1, 5, 7) - APyFloat(0, 0x1F, 1, 5, 7)).is_nan
-    assert (
-        APyFloat(0, 0x1F, 1, 5, 8) - APyFloat(0, 0x1F, 1, 5, 7)
-    ).is_nan  # Different format
+    assert real_is_nan(apyfloat(0, 0x1F, 1, 5, 7) - apyfloat(0, 0x1F, 1, 5, 7))
+    assert real_is_nan(apyfloat(0, 0x1F, 1, 5, 8) - apyfloat(0, 0x1F, 1, 5, 7))
 
 
 # Multiplication
 @pytest.mark.float_mul
-@pytest.mark.parametrize("exp", list(perm(["5", "6", "7", "8"], 2)))
-@pytest.mark.parametrize("man", list(perm(["5", "6", "7", "8"], 2)))
-@pytest.mark.parametrize("sign", list(set(perm(["-", "-", "", ""], 2))))
-@pytest.mark.parametrize("lhs,rhs", list(perm(["2.75", "2.5", "0"], 2)))
-def test_mul_mixed(exp, man, sign, lhs, rhs):
-    """Test multiplications where the operands and the result is exactly representable by the formats."""
-    expr = None
-    assert float(
-        eval(
-            expr
-            := f"APyFloat.from_float({sign[0]}{lhs}, {exp[0]}, {man[0]}) * APyFloat.from_float({sign[1]}{rhs}, {exp[1]}, {man[1]})"
-        )
-    ) == (float(eval(f"{sign[0]}{lhs} * {sign[1]}{rhs}")))
-    res = eval(expr)
-    assert res.exp_bits == max(int(exp[0]), int(exp[1]))
-    assert res.man_bits == max(int(man[0]), int(man[1]))
+@pytest.mark.parametrize("apyfloat, py_type", [(APyFloat, float), (APyCFloat, complex)])
+@pytest.mark.parametrize("exp_bits", list(perm([6, 10, 29], 2)))
+@pytest.mark.parametrize("man_bits", list(perm([8, 23, 50], 2)))
+@pytest.mark.parametrize("lhs, rhs", list(perm([-2.75, 2.75, -2.5, 2.5, 11.5, 0], 2)))
+def test_mul_mixed(
+    apyfloat: type[APyCFloat],
+    py_type: type[complex],
+    exp_bits: list[int],
+    man_bits: list[int],
+    lhs: float,
+    rhs: float,
+):
+    """
+    Test multiplications where the operands and the result is exactly representable by
+    the formats.
+    """
+    apy_lhs = apyfloat.from_float(lhs, exp_bits=exp_bits[0], man_bits=man_bits[0])
+    apy_rhs = apyfloat.from_float(rhs, exp_bits=exp_bits[1], man_bits=man_bits[1])
+    apy_product = apy_lhs * apy_rhs
+    assert py_type(apy_product) == py_type(lhs * rhs)
+    assert apy_product.exp_bits == max(exp_bits[0], exp_bits[1])
+    assert apy_product.man_bits == max(man_bits[0], man_bits[1])
 
 
 @pytest.mark.float_mul
-def test_mul_overflow():
+@pytest.mark.parametrize("apyfloat", [APyFloat, APyCFloat])
+def test_mul_overflow(apyfloat: type[APyCFloat]):
     """Test that a multiplication can overflow to infinity."""
-    res = APyFloat(0, 0b11110, 1, 5, 2) * APyFloat(0, 0b11110, 3, 5, 3)
-    assert res.is_inf
+    res = apyfloat(0, 0b11110, 1, 5, 2) * apyfloat(0, 0b11110, 3, 5, 3)
+    assert real_is_inf(res)
 
 
 @pytest.mark.float_mul
-def test_mul_underflow():
+@pytest.mark.parametrize("apyfloat", [APyFloat, APyCFloat])
+def test_mul_underflow(apyfloat: type[APyCFloat]):
     """Test that a multiplication can underflow to zero."""
-    res = APyFloat(0, 1, 1, 5, 2) * APyFloat(0, 1, 3, 5, 3)
-    assert res == 0
-
-    res = APyFloat(0, 0, 31, 4, 5) * APyFloat(0, 0, 5, 4, 5)
-    assert res == 0
-
-    res = APyFloat(0, 0, 31, 4, 5) * APyFloat(0, 1, 1, 4, 5)
-    assert res == 0
+    assert (apyfloat(0, 1, 1, 5, 2) * apyfloat(0, 1, 3, 5, 3)).is_zero
+    assert (apyfloat(0, 0, 31, 4, 5) * apyfloat(0, 0, 5, 4, 5)).is_zero
+    assert (apyfloat(0, 0, 31, 4, 5) * apyfloat(0, 1, 1, 4, 5)).is_zero
 
     # From GH#406
-    res = APyFloat(0, 53, 32895, 8, 23) * APyFloat(1, 1, 1999049, 8, 23)
-    assert res == 0
+    assert (apyfloat(0, 53, 32895, 8, 23) * apyfloat(1, 1, 1999049, 8, 23)).is_zero
 
 
 @pytest.mark.float_mul
-def test_mul_with_one():
+@pytest.mark.parametrize("apyfloat", [APyFloat, APyCFloat])
+def test_mul_with_one(apyfloat: type[APyCFloat]):
     """Test multiplication with one."""
-    a = APyFloat(0, 7, 0, 4, 4)  # One
+    a = apyfloat(0, 7, 0, 4, 4)  # One
     for exp in reversed(range(15)):  # Skip nan/inf
         for man in reversed(range(16)):
-            b = APyFloat(0, exp, man, 4, 4)
+            b = apyfloat(0, exp, man, 4, 4)
             res = a * b
             assert res.is_identical(b)
             res = b * a
@@ -507,12 +557,13 @@ def test_mul_with_one():
 
 
 @pytest.mark.float_mul
-def test_long_mul_with_one():
+@pytest.mark.parametrize("apyfloat", [APyFloat, APyCFloat])
+def test_long_mul_with_one(apyfloat: type[APyCFloat]):
     """Test long multiplication with one."""
-    a = APyFloat.from_float(1.0, 10, 50)  # One
+    a = apyfloat.from_float(1.0, 10, 50)  # One
     for exp in reversed(range(1023)):  # Skip nan/inf
         for man in reversed(range(4)):  # Try subset
-            b = APyFloat(0, exp, man, 10, 50)
+            b = apyfloat(0, exp, man, 10, 50)
             res = a * b
             assert res.is_identical(b)
             res = b * a
@@ -520,288 +571,331 @@ def test_long_mul_with_one():
 
 
 @pytest.mark.float_mul
-def test_mul_mixed_bias():
+@pytest.mark.parametrize("apyfloat", [APyFloat, APyCFloat])
+def test_mul_mixed_bias(apyfloat: type[APyCFloat]):
     # Test that the implementation doesn't do "x.cast() * y.cast()"
-    x = APyFloat(sign=0, exp=30, man=0, exp_bits=5, man_bits=2, bias=14)
-    y = APyFloat(sign=0, exp=15, man=0, exp_bits=5, man_bits=2, bias=16)
+    x = apyfloat(sign=0, exp=30, man=0, exp_bits=5, man_bits=2, bias=14)
+    y = apyfloat(sign=0, exp=15, man=0, exp_bits=5, man_bits=2, bias=16)
     assert (_ := x * y).is_identical(
-        APyFloat(sign=0, exp=30, man=0, exp_bits=5, man_bits=2, bias=15)
+        apyfloat(sign=0, exp=30, man=0, exp_bits=5, man_bits=2, bias=15)
     )
 
     # Multiply two one's but with different formats
-    x = APyFloat(sign=0, exp=14, man=0, exp_bits=5, man_bits=2, bias=14)
-    y = APyFloat(sign=0, exp=21, man=0, exp_bits=5, man_bits=2, bias=21)
+    x = apyfloat(sign=0, exp=14, man=0, exp_bits=5, man_bits=2, bias=14)
+    y = apyfloat(sign=0, exp=21, man=0, exp_bits=5, man_bits=2, bias=21)
     assert (_ := x * y).is_identical(
-        APyFloat(sign=0, exp=17, man=0, exp_bits=5, man_bits=2, bias=17)
+        apyfloat(sign=0, exp=17, man=0, exp_bits=5, man_bits=2, bias=17)
     )
 
 
 @pytest.mark.float_mul
-def test_mul_mixed_bias_overflow():
+@pytest.mark.parametrize("apyfloat", [APyFloat, APyCFloat])
+def test_mul_mixed_bias_overflow(apyfloat: type[APyCFloat]):
     """Test that a result can overflow to infinity due to a change in bias."""
-    x = APyFloat(sign=0, exp=21, man=0, exp_bits=5, man_bits=2, bias=5)
-    y = APyFloat(sign=0, exp=25, man=0, exp_bits=5, man_bits=2, bias=25)
+    x = apyfloat(sign=0, exp=21, man=0, exp_bits=5, man_bits=2, bias=5)
+    y = apyfloat(sign=0, exp=25, man=0, exp_bits=5, man_bits=2, bias=25)
 
     # Multiply with one
     assert (_ := x * y).is_identical(
-        APyFloat(sign=0, exp=31, man=0, exp_bits=5, man_bits=2, bias=15)
+        apyfloat(sign=0, exp=31, man=0, exp_bits=5, man_bits=2, bias=15)
     )
 
     # Multiply with one but with larger bias difference
-    y = APyFloat(sign=0, exp=27, man=0, exp_bits=5, man_bits=2, bias=27)
+    y = apyfloat(sign=0, exp=27, man=0, exp_bits=5, man_bits=2, bias=27)
     assert (_ := x * y).is_identical(
-        APyFloat(sign=0, exp=31, man=0, exp_bits=5, man_bits=2, bias=16)
+        apyfloat(sign=0, exp=31, man=0, exp_bits=5, man_bits=2, bias=16)
     )
 
     # Should become one
-    x = APyFloat(sign=0, exp=30, man=0, exp_bits=5, man_bits=2, bias=3)
-    y = APyFloat(sign=0, exp=1, man=0, exp_bits=5, man_bits=2, bias=28)
+    x = apyfloat(sign=0, exp=30, man=0, exp_bits=5, man_bits=2, bias=3)
+    y = apyfloat(sign=0, exp=1, man=0, exp_bits=5, man_bits=2, bias=28)
     assert (_ := x * y).is_identical(
-        APyFloat(sign=0, exp=15, man=0, exp_bits=5, man_bits=2)
+        apyfloat(sign=0, exp=15, man=0, exp_bits=5, man_bits=2)
     )
 
 
 @pytest.mark.float_add
-def test_add_mixed_bias_underflow():
+@pytest.mark.parametrize("apyfloat", [APyFloat, APyCFloat])
+def test_add_mixed_bias_underflow(apyfloat: type[APyCFloat]):
     """Test that a result can become zero due to a change in bias."""
-    x = APyFloat(sign=0, exp=0, man=0, exp_bits=5, man_bits=2, bias=5)
-    y = APyFloat(sign=0, exp=1, man=1, exp_bits=5, man_bits=2, bias=25)
+    x = apyfloat(sign=0, exp=0, man=0, exp_bits=5, man_bits=2, bias=5)
+    y = apyfloat(sign=0, exp=1, man=1, exp_bits=5, man_bits=2, bias=25)
 
     # Add with zero
     assert (_ := x + y).is_identical(
-        APyFloat(sign=0, exp=0, man=0, exp_bits=5, man_bits=2, bias=15)
+        apyfloat(sign=0, exp=0, man=0, exp_bits=5, man_bits=2, bias=15)
     )
 
     # Add with zero but with larger bias difference
-    y = APyFloat(sign=0, exp=1, man=1, exp_bits=5, man_bits=2, bias=27)
+    y = apyfloat(sign=0, exp=1, man=1, exp_bits=5, man_bits=2, bias=27)
     assert (_ := x + y).is_identical(
-        APyFloat(sign=0, exp=0, man=0, exp_bits=5, man_bits=2, bias=16)
+        apyfloat(sign=0, exp=0, man=0, exp_bits=5, man_bits=2, bias=16)
     )
 
     # Add with subnormal number
-    y = APyFloat(sign=0, exp=0, man=1, exp_bits=5, man_bits=2, bias=28)
+    y = apyfloat(sign=0, exp=0, man=1, exp_bits=5, man_bits=2, bias=28)
     assert (_ := x + y).is_identical(
-        APyFloat(sign=0, exp=0, man=0, exp_bits=5, man_bits=2, bias=16)
+        apyfloat(sign=0, exp=0, man=0, exp_bits=5, man_bits=2, bias=16)
     )
 
 
 @pytest.mark.float_mul
+@pytest.mark.parametrize("apyfloat, py_type", [(APyFloat, float), (APyCFloat, complex)])
+@pytest.mark.parametrize("exp_bits", [4, 30])
+@pytest.mark.parametrize("man_bits", [10, 60])
 @pytest.mark.parametrize("x", [0.0, 1.0, float("inf"), float("nan")])
 @pytest.mark.parametrize("y", [0.0, 1.0, float("inf"), float("nan")])
 @pytest.mark.parametrize("sign", [1, -1])
-def test_mul_special_cases(x, y, sign):
-    """Test the special cases for addition."""
-    assert str(
-        float(APyFloat.from_float(x, 4, 4) * APyFloat.from_float(sign * y, 4, 4))
-    ) == str(x * sign * y)
+def test_mul_special_cases(
+    apyfloat: type[APyCFloat],
+    py_type: type[complex],
+    exp_bits: int,
+    man_bits: int,
+    x: float,
+    y: float,
+    sign: int,
+):
+    """
+    Test the special cases for addition. String assertions make sure that 'nan' == 'nan'
+    holds true, which is not the case for floating-points in general.
+    """
+    a = apyfloat.from_float(x, exp_bits=exp_bits, man_bits=man_bits)
+    b = apyfloat.from_float(sign * y, exp_bits=exp_bits, man_bits=man_bits)
+    assert str(py_type(a * b)) == str(py_type(x) * py_type(sign * y))
 
 
 @pytest.mark.float_mul
-def test_mul_short_subnormal():
-    x = APyFloat(sign=0, exp=0, man=11, exp_bits=4, man_bits=9)
-    y = APyFloat(sign=0, exp=5, man=50, exp_bits=5, man_bits=10)
+@pytest.mark.parametrize("apyfloat", [APyFloat, APyCFloat])
+def test_mul_short_subnormal(apyfloat: type[APyCFloat]):
+    x = apyfloat(sign=0, exp=0, man=11, exp_bits=4, man_bits=9)
+    y = apyfloat(sign=0, exp=5, man=50, exp_bits=5, man_bits=10)
     res = x * y
-    assert res.is_identical(APyFloat(sign=0, exp=0, man=6, exp_bits=5, man_bits=10))
+    assert res.is_identical(apyfloat(sign=0, exp=0, man=6, exp_bits=5, man_bits=10))
 
-    x = APyFloat(sign=0, exp=1, man=10, exp_bits=4, man_bits=10)
-    y = APyFloat(sign=0, exp=1, man=20, exp_bits=4, man_bits=10)
+    x = apyfloat(sign=0, exp=1, man=10, exp_bits=4, man_bits=10)
+    y = apyfloat(sign=0, exp=1, man=20, exp_bits=4, man_bits=10)
     res = x * y
-    assert res.is_identical(APyFloat(sign=0, exp=0, man=16, exp_bits=4, man_bits=10))
+    assert res.is_identical(apyfloat(sign=0, exp=0, man=16, exp_bits=4, man_bits=10))
 
-    x = APyFloat(sign=0, exp=1, man=10, exp_bits=5, man_bits=15)
-    y = APyFloat(sign=0, exp=1, man=20, exp_bits=5, man_bits=15)
+    x = apyfloat(sign=0, exp=1, man=10, exp_bits=5, man_bits=15)
+    y = apyfloat(sign=0, exp=1, man=20, exp_bits=5, man_bits=15)
     res = x * y
-    assert res.is_identical(APyFloat(sign=0, exp=0, man=2, exp_bits=5, man_bits=15))
+    assert res.is_identical(apyfloat(sign=0, exp=0, man=2, exp_bits=5, man_bits=15))
 
-    x = APyFloat(0, 3, 10, 4, 10)
-    y = APyFloat(0, 4, 10, 4, 10)
+    x = apyfloat(0, 3, 10, 4, 10)
+    y = apyfloat(0, 4, 10, 4, 10)
     res = x * y
-    assert res.is_identical(APyFloat(sign=0, exp=0, man=522, exp_bits=4, man_bits=10))
+    assert res.is_identical(apyfloat(sign=0, exp=0, man=522, exp_bits=4, man_bits=10))
 
     # 2.0 x subn
-    res = APyFloat(0, 8, 0, 4, 3) * APyFloat(0, 0, 1, 4, 3)
-    assert res.is_identical(APyFloat(0, 0, 2, 4, 3))
+    res = apyfloat(0, 8, 0, 4, 3) * apyfloat(0, 0, 1, 4, 3)
+    assert res.is_identical(apyfloat(0, 0, 2, 4, 3))
 
-    res = APyFloat(0, 8, 0, 4, 3) * APyFloat(0, 0, 2, 4, 3)
-    assert res.is_identical(APyFloat(0, 0, 4, 4, 3))
+    res = apyfloat(0, 8, 0, 4, 3) * apyfloat(0, 0, 2, 4, 3)
+    assert res.is_identical(apyfloat(0, 0, 4, 4, 3))
 
     # 4.0 x subn
-    res = APyFloat(0, 9, 0, 4, 3) * APyFloat(0, 0, 1, 4, 3)
-    assert res.is_identical(APyFloat(0, 0, 4, 4, 3))
+    res = apyfloat(0, 9, 0, 4, 3) * apyfloat(0, 0, 1, 4, 3)
+    assert res.is_identical(apyfloat(0, 0, 4, 4, 3))
 
     # subnormal becoming normal
-    res = APyFloat(0, 10, 0, 4, 3) * APyFloat(0, 0, 1, 4, 3)
-    assert res.is_identical(APyFloat(0, 1, 0, 4, 3))
+    res = apyfloat(0, 10, 0, 4, 3) * apyfloat(0, 0, 1, 4, 3)
+    assert res.is_identical(apyfloat(0, 1, 0, 4, 3))
 
     # 0.5 x subn
-    res = APyFloat(0, 6, 0, 4, 3) * APyFloat(0, 0, 4, 4, 3)
-    assert res.is_identical(APyFloat(0, 0, 2, 4, 3))
+    res = apyfloat(0, 6, 0, 4, 3) * apyfloat(0, 0, 4, 4, 3)
+    assert res.is_identical(apyfloat(0, 0, 2, 4, 3))
 
     # 0.25 x subn
-    res = APyFloat(0, 5, 0, 4, 3) * APyFloat(0, 0, 4, 4, 3)
-    assert res.is_identical(APyFloat(0, 0, 1, 4, 3))
+    res = apyfloat(0, 5, 0, 4, 3) * apyfloat(0, 0, 4, 4, 3)
+    assert res.is_identical(apyfloat(0, 0, 1, 4, 3))
 
     # 0.125 x subn
-    res = APyFloat(0, 4, 0, 4, 3) * APyFloat(0, 0, 4, 4, 3)
-    assert res.is_identical(APyFloat(0, 0, 0, 4, 3))
+    res = apyfloat(0, 4, 0, 4, 3) * apyfloat(0, 0, 4, 4, 3)
+    assert res.is_identical(apyfloat(0, 0, 0, 4, 3))
 
     # Two normal numbers that generate carry, but with subnormal result
-    a = APyFloat(sign=1, exp=2, man=957, exp_bits=5, man_bits=10)
-    b = APyFloat(sign=0, exp=12, man=1015, exp_bits=5, man_bits=10)
+    a = apyfloat(sign=1, exp=2, man=957, exp_bits=5, man_bits=10)
+    b = apyfloat(sign=0, exp=12, man=1015, exp_bits=5, man_bits=10)
     res = a * b
-    assert res.is_identical(APyFloat(sign=1, exp=0, man=986, exp_bits=5, man_bits=10))
+    assert res.is_identical(apyfloat(sign=1, exp=0, man=986, exp_bits=5, man_bits=10))
 
 
 @pytest.mark.float_mul
-def test_long_mul():
-    x = APyFloat(sign=0, exp=3, man=22, exp_bits=4, man_bits=7)
-    y = APyFloat(sign=1, exp=32763, man=813782734503116, exp_bits=16, man_bits=52)
-    assert x * y == APyFloat.from_float(float(x) * float(y), exp_bits=16, man_bits=52)
-
-    x = APyFloat.from_float(5200, exp_bits=17, man_bits=52)
-    assert x * y == APyFloat.from_float(float(x) * float(y), exp_bits=17, man_bits=52)
-    x = APyFloat(sign=0, exp=3, man=122, exp_bits=4, man_bits=7)
-    res = x * y
-    assert res.is_identical(
-        APyFloat(sign=1, exp=32760, man=689156585396703, exp_bits=16, man_bits=52)
-    )
-    x = APyFloat(sign=0, exp=3, man=2**20 - 1, exp_bits=4, man_bits=20)
-    y = APyFloat(sign=0, exp=32760, man=2**50 - 1, exp_bits=16, man_bits=50)
-    res = x * y
-    assert res.is_identical(
-        APyFloat(sign=0, exp=32757, man=1125898833100799, exp_bits=16, man_bits=50)
-    )
-    x = APyFloat(sign=0, exp=0, man=11, exp_bits=4, man_bits=9)
-    y = APyFloat(sign=0, exp=5, man=50, exp_bits=16, man_bits=50)
-    res = x * y
-    assert res.is_identical(
-        APyFloat(sign=0, exp=0, man=6047313952768, exp_bits=16, man_bits=50)
-    )
-    x = APyFloat(sign=0, exp=0, man=11, exp_bits=4, man_bits=20)
-    y = APyFloat(sign=0, exp=5, man=50, exp_bits=16, man_bits=50)
-    res = x * y
-    assert res.is_identical(
-        APyFloat(sign=0, exp=0, man=2952790016, exp_bits=16, man_bits=50)
+@pytest.mark.parametrize("apyfloat, py_type", [(APyFloat, float), (APyCFloat, complex)])
+def test_long_mul(apyfloat: type[APyCFloat], py_type: type[complex]):
+    x = apyfloat(sign=0, exp=3, man=22, exp_bits=4, man_bits=7)
+    y = apyfloat(sign=1, exp=32763, man=813782734503116, exp_bits=16, man_bits=52)
+    assert x * y == apyfloat.from_float(
+        py_type(x) * py_type(y), exp_bits=16, man_bits=52
     )
 
-    x = APyFloat(sign=0, exp=1020, man=11, exp_bits=10, man_bits=9)
-    y = APyFloat(sign=0, exp=4090, man=50, exp_bits=12, man_bits=50)
-    res = x * y
-    assert res.is_identical(APyFloat(sign=0, exp=4095, man=0, exp_bits=12, man_bits=50))
-    x = APyFloat(sign=0, exp=1, man=10, exp_bits=4, man_bits=40)
-    y = APyFloat(sign=0, exp=1, man=20, exp_bits=4, man_bits=40)
+    x = apyfloat.from_float(5200, exp_bits=17, man_bits=52)
+    assert x * y == apyfloat.from_float(
+        py_type(x) * py_type(y), exp_bits=17, man_bits=52
+    )
+    x = apyfloat(sign=0, exp=3, man=122, exp_bits=4, man_bits=7)
     res = x * y
     assert res.is_identical(
-        APyFloat(sign=0, exp=0, man=17179869184, exp_bits=4, man_bits=40)
+        apyfloat(sign=1, exp=32760, man=689156585396703, exp_bits=16, man_bits=52)
+    )
+    x = apyfloat(sign=0, exp=3, man=2**20 - 1, exp_bits=4, man_bits=20)
+    y = apyfloat(sign=0, exp=32760, man=2**50 - 1, exp_bits=16, man_bits=50)
+    res = x * y
+    assert res.is_identical(
+        apyfloat(sign=0, exp=32757, man=1125898833100799, exp_bits=16, man_bits=50)
+    )
+    x = apyfloat(sign=0, exp=0, man=11, exp_bits=4, man_bits=9)
+    y = apyfloat(sign=0, exp=5, man=50, exp_bits=16, man_bits=50)
+    res = x * y
+    assert res.is_identical(
+        apyfloat(sign=0, exp=0, man=6047313952768, exp_bits=16, man_bits=50)
+    )
+    x = apyfloat(sign=0, exp=0, man=11, exp_bits=4, man_bits=20)
+    y = apyfloat(sign=0, exp=5, man=50, exp_bits=16, man_bits=50)
+    res = x * y
+    assert res.is_identical(
+        apyfloat(sign=0, exp=0, man=2952790016, exp_bits=16, man_bits=50)
+    )
+
+    x = apyfloat(sign=0, exp=1020, man=11, exp_bits=10, man_bits=9)
+    y = apyfloat(sign=0, exp=4090, man=50, exp_bits=12, man_bits=50)
+    res = x * y
+    assert res.is_identical(apyfloat(sign=0, exp=4095, man=0, exp_bits=12, man_bits=50))
+    x = apyfloat(sign=0, exp=1, man=10, exp_bits=4, man_bits=40)
+    y = apyfloat(sign=0, exp=1, man=20, exp_bits=4, man_bits=40)
+    res = x * y
+    assert res.is_identical(
+        apyfloat(sign=0, exp=0, man=17179869184, exp_bits=4, man_bits=40)
     )
 
     # Test that quantization can generate carry
     # The mantissa product will be very close to 2 and thus round up
-    x = APyFloat(sign=0, exp=1023, man=4503599627370494, exp_bits=11, man_bits=52)
-    y = APyFloat(sign=0, exp=1023, man=1, exp_bits=11, man_bits=52)
+    x = apyfloat(sign=0, exp=1023, man=4503599627370494, exp_bits=11, man_bits=52)
+    y = apyfloat(sign=0, exp=1023, man=1, exp_bits=11, man_bits=52)
     res = x * y
-    assert res.is_identical(APyFloat(sign=0, exp=1024, man=0, exp_bits=11, man_bits=52))
+    assert res.is_identical(apyfloat(sign=0, exp=1024, man=0, exp_bits=11, man_bits=52))
 
     # Check that multiplication can overflow
-    x = APyFloat(sign=0, exp=2000, man=4503599627370494, exp_bits=11, man_bits=60)
-    y = APyFloat(sign=0, exp=2000, man=66454545455555, exp_bits=11, man_bits=60)
+    x = apyfloat(sign=0, exp=2000, man=4503599627370494, exp_bits=11, man_bits=60)
+    y = apyfloat(sign=0, exp=2000, man=66454545455555, exp_bits=11, man_bits=60)
     res = x * y
-    assert res.is_identical(APyFloat(sign=0, exp=2047, man=0, exp_bits=11, man_bits=60))
+    assert res.is_identical(apyfloat(sign=0, exp=2047, man=0, exp_bits=11, man_bits=60))
 
     # Subnormal becoming normal after quantization
-    x = APyFloat(
+    x = apyfloat(
         sign=0, exp=0, man=4503599627370495, exp_bits=11, man_bits=52
     )  # (2.22507e-308)
-    y = APyFloat(
+    y = apyfloat(
         sign=0, exp=1023, man=1, exp_bits=11, man_bits=52
     )  # Slightly larger than 1
     res = x * y
-    assert res.is_identical(APyFloat(sign=0, exp=1, man=0, exp_bits=11, man_bits=52))
+    assert res.is_identical(apyfloat(sign=0, exp=1, man=0, exp_bits=11, man_bits=52))
 
 
 @pytest.mark.float_div
-@pytest.mark.parametrize("exp", list(perm(["5", "8"], 2)))
-@pytest.mark.parametrize("man", list(perm(["5", "8"], 2)))
-@pytest.mark.parametrize("sign", list(set(perm(["-", "-", "", ""], 2))))
-@pytest.mark.parametrize("lhs,rhs", list(perm(["4.5", "1.125"], 2)))
-def test_div_mixed_formats(exp, man, sign, lhs, rhs):
-    """Test multiplications where the operands and the result is exactly representable by the formats."""
-    expr = None
-    assert float(
-        eval(
-            expr
-            := f"APyFloat.from_float({sign[0]}{lhs}, {exp[0]}, {man[0]}) / APyFloat.from_float({sign[1]}{rhs}, {exp[1]}, {man[1]})"
-        )
-    ) == (float(eval(f"{sign[0]}{lhs} / {sign[1]}{rhs}")))
-    res = eval(expr)
-    assert res.exp_bits == max(int(exp[0]), int(exp[1]))
-    assert res.man_bits == max(int(man[0]), int(man[1]))
+@pytest.mark.parametrize("apyfloat, py_type", [(APyFloat, float), (APyCFloat, complex)])
+@pytest.mark.parametrize("exp_bits", list(perm([5, 8, 29], 2)))
+@pytest.mark.parametrize("man_bits", list(perm([5, 8, 50], 2)))
+@pytest.mark.parametrize("lhs, rhs", list(perm([4.5, -4.5, 1.125, -1.125], 2)))
+def test_div_mixed_formats(
+    apyfloat: type[APyCFloat],
+    py_type: type[complex],
+    exp_bits: list[int],
+    man_bits: list[int],
+    lhs: float,
+    rhs: float,
+):
+    """
+    Test division where the operands and the result is exactly representable by the
+    formats.
+    """
+    a = apyfloat.from_float(lhs, exp_bits=exp_bits[0], man_bits=man_bits[0])
+    b = apyfloat.from_float(rhs, exp_bits=exp_bits[1], man_bits=man_bits[1])
+    div_res = a / b
+    assert py_type(div_res) == py_type(lhs) / py_type(rhs)
+    assert div_res.exp_bits == max(exp_bits[0], exp_bits[1])
+    assert div_res.man_bits == max(man_bits[0], man_bits[1])
 
 
 @pytest.mark.float_div
-def test_div_overflow():
+@pytest.mark.parametrize("apyfloat", [APyFloat, APyCFloat])
+def test_div_overflow(apyfloat: type[APyCFloat]):
     """Test that a division can overflow to infinity."""
-    assert (APyFloat(0, 30, 1, 5, 2) / APyFloat(0, 1, 3, 5, 2)).is_inf
-
-    assert (APyFloat(0, 30, 1, 5, 2) / APyFloat(0, 0, 3, 5, 2)).is_inf
+    assert real_is_inf(apyfloat(0, 30, 1, 5, 2) / apyfloat(0, 1, 3, 5, 2))
+    assert real_is_inf(apyfloat(0, 30, 1, 5, 2) / apyfloat(0, 0, 3, 5, 2))
 
 
 @pytest.mark.float_div
-def test_div_underflow():
+@pytest.mark.parametrize("apyfloat", [APyFloat, APyCFloat])
+def test_div_underflow(apyfloat: type[APyCFloat]):
     """Test that a division can underflow to zero."""
-    assert (APyFloat(0, 1, 3, 5, 2) / APyFloat(1, 30, 3, 5, 2)) == 0
-
-    assert (APyFloat(0, 0, 3, 5, 2) / APyFloat(1, 30, 3, 5, 2)) == 0
+    assert (apyfloat(0, 1, 3, 5, 2) / apyfloat(1, 30, 3, 5, 2)) == 0
+    assert (apyfloat(0, 0, 3, 5, 2) / apyfloat(1, 30, 3, 5, 2)) == 0
 
 
 @pytest.mark.float_div
+@pytest.mark.parametrize("apyfloat, py_type", [(APyFloat, float)])
 @pytest.mark.parametrize("x", [0, 1, float("inf"), float("nan")])
 @pytest.mark.parametrize("y", [0, 1, float("inf"), float("nan")])
-def test_div_special_cases(x, y):
-    """Test the special cases for division."""
+def test_div_special_cases(
+    apyfloat: type[APyCFloat], py_type: type[complex], x: int, y: int
+):
+    """
+    Test the special cases for division.
+
+    Complex-valued floating-point numbers need special treatment and are tested in:
+    'lib/apycfloat/test_arithmetic.py'
+    """
+    num = apyfloat.from_float(x, exp_bits=4, man_bits=4)
+    den = apyfloat.from_float(y, exp_bits=4, man_bits=4)
+    s = str(num / den)
     try:
-        assert (
-            s := str(float(APyFloat.from_float(x, 4, 4) / APyFloat.from_float(y, 4, 4)))
-        ) == str(x / y)
+        assert s == str(apyfloat.from_float(py_type(x) / py_type(y), 4, 4))
     except ZeroDivisionError:
         if x == 1 or x == float("inf"):
-            assert s == "inf"
+            ref = "inf"
+            assert s == ref
         else:
-            assert s == "nan"
+            ref = "nan"
+            assert s == ref
 
 
 @pytest.mark.float_div
-def test_div_with_one():
+@pytest.mark.parametrize("apyfloat", [APyFloat, APyCFloat])
+def test_div_with_one(apyfloat: type[APyCFloat]):
     """Test division with one."""
-    a = APyFloat(0, 7, 0, 4, 4)  # One
+    a = apyfloat(0, 7, 0, 4, 4)  # One
     for exp in reversed(range(15)):  # Skip nan/inf
         for man in reversed(range(16)):
-            b = APyFloat(0, exp, man, 4, 4)
+            b = apyfloat(0, exp, man, 4, 4)
             res = b / a
             assert res.is_identical(b)
 
 
 @pytest.mark.float_mul
-def test_long_div_with_one():
+@pytest.mark.parametrize("apyfloat", [APyFloat, APyCFloat])
+def test_long_div_with_one(apyfloat: type[APyCFloat]):
     """Test long division with one."""
-    a = APyFloat.from_float(1.0, 10, 50)  # One
+    a = apyfloat.from_float(1.0, 10, 50)  # One
     for exp in reversed(range(1023)):  # Skip nan/inf
         for man in reversed(range(4)):  # Try subset
-            b = APyFloat(0, exp, man, 10, 50)
+            b = apyfloat(0, exp, man, 10, 50)
             res = b / a
             assert res.is_identical(b)
 
 
 @pytest.mark.float_div
-def test_subnormal_div():
+@pytest.mark.parametrize("apyfloat", [APyFloat, APyCFloat])
+def test_subnormal_div(apyfloat: type[APyCFloat]):
     # Subnormal divided by 1
     # Related to https://github.com/apytypes/apytypes/issues/235
-    x = APyFloat(sign=0, exp=0, man=1, exp_bits=4, man_bits=7)
-    y = APyFloat(sign=0, exp=7, man=0, exp_bits=4, man_bits=7)
+    x = apyfloat(sign=0, exp=0, man=1, exp_bits=4, man_bits=7)
+    y = apyfloat(sign=0, exp=7, man=0, exp_bits=4, man_bits=7)
     res = x / y
     assert res.is_identical(x)
 
-    x = APyFloat(sign=0, exp=0, man=1, exp_bits=11, man_bits=60)
+    x = apyfloat(sign=0, exp=0, man=1, exp_bits=11, man_bits=60)
     res = x / y
     assert res.is_identical(x)
 
@@ -809,106 +903,117 @@ def test_subnormal_div():
 
 
 @pytest.mark.float_div
-def test_subnormal_quant_div():
+@pytest.mark.parametrize("apyfloat", [APyFloat, APyCFloat])
+def test_subnormal_quant_div(apyfloat: type[APyFloat]):
     """Subnormal becoming normal after quantization."""
-    res = APyFloat(sign=0, exp=1, man=1023, exp_bits=5, man_bits=10) / APyFloat(
+    res = apyfloat(sign=0, exp=1, man=1023, exp_bits=5, man_bits=10) / apyfloat(
         sign=0, exp=16, man=0, exp_bits=5, man_bits=10
     )
-    assert res.is_identical(APyFloat(sign=0, exp=1, man=0, exp_bits=5, man_bits=10))
+    assert res.is_identical(apyfloat(sign=0, exp=1, man=0, exp_bits=5, man_bits=10))
 
     # -2 / -8.98847e+307
-    res = APyFloat(
+    res = apyfloat(
         sign=1, exp=1023, man=4503599627370495, exp_bits=11, man_bits=52
-    ) / APyFloat(sign=1, exp=2046, man=0, exp_bits=11, man_bits=52)
-    assert res.is_identical(APyFloat(sign=0, exp=1, man=0, exp_bits=11, man_bits=52))
+    ) / apyfloat(sign=1, exp=2046, man=0, exp_bits=11, man_bits=52)
+    assert res == apyfloat(sign=0, exp=1, man=0, exp_bits=11, man_bits=52)
 
 
 @pytest.mark.float_div
-def test_long_div():
+@pytest.mark.parametrize("apyfloat", [APyFloat, APyCFloat])
+def test_long_div(apyfloat: type[APyCFloat]):
     # Division between two long formats
-    x = APyFloat(sign=0, exp=1036, man=1123081534184704, exp_bits=11, man_bits=52)
-    y = APyFloat(sign=1, exp=1031, man=178161345727614, exp_bits=11, man_bits=52)
+    x = apyfloat(sign=0, exp=1036, man=1123081534184704, exp_bits=11, man_bits=52)
+    y = apyfloat(sign=1, exp=1031, man=178161345727614, exp_bits=11, man_bits=52)
     res = x / y
-    assert res.is_identical(
-        APyFloat(sign=1, exp=1028, man=908961869920955, exp_bits=11, man_bits=52)
+    assert res == apyfloat(
+        sign=1, exp=1028, man=908961869920955, exp_bits=11, man_bits=52
     )
 
     # Test that division can underflow
-    x = APyFloat(sign=0, exp=1, man=1123081534184704, exp_bits=11, man_bits=52)
-    y = APyFloat(sign=1, exp=1078, man=178161345727614, exp_bits=11, man_bits=52)
+    x = apyfloat(sign=0, exp=1, man=1123081534184704, exp_bits=11, man_bits=52)
+    y = apyfloat(sign=1, exp=1078, man=178161345727614, exp_bits=11, man_bits=52)
     res = x / y
-    assert res.is_identical(APyFloat(sign=1, exp=0, man=0, exp_bits=11, man_bits=52))
+    assert res == apyfloat(sign=1, exp=0, man=0, exp_bits=11, man_bits=52)
 
     # Test that division can overflow
-    x = APyFloat(sign=0, exp=1, man=1123081534184704, exp_bits=11, man_bits=52)
-    y = APyFloat(sign=1, exp=1078, man=178161345727614, exp_bits=11, man_bits=52)
+    x = apyfloat(sign=0, exp=1, man=1123081534184704, exp_bits=11, man_bits=52)
+    y = apyfloat(sign=1, exp=1078, man=178161345727614, exp_bits=11, man_bits=52)
     res = y / x
-    assert res.is_identical(APyFloat(sign=1, exp=2047, man=0, exp_bits=11, man_bits=52))
+    assert res == apyfloat(sign=1, exp=2047, man=0, exp_bits=11, man_bits=52)
 
     # Test division with mixed formats
-    x = APyFloat(sign=0, exp=7, man=2, exp_bits=4, man_bits=3)
-    y = APyFloat(sign=1, exp=1025, man=1970324836974592, exp_bits=11, man_bits=52)
+    x = apyfloat(sign=0, exp=7, man=2, exp_bits=4, man_bits=3)
+    y = apyfloat(sign=1, exp=1025, man=1970324836974592, exp_bits=11, man_bits=52)
     res = x / y
-    assert res.is_identical(
-        APyFloat(sign=1, exp=1020, man=3328747550665149, exp_bits=11, man_bits=52)
+    assert res == apyfloat(
+        sign=1, exp=1020, man=3328747550665149, exp_bits=11, man_bits=52
     )
 
     # Test division with 1
-    x = APyFloat(sign=0, exp=0, man=1, exp_bits=14, man_bits=59)
-    y = APyFloat(sign=0, exp=1023, man=0, exp_bits=11, man_bits=59)
+    x = apyfloat(sign=0, exp=0, man=1, exp_bits=14, man_bits=59)
+    y = apyfloat(sign=0, exp=1023, man=0, exp_bits=11, man_bits=59)
     res = x / y
     assert res.is_identical(x)
 
     # Quantization should round x.man to 2 with division with 2
-    x = APyFloat(sign=0, exp=0, man=3, exp_bits=14, man_bits=59)
-    y = APyFloat(sign=0, exp=1024, man=0, exp_bits=11, man_bits=59)
+    x = apyfloat(sign=0, exp=0, man=3, exp_bits=14, man_bits=59)
+    y = apyfloat(sign=0, exp=1024, man=0, exp_bits=11, man_bits=59)
     res = x / y
-    assert res.is_identical(APyFloat(sign=0, exp=0, man=2, exp_bits=14, man_bits=59))
+    assert res.is_identical(apyfloat(sign=0, exp=0, man=2, exp_bits=14, man_bits=59))
 
 
 @pytest.mark.float_div
-def test_div_mixed_bias():
-    # Test that the implementation doesn't do "x.cast() / y.cast()"
-    x = APyFloat(sign=0, exp=30, man=0, exp_bits=5, man_bits=2, bias=4)
-    y = APyFloat(sign=0, exp=30, man=0, exp_bits=5, man_bits=2, bias=8)
+@pytest.mark.parametrize("apyfloat", [APyFloat])
+def test_div_mixed_bias(apyfloat: type[APyFloat]):
+    """
+    Test that the implementation doesn't do `x.cast() / y.cast()`
+    NOTE: For now, this does not hold true for `APyCFloat` which does exactly that...
+    """
+    x = apyfloat(sign=0, exp=30, man=0, exp_bits=5, man_bits=2, bias=4)
+    y = apyfloat(sign=0, exp=30, man=0, exp_bits=5, man_bits=2, bias=8)
     assert (_ := x / y).is_identical(
-        APyFloat(sign=0, exp=10, man=0, exp_bits=5, man_bits=2, bias=6)
+        apyfloat(sign=0, exp=10, man=0, exp_bits=5, man_bits=2, bias=6)
     )
 
 
 @pytest.mark.float_mul
-def test_div_mixed_bias_overflow():
-    """Test that a result can overflow to infinity due to a change in bias."""
-    x = APyFloat(sign=0, exp=21, man=0, exp_bits=5, man_bits=2, bias=5)
-    y = APyFloat(sign=0, exp=25, man=0, exp_bits=5, man_bits=2, bias=25)
+@pytest.mark.parametrize("apyfloat", [APyFloat])
+def test_div_mixed_bias_overflow(apyfloat: type[APyCFloat]):
+    """
+    Test that a result can overflow to infinity due to a change in bias.
+    NOTE: For now, this does not hold true for `APyCFloat` since: `x.cast() / y.cast()`
+    """
+    x = apyfloat(sign=0, exp=21, man=0, exp_bits=5, man_bits=2, bias=5)
+    y = apyfloat(sign=0, exp=25, man=0, exp_bits=5, man_bits=2, bias=25)
 
     # Divide with one
     assert (_ := x / y).is_identical(
-        APyFloat(sign=0, exp=31, man=0, exp_bits=5, man_bits=2, bias=15)
+        apyfloat(sign=0, exp=31, man=0, exp_bits=5, man_bits=2, bias=15)
     )
 
     # Divide with one but with larger bias difference
-    y = APyFloat(sign=0, exp=27, man=0, exp_bits=5, man_bits=2, bias=27)
+    y = apyfloat(sign=0, exp=27, man=0, exp_bits=5, man_bits=2, bias=27)
     assert (_ := x / y).is_identical(
-        APyFloat(sign=0, exp=31, man=0, exp_bits=5, man_bits=2, bias=16)
+        apyfloat(sign=0, exp=31, man=0, exp_bits=5, man_bits=2, bias=16)
     )
 
 
 @pytest.mark.float_add
-def test_div_mixed_bias_underflow():
+@pytest.mark.parametrize("apyfloat", [APyFloat, APyCFloat])
+def test_div_mixed_bias_underflow(apyfloat: type[APyCFloat]):
     """Test that a result can become zero due to a change in bias."""
-    x = APyFloat(sign=0, exp=1, man=1, exp_bits=5, man_bits=2, bias=25)
-    y = APyFloat(sign=0, exp=5, man=0, exp_bits=5, man_bits=2, bias=5)
+    x = apyfloat(sign=0, exp=1, man=1, exp_bits=5, man_bits=2, bias=25)
+    y = apyfloat(sign=0, exp=5, man=0, exp_bits=5, man_bits=2, bias=5)
 
     # Divide with one
     assert (_ := x / y).is_identical(
-        APyFloat(sign=0, exp=0, man=0, exp_bits=5, man_bits=2, bias=15)
+        apyfloat(sign=0, exp=0, man=0, exp_bits=5, man_bits=2, bias=15)
     )
 
     # Divide with one but with larger bias difference
-    x = APyFloat(sign=0, exp=1, man=1, exp_bits=5, man_bits=2, bias=30)
+    x = apyfloat(sign=0, exp=1, man=1, exp_bits=5, man_bits=2, bias=30)
     assert (_ := x / y).is_identical(
-        APyFloat(sign=0, exp=0, man=0, exp_bits=5, man_bits=2, bias=17)
+        apyfloat(sign=0, exp=0, man=0, exp_bits=5, man_bits=2, bias=17)
     )
 
 
@@ -1126,15 +1231,17 @@ def test_power_special_cases(x, n, test_exp):
         assert eval(f"float(APyFloat.from_float(float({x}), 9, 7)**{n})") == test_exp
 
 
+@pytest.mark.parametrize("apyfloat", [APyFloat, APyCFloat])
 @pytest.mark.float_add
-def test_sum():
-    s = [APyFloat.from_float(0.3, 2, 5), APyFloat.from_float(0.7, 4, 7)]
+def test_sum(apyfloat: type[APyCFloat]):
+    s = [apyfloat.from_float(0.3, 2, 5), apyfloat.from_float(0.7, 4, 7)]
     assert sum(s).is_identical(s[0] + s[1])
 
 
+@pytest.mark.parametrize("apyfloat", [APyFloat, APyCFloat])
 @pytest.mark.float_mul
-def test_prod():
-    s = [APyFloat.from_float(0.3, 2, 5), APyFloat.from_float(0.7, 4, 7)]
+def test_prod(apyfloat: type[APyCFloat]):
+    s = [apyfloat.from_float(0.3, 2, 5), apyfloat.from_float(0.7, 4, 7)]
     assert math.prod(s).is_identical(s[0] * s[1])
 
 
@@ -1157,21 +1264,22 @@ def test_binary_logic():
     assert (~d).is_identical(APyFloat(1, 0, 62, 5, 6))
 
 
-def test_operation_with_numbers():
-    a = APyFloat(0, 15, 2, 5, 2)  # 1.75
+@pytest.mark.parametrize("apyfloat", [APyFloat, APyCFloat])
+def test_operation_with_numbers(apyfloat: type[APyCFloat]):
+    a = apyfloat(0, 15, 2, 5, 2)  # 1.75
 
     # Integer identities
     assert (a + 0).is_identical(a)
     assert (0 + a).is_identical(a)
     assert (a - 0).is_identical(a)
-    assert (0 - a).is_identical(-a)
+    assert (0 - a) == -a
     assert (a * 1).is_identical(a)
     assert (1 * a).is_identical(a)
     assert (a / 1).is_identical(a)
 
     # Operations with floats
     q_eight = 9  # Should quantize to eight
-    eight = APyFloat(0, 18, 0, 5, 2)
+    eight = apyfloat(0, 18, 0, 5, 2)
     assert (_ := a + q_eight).is_identical(a + eight)
     assert (_ := q_eight + a).is_identical(eight + a)
     assert (_ := a - q_eight).is_identical(a - eight)
@@ -1187,53 +1295,59 @@ def test_operation_with_numbers():
     assert (_ := a + q_zero).is_identical(a)
     assert (_ := q_zero + a).is_identical(a)
     assert (_ := a - q_zero).is_identical(a)
-    assert (_ := q_zero - a).is_identical(-a)
+    assert (_ := q_zero - a) == -a
     assert (_ := a * q_one).is_identical(a)
     assert (_ := q_one * a).is_identical(a)
     assert (_ := a / q_one).is_identical(a)
-    assert (_ := q_one / a).is_identical(APyFloat(0, 14, 1, 5, 2))
+    assert (_ := q_one / a).is_identical(apyfloat(0, 14, 1, 5, 2))
 
 
-def test_mantissa_full_range():
+@pytest.mark.parametrize("apyfloat", [APyFloat, APyCFloat])
+def test_mantissa_full_range(apyfloat: type[APyCFloat]):
     """
     Support for utilizing the full mantissa range during addition/subraction was added
     in #440
     """
-    a = APyFloat(sign=0, exp=1023, man=0, exp_bits=11, man_bits=61)
-    b = APyFloat(sign=0, exp=1023 - 61, man=0, exp_bits=11, man_bits=61)
-    assert (a + b) == APyFloat(sign=0, exp=1023, man=1, exp_bits=11, man_bits=61)
-    assert (a - b) == APyFloat(
+    a = apyfloat(sign=0, exp=1023, man=0, exp_bits=11, man_bits=61)
+    b = apyfloat(sign=0, exp=1023 - 61, man=0, exp_bits=11, man_bits=61)
+    assert (a + b) == apyfloat(sign=0, exp=1023, man=1, exp_bits=11, man_bits=61)
+    assert (a - b) == apyfloat(
         sign=0, exp=1022, man=(1 << 61) - 2, exp_bits=11, man_bits=61
     )
 
 
-def test_rdiv_int():
+@pytest.mark.parametrize("apyfloat", [APyFloat, APyCFloat])
+def test_rdiv_int(apyfloat: type[APyCFloat]):
     """
     R-division with an integer. As long as the integer fits into a float, Python chooses
     to promote the integer to float first, and only performs `__rtruediv__` with the
     integer if it does not fit into a float.
     """
-    a = APyFloat.from_float(2**1000, exp_bits=30, man_bits=50)
+    a = apyfloat.from_float(2**1000, exp_bits=30, man_bits=50)
     assert (2**2000 / a).is_identical(
-        APyFloat.from_float(2**1000, exp_bits=30, man_bits=50)
+        apyfloat.from_float(2**1000, exp_bits=30, man_bits=50)
     )
 
 
-def test_unary_arith():
-    a = APyFloat(0, 7, 13, 4, 4)  # One
-    assert (-a).is_identical(APyFloat(1, 7, 13, 4, 4))
+@pytest.mark.parametrize("apyfloat", [APyFloat, APyCFloat])
+def test_unary_arith(apyfloat: type[APyCFloat]):
+    a = apyfloat(0, 7, 13, 4, 4)  # One
+    assert -a == apyfloat(1, 7, 13, 4, 4)
+    assert (-a).man_bits == 4
+    assert (-a).exp_bits == 4
     assert (+a).is_identical(a)
 
 
-def test_add_zero_with_zero():
+@pytest.mark.parametrize("apyfloat", [APyFloat, APyCFloat])
+def test_add_zero_with_zero(apyfloat: type[APyCFloat]):
     # Same WL
-    assert APyFloat.from_float(0.0, 13, 10) + APyFloat.from_float(0.0, 13, 10)
-    assert APyFloat.from_float(0.0, 13, 10) + APyFloat.from_float(0.0, 13, 10)
+    assert apyfloat.from_float(0.0, 13, 10) + apyfloat.from_float(0.0, 13, 10) == 0
+    assert apyfloat.from_float(0.0, 13, 10) + apyfloat.from_float(0.0, 13, 10) == 0
 
     # Different WL, short
-    assert APyFloat.from_float(0.0, 6, 5) + APyFloat.from_float(0.0, 10, 6)
-    assert APyFloat.from_float(0.0, 10, 6) + APyFloat.from_float(0.0, 6, 5)
+    assert apyfloat.from_float(0.0, 6, 5) + apyfloat.from_float(0.0, 10, 6) == 0
+    assert apyfloat.from_float(0.0, 10, 6) + apyfloat.from_float(0.0, 6, 5) == 0
 
     # Different WL, long
-    assert APyFloat.from_float(0.0, 30, 61) + APyFloat.from_float(0.0, 28, 55)
-    assert APyFloat.from_float(0.0, 28, 55) + APyFloat.from_float(0.0, 30, 61)
+    assert apyfloat.from_float(0.0, 30, 61) + apyfloat.from_float(0.0, 28, 55) == 0
+    assert apyfloat.from_float(0.0, 28, 55) + apyfloat.from_float(0.0, 30, 61) == 0

--- a/lib/test/apyfloat/test_methods.py
+++ b/lib/test/apyfloat/test_methods.py
@@ -1,133 +1,164 @@
 from itertools import permutations as perm
 import pytest
-from apytypes import APyFloat, APyFixed
+from apytypes import APyFloat, APyFixed, APyCFloat
 
 
-def test_scalar_constructor_raises():
+def real_is_nan(fp: APyFloat | APyCFloat) -> bool:
+    """
+    Test if an `APyFloat` is NaN, or if the real part of an `APyCFloat` is NaN.
+
+    Parameters
+    ----------
+    fp : :class:`APyFloat` or :class:`APyCFloat`
+        The APyTypes floating-point number.
+    """
+    return fp.real.is_nan if isinstance(fp, APyCFloat) else fp.is_nan
+
+
+def real_is_inf(fp: APyFloat | APyCFloat) -> bool:
+    """
+    Test if an `APyFloat` is inf, or if the real part of an `APyCFloat` is inf.
+
+    Parameters
+    ----------
+    fp : :class:`APyFloat` or :class:`APyCFloat`
+        The APyTypes floating-point number.
+    """
+    return fp.real.is_inf if isinstance(fp, APyCFloat) else fp.is_inf
+
+
+@pytest.mark.parametrize("apyfloat", [APyFloat, APyCFloat])
+def test_scalar_constructor_raises(apyfloat: type[APyCFloat]):
     # Too many exponent bits
     with pytest.raises(
         ValueError,
-        match="Exponent bits must be a non-negative integer less or equal to .. but 300 was given",
+        match=r"APyC?Float\.__init__: exponent bits must be a non-negative integer less or equal to .. but 300 was given",
     ):
-        APyFloat(0, 0, 0, 300, 5)
+        _ = apyfloat(0, 0, 0, 300, 5)
     with pytest.raises(
         ValueError,
-        match="Exponent bits must be a non-negative integer less or equal to .. but -300 was given",
+        match=r"APyC?Float\.__init__: exponent bits must be a non-negative integer less or equal to .. but -300 was given",
     ):
-        APyFloat(0, 0, 0, -300, 5)
+        _ = apyfloat(0, 0, 0, -300, 5)
     # Too many mantissa bits
     with pytest.raises(
         ValueError,
-        match="Mantissa bits must be a non-negative integer less or equal to .. but 300 was given",
+        match=r"APyC?Float\.__init__: mantissa bits must be a non-negative integer less or equal to .. but 300 was given",
     ):
-        APyFloat(0, 0, 0, 5, 300)
+        _ = apyfloat(0, 0, 0, 5, 300)
     with pytest.raises(
         ValueError,
-        match="Mantissa bits must be a non-negative integer less or equal to .. but -300 was given",
+        match=r"APyC?Float\.__init__: mantissa bits must be a non-negative integer less or equal to .. but -300 was given",
     ):
-        APyFloat(0, 0, 0, 5, -300)
+        _ = apyfloat(0, 0, 0, 5, -300)
 
 
-def test_scalar_from_float_raises():
+@pytest.mark.parametrize("apyfloat", [APyFloat, APyCFloat])
+def test_scalar_from_float_constructor_raises(apyfloat: type[APyCFloat]):
     # Too many exponent bits
     with pytest.raises(
         ValueError,
-        match="Exponent bits must be a non-negative integer less or equal to .. but 300 was given",
+        match=r"APyC?Float\.from_float: exponent bits must be a non-negative integer less or equal to .. but 300 was given",
     ):
-        APyFloat.from_float(0, 300, 5)
+        _ = apyfloat.from_float(0.0, exp_bits=300, man_bits=5)
     with pytest.raises(
         ValueError,
-        match="Exponent bits must be a non-negative integer less or equal to .. but -300 was given",
+        match=r"APyC?Float\.from_float: exponent bits must be a non-negative integer less or equal to .. but -300 was given",
     ):
-        APyFloat.from_float(0, -300, 5)
+        _ = apyfloat.from_float(0.0, exp_bits=-300, man_bits=5)
     # Too many mantissa bits
     with pytest.raises(
         ValueError,
-        match="Mantissa bits must be a non-negative integer less or equal to .. but 300 was given",
+        match=r"APyC?Float\.from_float: mantissa bits must be a non-negative integer less or equal to .. but 300 was given",
     ):
-        APyFloat.from_float(0, 5, 300)
+        _ = apyfloat.from_float(0.0, exp_bits=5, man_bits=300)
     with pytest.raises(
         ValueError,
-        match="Mantissa bits must be a non-negative integer less or equal to .. but -300 was given",
+        match=r"APyC?Float\.from_float: mantissa bits must be a non-negative integer less or equal to .. but -300 was given",
     ):
-        APyFloat.from_float(0, 5, -300)
-    with pytest.raises(
-        ValueError,
-        match="Non supported type",
-    ):
-        APyFloat.from_float("0", 5, 10)
+        _ = apyfloat.from_float(0.0, exp_bits=5, man_bits=-300)
 
 
 def test_scalar_from_bits_raises():
     # Too many exponent bits
     with pytest.raises(
         ValueError,
-        match="Exponent bits must be a non-negative integer less or equal to .. but 300 was given",
+        match=r"APyC?Float\.from_bits: exponent bits must be a non-negative integer less or equal to .. but 300 was given",
     ):
-        APyFloat.from_bits(0, 300, 5)
+        _ = APyFloat.from_bits(0, 300, 5)
     with pytest.raises(
         ValueError,
-        match="Exponent bits must be a non-negative integer less or equal to .. but -300 was given",
+        match=r"APyC?Float\.from_bits: exponent bits must be a non-negative integer less or equal to .. but -300 was given",
     ):
-        APyFloat.from_bits(0, -300, 5)
+        _ = APyFloat.from_bits(0, -300, 5)
     # Too many mantissa bits
     with pytest.raises(
         ValueError,
-        match="Mantissa bits must be a non-negative integer less or equal to .. but 300 was given",
+        match=r"APyC?Float\.from_bits: mantissa bits must be a non-negative integer less or equal to .. but 300 was given",
     ):
-        APyFloat.from_bits(0, 5, 300)
+        _ = APyFloat.from_bits(0, 5, 300)
     with pytest.raises(
         ValueError,
-        match="Mantissa bits must be a non-negative integer less or equal to .. but -300 was given",
+        match=r"APyC?Float\.from_bits: mantissa bits must be a non-negative integer less or equal to .. but -300 was given",
     ):
-        APyFloat.from_bits(0, 5, -300)
+        _ = APyFloat.from_bits(0, 5, -300)
 
 
-def test_scalar_cast_raises():
+@pytest.mark.parametrize("apyfloat", [APyFloat, APyCFloat])
+def test_scalar_cast_raises(apyfloat: type[APyCFloat]):
     # Too many exponent bits
     with pytest.raises(
         ValueError,
-        match="Exponent bits must be a non-negative integer less or equal to .. but 300 was given",
+        match=r"APyC?Float\.cast: exponent bits must be a non-negative integer less or equal to .. but 300 was given",
     ):
-        APyFloat(0, 0, 0, 5, 5).cast(300, 5)
+        _ = apyfloat(0, 0, 0, 5, 5).cast(300, 5)
     with pytest.raises(
         ValueError,
-        match="Exponent bits must be a non-negative integer less or equal to .. but -300 was given",
+        match=r"APyC?Float\.cast: exponent bits must be a non-negative integer less or equal to .. but -300 was given",
     ):
-        APyFloat(0, 0, 0, 5, 5).cast(-300, 5)
+        _ = apyfloat(0, 0, 0, 5, 5).cast(-300, 5)
     # Too many mantissa bits
     with pytest.raises(
         ValueError,
-        match="Mantissa bits must be a non-negative integer less or equal to .. but 300 was given",
+        match=r"APyC?Float\.cast: mantissa bits must be a non-negative integer less or equal to .. but 300 was given",
     ):
-        APyFloat(0, 0, 0, 5, 5).cast(5, 300)
+        _ = apyfloat(0, 0, 0, 5, 5).cast(5, 300)
     with pytest.raises(
         ValueError,
-        match="Mantissa bits must be a non-negative integer less or equal to .. but -300 was given",
+        match=r"APyC?Float\.cast: mantissa bits must be a non-negative integer less or equal to .. but -300 was given",
     ):
-        APyFloat(0, 0, 0, 5, 5).cast(5, -300)
+        _ = apyfloat(0, 0, 0, 5, 5).cast(5, -300)
 
 
 @pytest.mark.float_special
-@pytest.mark.parametrize("float_s", ["nan", "inf", "-inf", "0.0", "-0.0"])
-def test_special_conversions(float_s):
-    assert (
-        str(float(APyFloat.from_float(float(float_s), 5, 5)))
-        == str(float(float_s))
-        == float_s
+@pytest.mark.parametrize("apyfloat, py_type", [(APyFloat, float), (APyCFloat, complex)])
+@pytest.mark.parametrize(
+    "float_val", [float("nan"), float("inf"), float("-inf"), 0.0, -0.0]
+)
+def test_special_conversions(
+    apyfloat: type[APyCFloat], py_type: type[complex], float_val: float
+):
+    assert str(py_type(apyfloat.from_float(py_type(float_val), 5, 5))) == str(
+        py_type(float_val)
     )
 
 
+@pytest.mark.parametrize("apyfloat, py_type", [(APyFloat, float), (APyCFloat, complex)])
 @pytest.mark.parametrize("exp", list(perm([5, 6, 7, 8], 2)))
 @pytest.mark.parametrize("man", list(perm([5, 6, 7, 8], 2)))
 @pytest.mark.parametrize("val", [2.625, 12])
 @pytest.mark.parametrize("neg", [-1.0, 1.0])
-def test_normal_conversions(exp, man, val, neg):
+def test_normal_conversions(
+    apyfloat: type[APyCFloat],
+    py_type: type[complex],
+    exp: tuple[int, int],
+    man: tuple[int, int],
+    val: float,
+    neg: float,
+):
     val *= neg
-    assert (
-        float(APyFloat.from_float(val, exp[0], man[0]))
-        == float(APyFloat.from_float(val, exp[1], man[1]))
-        == val
+    assert py_type(apyfloat.from_float(val, exp[0], man[0])) == py_type(
+        apyfloat.from_float(val, exp[1], man[1])
     )
 
 
@@ -183,141 +214,144 @@ def test_long_python_integer():
     assert a.to_bits() == val
 
 
-def test_convert_to_double():
-    a = APyFloat(0, 1, 1, 13, 60)
-    assert float(a) == 0.0
+@pytest.mark.parametrize("apyfloat, py_type", [(APyFloat, float), (APyCFloat, complex)])
+def test_convert_to_double(apyfloat: type[APyCFloat], py_type: type[complex]):
+    a = apyfloat(0, 1, 1, 13, 60)
+    assert py_type(a) == 0.0
 
-    a = APyFloat(0, 8100, 1, 13, 60)
-    assert a.is_finite
-    assert float(a) == float("inf")
-    assert float(-a) == float("-inf")
+    a = apyfloat(0, 8100, 1, 13, 60)
+    assert not real_is_inf(a)
+    assert py_type(a) == float("inf")
+    assert py_type(-a) == float("-inf")
 
-    a = APyFloat(0, 0, 7, 11, 54)
-    assert float(a) == 1e-323
+    a = apyfloat(0, 0, 7, 11, 54)
+    assert py_type(a) == 1e-323
 
-    a = APyFloat(0, 0, 1, 11, 52)
-    assert float(a) == 5e-324
+    a = apyfloat(0, 0, 1, 11, 52)
+    assert py_type(a) == 5e-324
 
 
-def test_from_float():
-    a = APyFloat(0, 0, 1, 11, 52)
-    b = APyFloat.from_float(5e-324, 11, 52)
+@pytest.mark.parametrize("apyfloat", [APyFloat, APyCFloat])
+def test_from_float(apyfloat: type[APyCFloat]):
+    a = apyfloat(0, 0, 1, 11, 52)
+    b = apyfloat.from_float(5e-324, 11, 52)
     assert b.is_identical(a)
 
     # Big float should become infinity
-    a = APyFloat.from_float(-(2**10), 4, 15)
-    assert a.is_identical(APyFloat(1, 15, 0, 4, 15))
+    a = apyfloat.from_float(-(2**10), 4, 15)
+    assert a.is_identical(apyfloat(1, 15, 0, 4, 15))
 
 
-def test_from_float_with_non_floats():
-    a = APyFloat.from_float(16, exp_bits=4, man_bits=2)
-    assert a.is_identical(APyFloat(sign=0, exp=11, man=0, exp_bits=4, man_bits=2))
+@pytest.mark.parametrize("apyfloat", [APyFloat])
+def test_from_float_with_non_floats(apyfloat: type[APyCFloat]):
+    a = apyfloat.from_float(16, exp_bits=4, man_bits=2)
+    assert a.is_identical(apyfloat(sign=0, exp=11, man=0, exp_bits=4, man_bits=2))
 
     # Should quantize to 16.0
-    a = APyFloat.from_float(17, exp_bits=4, man_bits=2)
-    assert a.is_identical(APyFloat(sign=0, exp=11, man=0, exp_bits=4, man_bits=2))
+    a = apyfloat.from_float(17, exp_bits=4, man_bits=2)
+    assert a.is_identical(apyfloat(sign=0, exp=11, man=0, exp_bits=4, man_bits=2))
 
     # Should quantize to -20.0
-    a = APyFloat.from_float(-19, exp_bits=4, man_bits=2)
-    assert a.is_identical(APyFloat(sign=1, exp=11, man=1, exp_bits=4, man_bits=2))
+    a = apyfloat.from_float(-19, exp_bits=4, man_bits=2)
+    assert a.is_identical(apyfloat(sign=1, exp=11, man=1, exp_bits=4, man_bits=2))
 
     # Tie break, should quantize to 16.0
-    a = APyFloat.from_float(18, exp_bits=4, man_bits=2)
-    assert a.is_identical(APyFloat(sign=0, exp=11, man=0, exp_bits=4, man_bits=2))
+    a = apyfloat.from_float(18, exp_bits=4, man_bits=2)
+    assert a.is_identical(apyfloat(sign=0, exp=11, man=0, exp_bits=4, man_bits=2))
 
     # Tie break, should quantize to 24.0
-    a = APyFloat.from_float(22, exp_bits=4, man_bits=2)
-    assert a.is_identical(APyFloat(sign=0, exp=11, man=2, exp_bits=4, man_bits=2))
+    a = apyfloat.from_float(22, exp_bits=4, man_bits=2)
+    assert a.is_identical(apyfloat(sign=0, exp=11, man=2, exp_bits=4, man_bits=2))
 
     # Should quantize to 28.0
-    a = APyFloat.from_float(29, exp_bits=4, man_bits=2)
-    assert a.is_identical(APyFloat(sign=0, exp=11, man=3, exp_bits=4, man_bits=2))
+    a = apyfloat.from_float(29, exp_bits=4, man_bits=2)
+    assert a.is_identical(apyfloat(sign=0, exp=11, man=3, exp_bits=4, man_bits=2))
 
     # Should quantize to 32.0
-    a = APyFloat.from_float(31, exp_bits=4, man_bits=2)
-    assert a.is_identical(APyFloat(sign=0, exp=12, man=0, exp_bits=4, man_bits=2))
+    a = apyfloat.from_float(31, exp_bits=4, man_bits=2)
+    assert a.is_identical(apyfloat(sign=0, exp=12, man=0, exp_bits=4, man_bits=2))
 
     # 152-bit number, should become negative infinity
-    a = APyFloat.from_float(
+    a = apyfloat.from_float(
         -0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF, exp_bits=4, man_bits=2
     )
-    assert a.is_identical(APyFloat(sign=1, exp=15, man=0, exp_bits=4, man_bits=2))
+    assert a.is_identical(apyfloat(sign=1, exp=15, man=0, exp_bits=4, man_bits=2))
 
     # Test with bool and non IEEE-like bias
-    a = APyFloat.from_float(True, exp_bits=4, man_bits=2, bias=4)
+    a = apyfloat.from_float(True, exp_bits=4, man_bits=2, bias=4)
     assert a.is_identical(
-        APyFloat(sign=0, exp=4, man=0, exp_bits=4, man_bits=2, bias=4)
+        apyfloat(sign=0, exp=4, man=0, exp_bits=4, man_bits=2, bias=4)
     )
 
     # Test with big integer
-    a = APyFloat.from_float(2**2047, exp_bits=28, man_bits=2)
+    a = apyfloat.from_float(2**2047, exp_bits=28, man_bits=2)
     assert a.is_identical(
-        APyFloat(sign=0, exp=(2047 + (2**27) - 1), man=0, exp_bits=28, man_bits=2)
+        apyfloat(sign=0, exp=(2047 + (2**27) - 1), man=0, exp_bits=28, man_bits=2)
     )
 
     # From APyFixed
-    assert APyFloat.from_float(APyFixed(0, bits=3, int_bits=2), 5, 2, 8).is_identical(
-        APyFloat(0, 0, 0, 5, 2, 8)
+    assert apyfloat.from_float(APyFixed(0, bits=3, int_bits=2), 5, 2, 8).is_identical(
+        apyfloat(0, 0, 0, 5, 2, 8)
     )  # 0
 
-    assert APyFloat.from_float(APyFixed(3, bits=3, int_bits=2), 5, 2).is_identical(
-        APyFloat(0, 15, 2, 5, 2)
+    assert apyfloat.from_float(APyFixed(3, bits=3, int_bits=2), 5, 2).is_identical(
+        apyfloat(0, 15, 2, 5, 2)
     )  # 1.5
 
-    assert APyFloat.from_float(APyFixed(13, bits=4, int_bits=3), 5, 2).is_identical(
-        APyFloat(1, 15, 2, 5, 2)
+    assert apyfloat.from_float(APyFixed(13, bits=4, int_bits=3), 5, 2).is_identical(
+        apyfloat(1, 15, 2, 5, 2)
     )  # -1.5
 
-    assert APyFloat.from_float(APyFixed(3, bits=3, int_bits=-1), 7, 3).is_identical(
-        APyFloat(0, 60, 4, 7, 3)
+    assert apyfloat.from_float(APyFixed(3, bits=3, int_bits=-1), 7, 3).is_identical(
+        apyfloat(0, 60, 4, 7, 3)
     )  # 0.1875
 
-    assert APyFloat.from_float(APyFixed(1, bits=5, int_bits=40), 5, 2).is_identical(
-        APyFloat(0, 31, 0, 5, 2)
+    assert apyfloat.from_float(APyFixed(1, bits=5, int_bits=40), 5, 2).is_identical(
+        apyfloat(0, 31, 0, 5, 2)
     )  # Saturate to infinity
 
-    assert APyFloat.from_float(APyFixed(1, bits=12, int_bits=2), 4, 3).is_identical(
-        APyFloat(0, 0, 0, 4, 3)
+    assert apyfloat.from_float(APyFixed(1, bits=12, int_bits=2), 4, 3).is_identical(
+        apyfloat(0, 0, 0, 4, 3)
     )  # Quantize to zero
 
-    assert APyFloat.from_float(APyFixed(1, bits=10, int_bits=2), 4, 3).is_identical(
-        APyFloat(0, 0, 2, 4, 3)
+    assert apyfloat.from_float(APyFixed(1, bits=10, int_bits=2), 4, 3).is_identical(
+        apyfloat(0, 0, 2, 4, 3)
     )  # Subnormal
 
-    assert APyFloat.from_float(
+    assert apyfloat.from_float(
         APyFixed(1, int_bits=1, frac_bits=1076), 11, 54
-    ).is_identical(APyFloat(0, 0, 1, 11, 54))  # Smallest subnormal
+    ).is_identical(apyfloat(0, 0, 1, 11, 54))  # Smallest subnormal
 
-    assert APyFloat.from_float(
+    assert apyfloat.from_float(
         APyFixed(1, bits=2, int_bits=-1072), 11, 52
-    ).is_identical(APyFloat(0, 0, 1, 11, 52))  # Smallest subnormal
+    ).is_identical(apyfloat(0, 0, 1, 11, 52))  # Smallest subnormal
 
-    assert APyFloat.from_float(
+    assert apyfloat.from_float(
         APyFixed(2**11 - 1, int_bits=1025, frac_bits=25),
         5,
         10,  # Should round to smallest normal
-    ).is_identical(APyFloat(0, 1, 0, 5, 10))
+    ).is_identical(apyfloat(0, 1, 0, 5, 10))
 
-    # From APyFloat, which is equivalent to a cast with TIES_EVEN
+    # From apyfloat, which is equivalent to a cast with TIES_EVEN
 
     # -0 to -0
-    assert APyFloat.from_float(APyFloat(1, 0, 0, 5, 7), 10, 24, 8).is_identical(
-        APyFloat(1, 0, 0, 10, 24, 8)
+    assert apyfloat.from_float(apyfloat(1, 0, 0, 5, 7), 10, 24, 8).is_identical(
+        apyfloat(1, 0, 0, 10, 24, 8)
     )
 
     # Cast -inf to -inf
-    assert APyFloat.from_float(APyFloat(1, 31, 0, 5, 7), 11, 34).is_identical(
-        APyFloat(1, 2047, 0, 11, 34)
+    assert apyfloat.from_float(apyfloat(1, 31, 0, 5, 7), 11, 34).is_identical(
+        apyfloat(1, 2047, 0, 11, 34)
     )
 
     # Cast from big number becomes infinity
-    assert APyFloat.from_float(APyFloat(1, 30, 4, 5, 3), 4, 3).is_identical(
-        APyFloat(1, 15, 0, 4, 3)
+    assert apyfloat.from_float(apyfloat(1, 30, 4, 5, 3), 4, 3).is_identical(
+        apyfloat(1, 15, 0, 4, 3)
     )
 
     # Cast where result becomes subnormal
-    assert APyFloat.from_float(APyFloat(0, 8, 0, 5, 2), 4, 3).is_identical(
-        APyFloat(0, 0, 4, 4, 3)
+    assert apyfloat.from_float(apyfloat(0, 8, 0, 5, 2), 4, 3).is_identical(
+        apyfloat(0, 0, 4, 4, 3)
     )
 
 
@@ -515,30 +549,30 @@ def test_python_deepcopy():
 
 
 @pytest.mark.parametrize("func", ["inf", "nan"])
-def test_inf_nan_creation(func):
-    #
-    # Test raises
-
+def test_inf_nan_creation(func: str):
     # Too many exponent bits
     with pytest.raises(
         ValueError,
-        match="Exponent bits must be a non-negative integer less or equal to .. but 300 was given",
+        match=f"APyC?Float.{func}: exponent bits must be a non-negative integer less or equal to .. but 300 was given",
     ):
         eval(f"APyFloat.{func}(300, 5)")
+
     with pytest.raises(
         ValueError,
-        match="Exponent bits must be a non-negative integer less or equal to .. but -300 was given",
+        match=f"APyC?Float.{func}: exponent bits must be a non-negative integer less or equal to .. but -300 was given",
     ):
         eval(f"APyFloat.{func}(-300, 5)")
+
     # Too many mantissa bits
     with pytest.raises(
         ValueError,
-        match="Mantissa bits must be a non-negative integer less or equal to .. but 300 was given",
+        match=f"APyC?Float.{func}: mantissa bits must be a non-negative integer less or equal to .. but 300 was given",
     ):
         eval(f"APyFloat.{func}(5, 300)")
+
     with pytest.raises(
         ValueError,
-        match="Mantissa bits must be a non-negative integer less or equal to .. but -300 was given",
+        match=f"APyC?Float.{func}: mantissa bits must be a non-negative integer less or equal to .. but -300 was given",
     ):
         eval(f"APyFloat.{func}(5, -300)")
 

--- a/lib/test/apyfloat/test_rounding.py
+++ b/lib/test/apyfloat/test_rounding.py
@@ -1,14 +1,15 @@
 import apytypes
-from apytypes import APyFloat, QuantizationMode, APyFloatQuantizationContext
+from apytypes import APyFloat, APyCFloat, QuantizationMode, APyFloatQuantizationContext
 import pytest
 
 
-def test_issue_245():
-    # Test that jamming bit is not applied when result is zero
+@pytest.mark.parametrize("apyfloat", [APyFloat])
+def test_issue_245(apyfloat: type[APyCFloat]):
+    # Test that jamming bit *is* applied even when operands are zero
     # https://github.com/apytypes/apytypes/issues/245
     with APyFloatQuantizationContext(QuantizationMode.JAM):
-        res = APyFloat(0, 15, 0, 5, 2) + APyFloat(0, 0, 0, 5, 2)
-        assert res.is_identical(APyFloat(0, 15, 1, 5, 2))
+        res = apyfloat(0, 15, 0, 5, 2) + apyfloat(0, 0, 0, 5, 2)
+        assert res.is_identical(apyfloat(0, 15, 1, 5, 2))
 
     with APyFloatQuantizationContext(QuantizationMode.JAM):
         res = APyFloat(0, 15, 0, 5, 2) - APyFloat(0, 0, 0, 5, 2)
@@ -26,7 +27,7 @@ def test_issue_245():
 @pytest.mark.float_add
 @pytest.mark.float_sub
 @pytest.mark.parametrize("man", [10, 60])
-def test_add_sub_zero_sign(man):
+def test_add_sub_zero_sign(man: int):
     pos_zero = APyFloat(0, 0, 0, 5, 10)
     neg_zero = APyFloat(1, 0, 0, 5, man)
     non_zero = APyFloat.from_float(1.0, 5, man)
@@ -67,35 +68,36 @@ def test_add_sub_zero_sign(man):
 @pytest.mark.parametrize("t", [0, 2])
 class TestAPyFloatQuantizationAddSub:
     """
-    Test class for the different quantization modes for addition in APyFloat.
-    If subtraction is implemented as 'a + (-b)' then this also tests the quantization modes for subtraction.
-    't' is used to test the case where the word lengths don't match.
+    Test class for the different quantization modes for addition in APyFloat. If
+    subtraction is implemented as 'a + (-b)' then this also tests the quantization modes
+    for subtraction. 't' is used to test the case where the word lengths don't match.
     """
 
-    def test_to_pos(self, t):
+    @pytest.mark.parametrize("apyfloat", [APyFloat, APyCFloat])
+    def test_to_pos(self, apyfloat: type[APyCFloat], t: int):
         with APyFloatQuantizationContext(QuantizationMode.TO_POS):
             # 1.5 + very small number should quantize to 1.75
-            res = APyFloat(0, 15, 2, 5, 2) + APyFloat(0, 1, 0, 5, 2, 15 + t)
-            assert res.is_identical(APyFloat(0, 15 + t // 2, 3, 5, 2, 15 + t // 2))
+            res = apyfloat(0, 15, 2, 5, 2) + apyfloat(0, 1, 0, 5, 2, 15 + t)
+            assert res.is_identical(apyfloat(0, 15 + t // 2, 3, 5, 2, 15 + t // 2))
 
             # -1.5 + very small number should quantize to 1.25
-            res = APyFloat(1, 15, 2, 5, 2) + APyFloat(0, 1, 0, 5, 2, 15 + t)
-            assert res.is_identical(APyFloat(1, 15 + t // 2, 1, 5, 2, 15 + t // 2))
+            res = apyfloat(1, 15, 2, 5, 2) + apyfloat(0, 1, 0, 5, 2, 15 + t)
+            assert res.is_identical(apyfloat(1, 15 + t // 2, 1, 5, 2, 15 + t // 2))
 
             # Two big positive numbers should become infinity
-            res = APyFloat(0, 30, 3, 5, 2) + APyFloat(0, 30, 3, 5, 2, 15 + t)
-            assert res.is_identical(APyFloat(0, 31, 0, 5, 2, 15 + t // 2))
+            res = apyfloat(0, 30, 3, 5, 2) + apyfloat(0, 30, 3, 5, 2, 15 + t)
+            assert res.is_identical(apyfloat(0, 31, 0, 5, 2, 15 + t // 2))
 
             # Two big negative numbers should saturate
-            res = APyFloat(1, 30, 3, 5, 2) + APyFloat(1, 30, 3, 5, 2, 15 + t)
-            assert res.is_identical(APyFloat(1, 30, 3, 5, 2, 15 + t // 2))
+            res = apyfloat(1, 30, 3, 5, 2) + apyfloat(1, 30, 3, 5, 2, 15 + t)
+            assert res.is_identical(apyfloat(1, 30, 3, 5, 2, 15 + t // 2))
 
             # Far case
-            lhs = APyFloat(sign=0, exp=125, man=1392008, exp_bits=8, man_bits=23)
-            rhs = APyFloat(
+            lhs = apyfloat(sign=0, exp=125, man=1392008, exp_bits=8, man_bits=23)
+            rhs = apyfloat(
                 sign=1, exp=190 + t, man=65537, exp_bits=8, man_bits=23, bias=127 + t
             )
-            ref = APyFloat(
+            ref = apyfloat(
                 sign=1,
                 exp=190 + t // 2,
                 man=65536,
@@ -105,30 +107,31 @@ class TestAPyFloatQuantizationAddSub:
             )
             assert (lhs + rhs).is_identical(ref)
 
-    def test_to_neg(self, t):
+    @pytest.mark.parametrize("apyfloat", [APyFloat, APyCFloat])
+    def test_to_neg(self, apyfloat: type[APyCFloat], t: int):
         with APyFloatQuantizationContext(QuantizationMode.TO_NEG):
             # 1.5 + very small number should quantize to 1.5
-            res = APyFloat(0, 15, 2, 5, 2) + APyFloat(0, 1, 0, 5, 2, 15 + t)
-            assert res.is_identical(APyFloat(0, 15 + t // 2, 2, 5, 2, 15 + t // 2))
+            res = apyfloat(0, 15, 2, 5, 2) + apyfloat(0, 1, 0, 5, 2, 15 + t)
+            assert res.is_identical(apyfloat(0, 15 + t // 2, 2, 5, 2, 15 + t // 2))
 
             # -1.5 + very small number should quantize to 1.5
-            res = APyFloat(1, 15, 2, 5, 2) + APyFloat(0, 1, 0, 5, 2, 15 + t)
-            assert res.is_identical(APyFloat(1, 15 + t // 2, 2, 5, 2, 15 + t // 2))
+            res = apyfloat(1, 15, 2, 5, 2) + apyfloat(0, 1, 0, 5, 2, 15 + t)
+            assert res.is_identical(apyfloat(1, 15 + t // 2, 2, 5, 2, 15 + t // 2))
 
             # Two big positive numbers should saturate
-            res = APyFloat(0, 30, 3, 5, 2) + APyFloat(0, 30, 3, 5, 2, 15 + t)
-            assert res.is_identical(APyFloat(0, 30, 3, 5, 2, 15 + t // 2))
+            res = apyfloat(0, 30, 3, 5, 2) + apyfloat(0, 30, 3, 5, 2, 15 + t)
+            assert res.is_identical(apyfloat(0, 30, 3, 5, 2, 15 + t // 2))
 
             # Two big negative numbers should become infinity
-            res = APyFloat(1, 30, 3, 5, 2) + APyFloat(1, 30, 3, 5, 2, 15 + t)
-            assert res.is_identical(APyFloat(1, 31, 0, 5, 2, 15 + t // 2))
+            res = apyfloat(1, 30, 3, 5, 2) + apyfloat(1, 30, 3, 5, 2, 15 + t)
+            assert res.is_identical(apyfloat(1, 31, 0, 5, 2, 15 + t // 2))
 
             # Far case
-            lhs = APyFloat(sign=1, exp=0, man=190, exp_bits=8, man_bits=23)
-            rhs = APyFloat(
+            lhs = apyfloat(sign=1, exp=0, man=190, exp_bits=8, man_bits=23)
+            rhs = apyfloat(
                 sign=1, exp=151 + t, man=494, exp_bits=8, man_bits=23, bias=127 + t
             )
-            ref = APyFloat(
+            ref = apyfloat(
                 sign=1,
                 exp=151 + t // 2,
                 man=495,
@@ -138,30 +141,32 @@ class TestAPyFloatQuantizationAddSub:
             )
             assert (lhs + rhs).is_identical(ref)
 
-    def test_to_zero(self, t):
+    @pytest.mark.parametrize("apyfloat", [APyFloat, APyCFloat])
+    def test_to_zero(self, apyfloat: type[APyCFloat], t: int):
         with APyFloatQuantizationContext(QuantizationMode.TO_ZERO):
             # 1.5 + relatively big number (0.21875) should still quantize to 1.5
-            res = APyFloat(0, 15, 2, 5, 2) + APyFloat(0, 12, 3, 5, 2, 15 + t)
-            assert res.is_identical(APyFloat(0, 15 + t // 2, 2, 5, 2, 15 + t // 2))
+            res = apyfloat(0, 15, 2, 5, 2) + apyfloat(0, 12, 3, 5, 2, 15 + t)
+            assert res.is_identical(apyfloat(0, 15 + t // 2, 2, 5, 2, 15 + t // 2))
 
-            # -1.5 + relatively big negative number (0.21875) should still quantize to -1.5
-            res = APyFloat(1, 15, 2, 5, 2) + APyFloat(1, 12, 3, 5, 2, 15 + t)
-            assert res.is_identical(APyFloat(1, 15 + t // 2, 2, 5, 2, 15 + t // 2))
+            # -1.5 + relatively big negative number (0.21875) should still quantize to
+            # -1.5
+            res = apyfloat(1, 15, 2, 5, 2) + apyfloat(1, 12, 3, 5, 2, 15 + t)
+            assert res.is_identical(apyfloat(1, 15 + t // 2, 2, 5, 2, 15 + t // 2))
 
             # Two big positive numbers should saturate
-            res = APyFloat(0, 30, 3, 5, 2) + APyFloat(0, 30, 3, 5, 2, 15 + t)
-            assert res.is_identical(APyFloat(0, 30, 3, 5, 2, 15 + t // 2))
+            res = apyfloat(0, 30, 3, 5, 2) + apyfloat(0, 30, 3, 5, 2, 15 + t)
+            assert res.is_identical(apyfloat(0, 30, 3, 5, 2, 15 + t // 2))
 
             # Two big negative numbers should saturate
-            res = APyFloat(1, 30, 3, 5, 2) + APyFloat(1, 30, 3, 5, 2, 15 + t)
-            assert res.is_identical(APyFloat(1, 30, 3, 5, 2, 15 + t // 2))
+            res = apyfloat(1, 30, 3, 5, 2) + apyfloat(1, 30, 3, 5, 2, 15 + t)
+            assert res.is_identical(apyfloat(1, 30, 3, 5, 2, 15 + t // 2))
 
             # Far case
-            lhs = APyFloat(sign=0, exp=125, man=1392008, exp_bits=8, man_bits=23)
-            rhs = APyFloat(
+            lhs = apyfloat(sign=0, exp=125, man=1392008, exp_bits=8, man_bits=23)
+            rhs = apyfloat(
                 sign=1, exp=190 + t, man=65537, exp_bits=8, man_bits=23, bias=127 + t
             )
-            ref = APyFloat(
+            ref = apyfloat(
                 sign=1,
                 exp=190 + t // 2,
                 man=65536,
@@ -171,91 +176,94 @@ class TestAPyFloatQuantizationAddSub:
             )
             assert (lhs + rhs).is_identical(ref)
 
-    def test_to_ties_even(self, t):
+    @pytest.mark.parametrize("apyfloat", [APyFloat, APyCFloat])
+    def test_to_ties_even(self, apyfloat: type[APyCFloat], t: int):
         with APyFloatQuantizationContext(QuantizationMode.TIES_EVEN):
             # 1.5 + relatively big number (0.21875) should quantize to 1.75
-            res = APyFloat(0, 15, 2, 5, 2) + APyFloat(0, 12 + t, 3, 5, 2, 15 + t)
-            assert res.is_identical(APyFloat(0, 15 + t // 2, 3, 5, 2, 15 + t // 2))
+            res = apyfloat(0, 15, 2, 5, 2) + apyfloat(0, 12 + t, 3, 5, 2, 15 + t)
+            assert res.is_identical(apyfloat(0, 15 + t // 2, 3, 5, 2, 15 + t // 2))
 
             # -1.5 + relatively big negative number (0.21875) should quantize to -1.75
-            res = APyFloat(1, 15, 2, 5, 2) + APyFloat(1, 12 + t, 3, 5, 2, 15 + t)
-            assert res.is_identical(APyFloat(1, 15 + t // 2, 3, 5, 2, 15 + t // 2))
+            res = apyfloat(1, 15, 2, 5, 2) + apyfloat(1, 12 + t, 3, 5, 2, 15 + t)
+            assert res.is_identical(apyfloat(1, 15 + t // 2, 3, 5, 2, 15 + t // 2))
 
             # 1.5 + very small number should quantize to 1.5
-            res = APyFloat(0, 15, 2, 5, 2) + APyFloat(0, 1, 0, 5, 2, 15 + t)
-            assert res.is_identical(APyFloat(0, 15 + t // 2, 2, 5, 2, 15 + t // 2))
+            res = apyfloat(0, 15, 2, 5, 2) + apyfloat(0, 1, 0, 5, 2, 15 + t)
+            assert res.is_identical(apyfloat(0, 15 + t // 2, 2, 5, 2, 15 + t // 2))
 
             # -1.5 + very small negative number should quantize to 1.5
-            res = APyFloat(1, 15, 2, 5, 2) + APyFloat(0, 1, 0, 5, 2, 15 + t)
-            assert res.is_identical(APyFloat(1, 15 + t // 2, 2, 5, 2, 15 + t // 2))
+            res = apyfloat(1, 15, 2, 5, 2) + apyfloat(0, 1, 0, 5, 2, 15 + t)
+            assert res.is_identical(apyfloat(1, 15 + t // 2, 2, 5, 2, 15 + t // 2))
 
             # 1.5 + tie should quantize to 1.5
-            res = APyFloat(0, 15, 2, 5, 2) + APyFloat(0, 12, 0, 5, 2, 15 + t)
-            assert res.is_identical(APyFloat(0, 15 + t // 2, 2, 5, 2, 15 + t // 2))
+            res = apyfloat(0, 15, 2, 5, 2) + apyfloat(0, 12, 0, 5, 2, 15 + t)
+            assert res.is_identical(apyfloat(0, 15 + t // 2, 2, 5, 2, 15 + t // 2))
 
             # -1.5 + negative tie should quantize to -1.5
-            res = APyFloat(1, 15, 2, 5, 2) + APyFloat(1, 12 + t, 0, 5, 2, 15 + t)
-            assert res.is_identical(APyFloat(1, 15 + t // 2, 2, 5, 2, 15 + t // 2))
+            res = apyfloat(1, 15, 2, 5, 2) + apyfloat(1, 12 + t, 0, 5, 2, 15 + t)
+            assert res.is_identical(apyfloat(1, 15 + t // 2, 2, 5, 2, 15 + t // 2))
 
             # 1.75 + tie should quantize to 2.0
-            res = APyFloat(0, 15, 3, 5, 2) + APyFloat(0, 12 + t, 0, 5, 2, 15 + t)
-            assert res.is_identical(APyFloat(0, 16 + t // 2, 0, 5, 2, 15 + t // 2))
+            res = apyfloat(0, 15, 3, 5, 2) + apyfloat(0, 12 + t, 0, 5, 2, 15 + t)
+            assert res.is_identical(apyfloat(0, 16 + t // 2, 0, 5, 2, 15 + t // 2))
 
             # -1.75 + negative tie should quantize to -2.0
-            res = APyFloat(1, 15, 3, 5, 2) + APyFloat(1, 12 + t, 0, 5, 2, 15 + t)
-            assert res.is_identical(APyFloat(1, 16 + t // 2, 0, 5, 2, 15 + t // 2))
+            res = apyfloat(1, 15, 3, 5, 2) + apyfloat(1, 12 + t, 0, 5, 2, 15 + t)
+            assert res.is_identical(apyfloat(1, 16 + t // 2, 0, 5, 2, 15 + t // 2))
 
             # Two big positive numbers should become infinity
-            res = APyFloat(0, 30, 3, 5, 2) + APyFloat(0, 30, 3, 5, 2, 15 + t)
-            assert res.is_identical(APyFloat(0, 31, 0, 5, 2, 15 + t // 2))
+            res = apyfloat(0, 30, 3, 5, 2) + apyfloat(0, 30, 3, 5, 2, 15 + t)
+            assert res.is_identical(apyfloat(0, 31, 0, 5, 2, 15 + t // 2))
 
             # Two big negative numbers should become infinity
-            res = APyFloat(1, 30, 3, 5, 2) + APyFloat(1, 30, 3, 5, 2, 15 + t)
-            assert res.is_identical(APyFloat(1, 31, 0, 5, 2, 15 + t // 2))
+            res = apyfloat(1, 30, 3, 5, 2) + apyfloat(1, 30, 3, 5, 2, 15 + t)
+            assert res.is_identical(apyfloat(1, 31, 0, 5, 2, 15 + t // 2))
 
-    def test_to_ties_away(self, t):
+    @pytest.mark.parametrize("apyfloat", [APyFloat, APyCFloat])
+    def test_to_ties_away(self, apyfloat: type[APyCFloat], t: int):
         with APyFloatQuantizationContext(QuantizationMode.TIES_EVEN):
             # 1.5 + relatively big number (0.21875) should quantize to 1.75
-            res = APyFloat(0, 15, 2, 5, 2) + APyFloat(0, 12 + t, 3, 5, 2, 15 + t)
-            assert res.is_identical(APyFloat(0, 15 + t // 2, 3, 5, 2, 15 + t // 2))
+            res = apyfloat(0, 15, 2, 5, 2) + apyfloat(0, 12 + t, 3, 5, 2, 15 + t)
+            assert res.is_identical(apyfloat(0, 15 + t // 2, 3, 5, 2, 15 + t // 2))
 
             # -1.5 + relatively big negative number (0.21875) should quantize to -1.75
-            res = APyFloat(1, 15, 2, 5, 2) + APyFloat(1, 12 + t, 3, 5, 2, 15 + t)
-            assert res.is_identical(APyFloat(1, 15 + t // 2, 3, 5, 2, 15 + t // 2))
+            res = apyfloat(1, 15, 2, 5, 2) + apyfloat(1, 12 + t, 3, 5, 2, 15 + t)
+            assert res.is_identical(apyfloat(1, 15 + t // 2, 3, 5, 2, 15 + t // 2))
 
             # 1.5 + very small number should quantize to 1.5
-            res = APyFloat(0, 15, 2, 5, 2) + APyFloat(0, 1, 0, 5, 2, 15 + t)
-            assert res.is_identical(APyFloat(0, 15 + t // 2, 2, 5, 2, 15 + t // 2))
+            res = apyfloat(0, 15, 2, 5, 2) + apyfloat(0, 1, 0, 5, 2, 15 + t)
+            assert res.is_identical(apyfloat(0, 15 + t // 2, 2, 5, 2, 15 + t // 2))
 
             # -1.5 + very small negative number should quantize to 1.5
-            res = APyFloat(1, 15, 2, 5, 2) + APyFloat(0, 1, 0, 5, 2, 15 + t)
-            assert res.is_identical(APyFloat(1, 15 + t // 2, 2, 5, 2, 15 + t // 2))
+            res = apyfloat(1, 15, 2, 5, 2) + apyfloat(0, 1, 0, 5, 2, 15 + t)
+            assert res.is_identical(apyfloat(1, 15 + t // 2, 2, 5, 2, 15 + t // 2))
 
             # 1.5 + tie should quantize to 1.75
-            res = APyFloat(0, 15, 2, 5, 2) + APyFloat(0, 12 + t, 0, 5, 2, 15 + t)
-            assert res.is_identical(APyFloat(0, 15 + t // 2, 2, 5, 2, 15 + t // 2))
+            res = apyfloat(0, 15, 2, 5, 2) + apyfloat(0, 12 + t, 0, 5, 2, 15 + t)
+            assert res.is_identical(apyfloat(0, 15 + t // 2, 2, 5, 2, 15 + t // 2))
 
             # -1.5 + negative tie should quantize to -1.75
-            res = APyFloat(1, 15, 2, 5, 2) + APyFloat(1, 12 + t, 0, 5, 2, 15 + t)
-            assert res.is_identical(APyFloat(1, 15 + t // 2, 2, 5, 2, 15 + t // 2))
+            res = apyfloat(1, 15, 2, 5, 2) + apyfloat(1, 12 + t, 0, 5, 2, 15 + t)
+            assert res.is_identical(apyfloat(1, 15 + t // 2, 2, 5, 2, 15 + t // 2))
 
             # 1.75 + tie should quantize to 2.0
-            res = APyFloat(0, 15, 3, 5, 2) + APyFloat(0, 12 + t, 0, 5, 2, 15 + t)
-            assert res.is_identical(APyFloat(0, 16 + t // 2, 0, 5, 2, 15 + t // 2))
+            res = apyfloat(0, 15, 3, 5, 2) + apyfloat(0, 12 + t, 0, 5, 2, 15 + t)
+            assert res.is_identical(apyfloat(0, 16 + t // 2, 0, 5, 2, 15 + t // 2))
 
             # -1.75 + negative tie should quantize to -2.0
-            res = APyFloat(1, 15, 3, 5, 2) + APyFloat(1, 12 + t, 0, 5, 2, 15 + t)
-            assert res.is_identical(APyFloat(1, 16 + t // 2, 0, 5, 2, 15 + t // 2))
+            res = apyfloat(1, 15, 3, 5, 2) + apyfloat(1, 12 + t, 0, 5, 2, 15 + t)
+            assert res.is_identical(apyfloat(1, 16 + t // 2, 0, 5, 2, 15 + t // 2))
 
             # Two big positive numbers should become infinity
-            res = APyFloat(0, 30, 3, 5, 2) + APyFloat(0, 30, 3, 5, 2, 15 + t)
-            assert res.is_identical(APyFloat(0, 31, 0, 5, 2, 15 + t // 2))
+            res = apyfloat(0, 30, 3, 5, 2) + apyfloat(0, 30, 3, 5, 2, 15 + t)
+            assert res.is_identical(apyfloat(0, 31, 0, 5, 2, 15 + t // 2))
 
             # Two big negative numbers should become infinity
-            res = APyFloat(1, 30, 3, 5, 2) + APyFloat(1, 30, 3, 5, 2, 15 + t)
-            assert res.is_identical(APyFloat(1, 31, 0, 5, 2, 15 + t // 2))
+            res = apyfloat(1, 30, 3, 5, 2) + apyfloat(1, 30, 3, 5, 2, 15 + t)
+            assert res.is_identical(apyfloat(1, 31, 0, 5, 2, 15 + t // 2))
 
-    def test_jam(self, t):
+    def test_jam(self, t: int):
+        # NOTE: not equal behaviour for real- and complex-valued floating-points
         with APyFloatQuantizationContext(QuantizationMode.JAM):
             # 1.5 + very small number should quantize to 1.75
             res = APyFloat(0, 15, 2, 5, 2) + APyFloat(0, 1, 0, 5, 2, 15 + t)
@@ -291,41 +299,43 @@ class TestAPyFloatQuantizationAddSub:
             )
             assert (lhs + rhs).is_identical(ref)
 
-    def test_stoch_weighted(self, t):
+    @pytest.mark.parametrize("apyfloat", [APyFloat, APyCFloat])
+    def test_stoch_weighted(self, apyfloat: type[APyCFloat], t: int):
         with APyFloatQuantizationContext(QuantizationMode.STOCH_WEIGHTED):
             # 1.5 + 0.125 should quantize to 1.5 or 1.75
-            res = APyFloat(0, 15, 2, 5, 2) + APyFloat(0, 12 + t, 0, 5, 2, 15 + t)
-            assert res.is_identical(APyFloat(0, 15 + t // 2, 2, 5, 2, 15 + t // 2)) or (
-                res.is_identical(APyFloat(0, 15 + t // 2, 3, 5, 2, 15 + t // 2))
+            res = apyfloat(0, 15, 2, 5, 2) + apyfloat(0, 12 + t, 0, 5, 2, 15 + t)
+            assert res.is_identical(apyfloat(0, 15 + t // 2, 2, 5, 2, 15 + t // 2)) or (
+                res.is_identical(apyfloat(0, 15 + t // 2, 3, 5, 2, 15 + t // 2))
             )
 
-            res = APyFloat(0, 1023, 0, 11, 52) + APyFloat(
+            res = apyfloat(0, 1023, 0, 11, 52) + apyfloat(
                 0, 1022 + t, (1 << 52) - 1, 11, 52, 1023 + t
             )
             assert res.is_identical(
-                APyFloat(0, 1024 + t // 2, 0, 11, 52, 1023 + t // 2)
+                apyfloat(0, 1024 + t // 2, 0, 11, 52, 1023 + t // 2)
             ) or (
                 res.is_identical(
-                    APyFloat(0, 1023 + t // 2, 4503599627370495, 11, 52, 1023 + t // 2)
+                    apyfloat(0, 1023 + t // 2, 4503599627370495, 11, 52, 1023 + t // 2)
                 )
             )
 
-    def test_stoch_equal(self, t):
+    @pytest.mark.parametrize("apyfloat", [APyFloat, APyCFloat])
+    def test_stoch_equal(self, apyfloat: type[APyCFloat], t: int):
         with APyFloatQuantizationContext(QuantizationMode.STOCH_EQUAL):
             # 1.5 + 0.125 should quantize to 1.5 or 1.75
-            res = APyFloat(0, 15, 2, 5, 2) + APyFloat(0, 12 + t, 0, 5, 2, 15 + t)
-            assert res.is_identical(APyFloat(0, 15 + t // 2, 2, 5, 2, 15 + t // 2)) or (
-                res.is_identical(APyFloat(0, 15 + t // 2, 3, 5, 2, 15 + t // 2))
+            res = apyfloat(0, 15, 2, 5, 2) + apyfloat(0, 12 + t, 0, 5, 2, 15 + t)
+            assert res.is_identical(apyfloat(0, 15 + t // 2, 2, 5, 2, 15 + t // 2)) or (
+                res.is_identical(apyfloat(0, 15 + t // 2, 3, 5, 2, 15 + t // 2))
             )
 
-            res = APyFloat(0, 1023, 0, 11, 52) + APyFloat(
+            res = apyfloat(0, 1023, 0, 11, 52) + apyfloat(
                 0, 1022 + t, (1 << 52) - 1, 11, 52, 1023 + t
             )
             assert res.is_identical(
-                APyFloat(0, 1024 + t // 2, 0, 11, 52, 1023 + t // 2)
+                apyfloat(0, 1024 + t // 2, 0, 11, 52, 1023 + t // 2)
             ) or (
                 res.is_identical(
-                    APyFloat(0, 1023 + t // 2, 4503599627370495, 11, 52, 1023 + t // 2)
+                    apyfloat(0, 1023 + t // 2, 4503599627370495, 11, 52, 1023 + t // 2)
                 )
             )
 
@@ -336,87 +346,91 @@ class TestAPyFloatQuantizationMul:
     Test class for the different quantization modes for multiplication in APyFloat.
     """
 
-    def test_to_pos(self):
+    @pytest.mark.parametrize("apyfloat", [APyFloat, APyCFloat])
+    def test_to_pos(self, apyfloat: type[APyCFloat]):
         with APyFloatQuantizationContext(QuantizationMode.TO_POS):
             # Should round up
-            res = APyFloat(0, 7, 6, 4, 3) * APyFloat(0, 7, 1, 4, 3)
-            assert res.is_identical(APyFloat(0, 8, 0, 4, 3))
+            res = apyfloat(0, 7, 6, 4, 3) * apyfloat(0, 7, 1, 4, 3)
+            assert res.is_identical(apyfloat(0, 8, 0, 4, 3))
 
             # Should round down
-            res = APyFloat(1, 7, 6, 4, 3) * APyFloat(0, 7, 1, 4, 3)
-            assert res.is_identical(APyFloat(1, 7, 7, 4, 3))
+            res = apyfloat(1, 7, 6, 4, 3) * apyfloat(0, 7, 1, 4, 3)
+            assert res.is_identical(apyfloat(1, 7, 7, 4, 3))
 
             # Close to +0 should quantize to subnormal
-            res = APyFloat(0, 1, 0, 4, 3) * APyFloat(0, 1, 1, 4, 3)
-            assert res.is_identical(APyFloat(0, 0, 1, 4, 3))
+            res = apyfloat(0, 1, 0, 4, 3) * apyfloat(0, 1, 1, 4, 3)
+            assert res.is_identical(apyfloat(0, 0, 1, 4, 3))
 
             # Close to -0 should quantize to 0
-            res = APyFloat(1, 1, 0, 4, 3) * APyFloat(0, 1, 1, 4, 3)
-            assert res.is_identical(APyFloat(1, 0, 0, 4, 3))
+            res = apyfloat(1, 1, 0, 4, 3) * apyfloat(0, 1, 1, 4, 3)
+            assert res.is_identical(apyfloat(1, 0, 0, 4, 3))
 
             # Same two tests but with subnormal operands
-            res = APyFloat(0, 0, 1, 4, 3) * APyFloat(0, 0, 1, 4, 3)
-            assert res.is_identical(APyFloat(0, 0, 1, 4, 3))
+            res = apyfloat(0, 0, 1, 4, 3) * apyfloat(0, 0, 1, 4, 3)
+            assert res.is_identical(apyfloat(0, 0, 1, 4, 3))
 
-            res = APyFloat(1, 0, 1, 4, 3) * APyFloat(0, 0, 1, 4, 3)
-            assert res.is_identical(APyFloat(1, 0, 0, 4, 3))
+            res = apyfloat(1, 0, 1, 4, 3) * apyfloat(0, 0, 1, 4, 3)
+            assert res.is_identical(apyfloat(1, 0, 0, 4, 3))
 
             # Big positive number should become infinity
-            res = APyFloat(0, 30, 3, 5, 2) * APyFloat(0, 30, 3, 5, 2)
-            assert res.is_identical(APyFloat(0, 31, 0, 5, 2))
+            res = apyfloat(0, 30, 3, 5, 2) * apyfloat(0, 30, 3, 5, 2)
+            assert res.is_identical(apyfloat(0, 31, 0, 5, 2))
 
             # Big negative number should saturate
-            res = APyFloat(1, 30, 3, 5, 2) * APyFloat(0, 30, 3, 5, 2)
-            assert res.is_identical(APyFloat(1, 30, 3, 5, 2))
+            res = apyfloat(1, 30, 3, 5, 2) * apyfloat(0, 30, 3, 5, 2)
+            assert res.is_identical(apyfloat(1, 30, 3, 5, 2))
 
             # Tests from https://github.com/apytypes/apytypes/issues/406
-            res = APyFloat(1, 1, 1023, 5, 10) * APyFloat(1, 26, 80, 5, 10)
+            res = apyfloat(1, 1, 1023, 5, 10) * apyfloat(1, 26, 80, 5, 10)
             assert res.is_identical(
-                APyFloat(sign=0, exp=13, man=80, exp_bits=5, man_bits=10)
+                apyfloat(sign=0, exp=13, man=80, exp_bits=5, man_bits=10),
+                ignore_zero_sign=True,
             )
 
-            res = APyFloat(sign=0, exp=2, man=72, exp_bits=5, man_bits=10) * APyFloat(
+            res = apyfloat(sign=0, exp=2, man=72, exp_bits=5, man_bits=10) * apyfloat(
                 sign=0, exp=0, man=58, exp_bits=5, man_bits=10
             )
             assert res.is_identical(
-                APyFloat(sign=0, exp=0, man=1, exp_bits=5, man_bits=10)
+                apyfloat(sign=0, exp=0, man=1, exp_bits=5, man_bits=10)
             )
 
-    def test_to_neg(self):
+    @pytest.mark.parametrize("apyfloat", [APyFloat, APyCFloat])
+    def test_to_neg(self, apyfloat: type[APyCFloat]):
         with APyFloatQuantizationContext(QuantizationMode.TO_NEG):
             # Should round down
-            res = APyFloat(0, 7, 6, 4, 3) * APyFloat(0, 7, 1, 4, 3)
-            assert res.is_identical(APyFloat(0, 7, 7, 4, 3))
+            res = apyfloat(0, 7, 6, 4, 3) * apyfloat(0, 7, 1, 4, 3)
+            assert res.is_identical(apyfloat(0, 7, 7, 4, 3))
 
             # Should round down
-            res = APyFloat(1, 7, 6, 4, 3) * APyFloat(0, 7, 1, 4, 3)
-            assert res.is_identical(APyFloat(1, 8, 0, 4, 3))
+            res = apyfloat(1, 7, 6, 4, 3) * apyfloat(0, 7, 1, 4, 3)
+            assert res.is_identical(apyfloat(1, 8, 0, 4, 3), ignore_zero_sign=True)
 
             # Close to +0 should quantize to zero
-            res = APyFloat(0, 1, 0, 4, 3) * APyFloat(0, 1, 1, 4, 3)
-            assert res.is_identical(APyFloat(0, 0, 0, 4, 3))
+            res = apyfloat(0, 1, 0, 4, 3) * apyfloat(0, 1, 1, 4, 3)
+            assert res.is_identical(apyfloat(0, 0, 0, 4, 3), ignore_zero_sign=True)
 
             # Close to -0 should quantize to subnormal
-            res = APyFloat(1, 1, 0, 4, 3) * APyFloat(0, 1, 1, 4, 3)
-            assert res.is_identical(APyFloat(1, 0, 1, 4, 3))
+            res = apyfloat(1, 1, 0, 4, 3) * apyfloat(0, 1, 1, 4, 3)
+            assert res.is_identical(apyfloat(1, 0, 1, 4, 3), ignore_zero_sign=True)
 
             # Same two tests but with subnormal operands
-            res = APyFloat(0, 0, 1, 4, 3) * APyFloat(0, 0, 1, 4, 3)
-            assert res.is_identical(APyFloat(0, 0, 0, 4, 3))
+            res = apyfloat(0, 0, 1, 4, 3) * apyfloat(0, 0, 1, 4, 3)
+            assert res.is_identical(apyfloat(0, 0, 0, 4, 3), ignore_zero_sign=True)
 
-            res = APyFloat(1, 0, 1, 4, 3) * APyFloat(0, 0, 1, 4, 3)
-            assert res.is_identical(APyFloat(1, 0, 1, 4, 3))
+            res = apyfloat(1, 0, 1, 4, 3) * apyfloat(0, 0, 1, 4, 3)
+            assert res.is_identical(apyfloat(1, 0, 1, 4, 3), ignore_zero_sign=True)
 
             # Big positive number should saturate
-            res = APyFloat(0, 30, 3, 5, 2) * APyFloat(0, 30, 3, 5, 2)
-            assert res.is_identical(APyFloat(0, 30, 3, 5, 2))
+            res = apyfloat(0, 30, 3, 5, 2) * apyfloat(0, 30, 3, 5, 2)
+            assert res.is_identical(apyfloat(0, 30, 3, 5, 2))
 
             # Big negative number should become infinity
-            res = APyFloat(1, 30, 3, 5, 2) * APyFloat(0, 30, 3, 5, 2)
-            assert res.is_identical(APyFloat(1, 31, 0, 5, 2))
+            res = apyfloat(1, 30, 3, 5, 2) * apyfloat(0, 30, 3, 5, 2)
+            assert res.is_identical(apyfloat(1, 31, 0, 5, 2), ignore_zero_sign=True)
 
     def test_jam(self):
         # TODO: more tests
+        # NOTE: not equal behaviour for real- and complex-valued floating-points
         with APyFloatQuantizationContext(QuantizationMode.JAM):
             # Test jamming for subnormal result
             res = APyFloat(sign=0, exp=0, man=1, exp_bits=5, man_bits=10) * APyFloat(
@@ -426,67 +440,70 @@ class TestAPyFloatQuantizationMul:
                 APyFloat(sign=1, exp=0, man=1, exp_bits=5, man_bits=10)
             )
 
-    def test_jam_unbiased(self):
+    @pytest.mark.parametrize("apyfloat", [APyFloat, APyCFloat])
+    def test_jam_unbiased(self, apyfloat: type[APyCFloat]):
         # TODO: more tests
         with APyFloatQuantizationContext(QuantizationMode.JAM_UNBIASED):
             # Test jamming for subnormal result
-            res = APyFloat(sign=0, exp=0, man=1, exp_bits=5, man_bits=10) * APyFloat(
+            res = apyfloat(sign=0, exp=0, man=1, exp_bits=5, man_bits=10) * apyfloat(
                 sign=1, exp=0, man=1, exp_bits=5, man_bits=10
             )
             assert res.is_identical(
-                APyFloat(sign=1, exp=0, man=1, exp_bits=5, man_bits=10)
+                apyfloat(sign=1, exp=0, man=1, exp_bits=5, man_bits=10)
             )
 
-    def test_stoch_weighted(self):
+    @pytest.mark.parametrize("apyfloat", [APyFloat, APyCFloat])
+    def test_stoch_weighted(self, apyfloat: type[APyCFloat]):
         with APyFloatQuantizationContext(QuantizationMode.STOCH_WEIGHTED):
             # 1.25 * 1.25 should quantize to 1.5 or 1.75
-            res = APyFloat(0, 15, 1, 5, 2) * APyFloat(0, 15, 1, 5, 2)
-            assert res.is_identical(APyFloat(0, 15, 2, 5, 2)) or (
-                res.is_identical(APyFloat(0, 15, 3, 5, 2))
+            res = apyfloat(0, 15, 1, 5, 2) * apyfloat(0, 15, 1, 5, 2)
+            assert res.is_identical(apyfloat(0, 15, 2, 5, 2)) or (
+                res.is_identical(apyfloat(0, 15, 3, 5, 2))
             )
 
-            res = APyFloat(0, 15, 1, 5, 52) * APyFloat(0, 15, 1, 5, 52)
-            assert res.is_identical(APyFloat(0, 15, 2, 5, 52)) or (
-                res.is_identical(APyFloat(0, 15, 3, 5, 52))
+            res = apyfloat(0, 15, 1, 5, 52) * apyfloat(0, 15, 1, 5, 52)
+            assert res.is_identical(apyfloat(0, 15, 2, 5, 52)) or (
+                res.is_identical(apyfloat(0, 15, 3, 5, 52))
             )
 
             # Should quantize to zero or smallest subnormal
-            res = APyFloat(0, 1, 0, 4, 2) * APyFloat(0, 1, 0, 4, 2)
-            assert res.is_identical(APyFloat(0, 0, 0, 4, 2)) or (
-                res.is_identical(APyFloat(0, 0, 1, 4, 2))
+            res = apyfloat(0, 1, 0, 4, 2) * apyfloat(0, 1, 0, 4, 2)
+            assert res.is_identical(apyfloat(0, 0, 0, 4, 2)) or (
+                res.is_identical(apyfloat(0, 0, 1, 4, 2))
             )
 
-            res = APyFloat(0, 0, (1 << 27) - 1, 4, 52) * APyFloat(
+            res = apyfloat(0, 0, (1 << 27) - 1, 4, 52) * apyfloat(
                 0, 0, (1 << 30) - 1, 4, 52
             )
-            assert res.is_identical(APyFloat(0, 0, 0, 4, 52)) or (
-                res.is_identical(APyFloat(0, 0, 1, 4, 52))
+            assert res.is_identical(apyfloat(0, 0, 0, 4, 52)) or (
+                res.is_identical(apyfloat(0, 0, 1, 4, 52))
             )
 
-    def test_stoch_equal(self):
+    @pytest.mark.parametrize("apyfloat", [APyFloat, APyCFloat])
+    def test_stoch_equal(self, apyfloat: type[APyCFloat]):
         with APyFloatQuantizationContext(QuantizationMode.STOCH_EQUAL):
             # 1.25 * 1.25 should quantize to 1.5 or 1.75
-            res = APyFloat(0, 15, 1, 5, 2) * APyFloat(0, 15, 1, 5, 2)
-            assert res.is_identical(APyFloat(0, 15, 2, 5, 2)) or (
-                res.is_identical(APyFloat(0, 15, 3, 5, 2))
+            res = apyfloat(0, 15, 1, 5, 2) * apyfloat(0, 15, 1, 5, 2)
+            assert res.is_identical(apyfloat(0, 15, 2, 5, 2)) or (
+                res.is_identical(apyfloat(0, 15, 3, 5, 2))
             )
 
-            res = APyFloat(0, 15, 1, 5, 52) * APyFloat(0, 15, 1, 5, 52)
-            assert res.is_identical(APyFloat(0, 15, 2, 5, 52)) or (
-                res.is_identical(APyFloat(0, 15, 3, 5, 52))
+            res = apyfloat(0, 15, 1, 5, 52) * apyfloat(0, 15, 1, 5, 52)
+            assert res.is_identical(apyfloat(0, 15, 2, 5, 52)) or (
+                res.is_identical(apyfloat(0, 15, 3, 5, 52))
             )
 
             # Should quantize to zero or smallest subnormal
-            res = APyFloat(0, 1, 0, 4, 2) * APyFloat(0, 1, 0, 4, 2)
-            assert res.is_identical(APyFloat(0, 0, 0, 4, 2)) or (
-                res.is_identical(APyFloat(0, 0, 1, 4, 2))
+            res = apyfloat(0, 1, 0, 4, 2) * apyfloat(0, 1, 0, 4, 2)
+            assert res.is_identical(apyfloat(0, 0, 0, 4, 2)) or (
+                res.is_identical(apyfloat(0, 0, 1, 4, 2))
             )
 
-            res = APyFloat(0, 0, (1 << 27) - 1, 4, 52) * APyFloat(
+            res = apyfloat(0, 0, (1 << 27) - 1, 4, 52) * apyfloat(
                 0, 0, (1 << 30) - 1, 4, 52
             )
-            assert res.is_identical(APyFloat(0, 0, 0, 4, 52)) or (
-                res.is_identical(APyFloat(0, 0, 1, 4, 52))
+            assert res.is_identical(apyfloat(0, 0, 0, 4, 52)) or (
+                res.is_identical(apyfloat(0, 0, 1, 4, 52))
             )
 
 
@@ -496,145 +513,151 @@ class TestAPyFloatQuantizationDiv:
     Test class for the different quantization modes for division in APyFloat.
     """
 
-    def test_to_pos(self):
+    @pytest.mark.parametrize("apyfloat", [APyFloat, APyCFloat])
+    def test_to_pos(self, apyfloat: type[APyCFloat]):
         with APyFloatQuantizationContext(QuantizationMode.TO_POS):
             # 1.5 / 1.25 (=1.2) should quantize to 1.25
-            res = APyFloat(0, 15, 2, 5, 2) / APyFloat(0, 15, 1, 5, 2)
-            assert res.is_identical(APyFloat(0, 15, 1, 5, 2))
+            res = apyfloat(0, 15, 2, 5, 2) / apyfloat(0, 15, 1, 5, 2)
+            assert res.is_identical(apyfloat(0, 15, 1, 5, 2))
 
             # -1.5 / 1.25 (=-1.2) should quantize to -1
-            res = APyFloat(1, 15, 2, 5, 2) / APyFloat(0, 15, 1, 5, 2)
-            assert res.is_identical(APyFloat(1, 15, 0, 5, 2))
+            res = apyfloat(1, 15, 2, 5, 2) / apyfloat(0, 15, 1, 5, 2)
+            assert res.is_identical(apyfloat(1, 15, 0, 5, 2))
 
             # Should become infinity
-            res = APyFloat(0, 30, 3, 5, 2) / APyFloat(0, 0, 3, 5, 2)
-            assert res.is_identical(APyFloat(0, 31, 0, 5, 2))
+            res = apyfloat(0, 30, 3, 5, 2) / apyfloat(0, 0, 3, 5, 2)
+            assert res.is_identical(apyfloat(0, 31, 0, 5, 2))
 
             # Should saturate
-            res = APyFloat(0, 30, 3, 5, 2) / APyFloat(1, 0, 3, 5, 2)
-            assert res.is_identical(APyFloat(1, 30, 3, 5, 2))
+            res = apyfloat(0, 30, 3, 5, 2) / apyfloat(1, 0, 3, 5, 2)
+            assert res.is_identical(apyfloat(1, 30, 3, 5, 2), ignore_zero_sign=True)
 
-    def test_to_neg(self):
+    @pytest.mark.parametrize("apyfloat", [APyFloat, APyCFloat])
+    def test_to_neg(self, apyfloat: type[APyCFloat]):
         with APyFloatQuantizationContext(QuantizationMode.TO_NEG):
             # 1.5 / 1.25 (=1.2) should quantize to 1.0
-            res = APyFloat(0, 15, 2, 5, 2) / APyFloat(0, 15, 1, 5, 2)
-            assert res.is_identical(APyFloat(0, 15, 0, 5, 2))
+            res = apyfloat(0, 15, 2, 5, 2) / apyfloat(0, 15, 1, 5, 2)
+            assert res.is_identical(apyfloat(0, 15, 0, 5, 2), ignore_zero_sign=True)
 
             # -1.5 / 1.25 (=-1.2) should quantize to -1.25
-            res = APyFloat(1, 15, 2, 5, 2) / APyFloat(0, 15, 1, 5, 2)
-            assert res.is_identical(APyFloat(1, 15, 1, 5, 2))
+            res = apyfloat(1, 15, 2, 5, 2) / apyfloat(0, 15, 1, 5, 2)
+            assert res.is_identical(apyfloat(1, 15, 1, 5, 2))
 
             # Should saturate
-            res = APyFloat(0, 30, 3, 5, 2) / APyFloat(0, 0, 3, 5, 2)
-            assert res.is_identical(APyFloat(0, 30, 3, 5, 2))
+            res = apyfloat(0, 30, 3, 5, 2) / apyfloat(0, 0, 3, 5, 2)
+            assert res.is_identical(apyfloat(0, 30, 3, 5, 2), ignore_zero_sign=True)
 
             # Should become infinity
-            res = APyFloat(0, 30, 3, 5, 2) / APyFloat(1, 0, 3, 5, 2)
-            assert res.is_identical(APyFloat(1, 31, 0, 5, 2))
+            res = apyfloat(0, 30, 3, 5, 2) / apyfloat(1, 0, 3, 5, 2)
+            assert res.is_identical(apyfloat(1, 31, 0, 5, 2), ignore_zero_sign=True)
 
-    def test_to_zero(self):
+    @pytest.mark.parametrize("apyfloat", [APyFloat, APyCFloat])
+    def test_to_zero(self, apyfloat: type[APyCFloat]):
         with APyFloatQuantizationContext(QuantizationMode.TO_ZERO):
             # 1.25 / 1.5 should quantize to 0.75
-            res = APyFloat(0, 15, 1, 5, 2) / APyFloat(0, 15, 2, 5, 2)
-            assert res.is_identical(APyFloat(0, 14, 2, 5, 2))
+            res = apyfloat(0, 15, 1, 5, 2) / apyfloat(0, 15, 2, 5, 2)
+            assert res.is_identical(apyfloat(0, 14, 2, 5, 2))
 
             # -1.25 / 1.5 should quantize to -0.75
-            res = APyFloat(1, 15, 1, 5, 2) / APyFloat(0, 15, 2, 5, 2)
-            assert res.is_identical(APyFloat(1, 14, 2, 5, 2))
+            res = apyfloat(1, 15, 1, 5, 2) / apyfloat(0, 15, 2, 5, 2)
+            assert res.is_identical(apyfloat(1, 14, 2, 5, 2))
 
             # Should saturate
-            res = APyFloat(0, 30, 3, 5, 2) / APyFloat(0, 0, 3, 5, 2)
-            assert res.is_identical(APyFloat(0, 30, 3, 5, 2))
+            res = apyfloat(0, 30, 3, 5, 2) / apyfloat(0, 0, 3, 5, 2)
+            assert res.is_identical(apyfloat(0, 30, 3, 5, 2))
 
             # Should saturate
-            res = APyFloat(0, 30, 3, 5, 2) / APyFloat(1, 0, 3, 5, 2)
-            assert res.is_identical(APyFloat(1, 30, 3, 5, 2))
+            res = apyfloat(0, 30, 3, 5, 2) / apyfloat(1, 0, 3, 5, 2)
+            assert res.is_identical(apyfloat(1, 30, 3, 5, 2), ignore_zero_sign=True)
 
-    def test_to_ties_even(self):
+    @pytest.mark.parametrize("apyfloat", [APyFloat, APyCFloat])
+    def test_to_ties_even(self, apyfloat: type[APyCFloat]):
         with APyFloatQuantizationContext(QuantizationMode.TIES_EVEN):
             # 1.25 / 1.5 should quantize to closes which is 0.875
-            res = APyFloat(0, 15, 1, 5, 2) / APyFloat(0, 15, 2, 5, 2)
-            assert res.is_identical(APyFloat(0, 14, 3, 5, 2))
+            res = apyfloat(0, 15, 1, 5, 2) / apyfloat(0, 15, 2, 5, 2)
+            assert res.is_identical(apyfloat(0, 14, 3, 5, 2))
 
             # -1.25 / 1.5 should quantize to closes which is 0.875
-            res = APyFloat(1, 15, 1, 5, 2) / APyFloat(0, 15, 2, 5, 2)
-            assert res.is_identical(APyFloat(1, 14, 3, 5, 2))
+            res = apyfloat(1, 15, 1, 5, 2) / apyfloat(0, 15, 2, 5, 2)
+            assert res.is_identical(apyfloat(1, 14, 3, 5, 2))
 
             # 1.5 / 1.25 (=1.2) should quantize to closest which is 1.25
-            res = APyFloat(0, 15, 2, 5, 2) / APyFloat(0, 15, 1, 5, 2)
-            assert res.is_identical(APyFloat(0, 15, 1, 5, 2))
+            res = apyfloat(0, 15, 2, 5, 2) / apyfloat(0, 15, 1, 5, 2)
+            assert res.is_identical(apyfloat(0, 15, 1, 5, 2))
 
             # -1.5 / 1.25 (=-1.2) should quantize to closes which is -1.25
-            res = APyFloat(1, 15, 2, 5, 2) / APyFloat(0, 15, 1, 5, 2)
-            assert res.is_identical(APyFloat(1, 15, 1, 5, 2))
+            res = apyfloat(1, 15, 2, 5, 2) / apyfloat(0, 15, 1, 5, 2)
+            assert res.is_identical(apyfloat(1, 15, 1, 5, 2))
 
             # 2**-16 / 2 should tie to 0
-            res = APyFloat(0, 0, 1, 5, 2) / APyFloat(0, 16, 0, 5, 2)
-            assert res.is_identical(APyFloat(0, 0, 0, 5, 2))
+            res = apyfloat(0, 0, 1, 5, 2) / apyfloat(0, 16, 0, 5, 2)
+            assert res.is_identical(apyfloat(0, 0, 0, 5, 2))
 
             # -2**-16 / 2 should tie to 0
-            res = APyFloat(1, 0, 1, 5, 2) / APyFloat(0, 16, 0, 5, 2)
-            assert res.is_identical(APyFloat(1, 0, 0, 5, 2))
+            res = apyfloat(1, 0, 1, 5, 2) / apyfloat(0, 16, 0, 5, 2)
+            assert res.is_identical(apyfloat(1, 0, 0, 5, 2))
 
             # 3*2**-16 / 2 should tie to 2*2**-16
-            res = APyFloat(0, 0, 3, 5, 2) / APyFloat(0, 16, 0, 5, 2)
-            assert res.is_identical(APyFloat(0, 0, 2, 5, 2))
+            res = apyfloat(0, 0, 3, 5, 2) / apyfloat(0, 16, 0, 5, 2)
+            assert res.is_identical(apyfloat(0, 0, 2, 5, 2))
 
             # -3*2**-16 / 2 should tie to -2*2**-16
-            res = APyFloat(1, 0, 3, 5, 2) / APyFloat(0, 16, 0, 5, 2)
-            assert res.is_identical(APyFloat(1, 0, 2, 5, 2))
+            res = apyfloat(1, 0, 3, 5, 2) / apyfloat(0, 16, 0, 5, 2)
+            assert res.is_identical(apyfloat(1, 0, 2, 5, 2))
 
             # Should become infinity
-            res = APyFloat(0, 30, 3, 5, 2) / APyFloat(0, 0, 3, 5, 2)
-            assert res.is_identical(APyFloat(0, 31, 0, 5, 2))
+            res = apyfloat(0, 30, 3, 5, 2) / apyfloat(0, 0, 3, 5, 2)
+            assert res.is_identical(apyfloat(0, 31, 0, 5, 2))
 
             # Should become infinity
-            res = APyFloat(0, 30, 3, 5, 2) / APyFloat(1, 0, 3, 5, 2)
-            assert res.is_identical(APyFloat(1, 31, 0, 5, 2))
+            res = apyfloat(0, 30, 3, 5, 2) / apyfloat(1, 0, 3, 5, 2)
+            assert res.is_identical(apyfloat(1, 31, 0, 5, 2), ignore_zero_sign=True)
 
-    def test_to_ties_away(self):
+    @pytest.mark.parametrize("apyfloat", [APyFloat, APyCFloat])
+    def test_to_ties_away(self, apyfloat: type[APyCFloat]):
         with APyFloatQuantizationContext(QuantizationMode.TIES_AWAY):
             # 1.25 / 1.5 should quantize to closes which is 0.875
-            res = APyFloat(0, 15, 1, 5, 2) / APyFloat(0, 15, 2, 5, 2)
-            assert res.is_identical(APyFloat(0, 14, 3, 5, 2))
+            res = apyfloat(0, 15, 1, 5, 2) / apyfloat(0, 15, 2, 5, 2)
+            assert res.is_identical(apyfloat(0, 14, 3, 5, 2))
 
             # -1.25 / 1.5 should quantize to closes which is 0.875
-            res = APyFloat(1, 15, 1, 5, 2) / APyFloat(0, 15, 2, 5, 2)
-            assert res.is_identical(APyFloat(1, 14, 3, 5, 2))
+            res = apyfloat(1, 15, 1, 5, 2) / apyfloat(0, 15, 2, 5, 2)
+            assert res.is_identical(apyfloat(1, 14, 3, 5, 2))
 
             # 1.5 / 1.25 (=1.2) should quantize to closest which is 1.25
-            res = APyFloat(0, 15, 2, 5, 2) / APyFloat(0, 15, 1, 5, 2)
-            assert res.is_identical(APyFloat(0, 15, 1, 5, 2))
+            res = apyfloat(0, 15, 2, 5, 2) / apyfloat(0, 15, 1, 5, 2)
+            assert res.is_identical(apyfloat(0, 15, 1, 5, 2))
 
             # -1.5 / 1.25 (=-1.2) should quantize to closes which is -1.25
-            res = APyFloat(1, 15, 2, 5, 2) / APyFloat(0, 15, 1, 5, 2)
-            assert res.is_identical(APyFloat(1, 15, 1, 5, 2))
+            res = apyfloat(1, 15, 2, 5, 2) / apyfloat(0, 15, 1, 5, 2)
+            assert res.is_identical(apyfloat(1, 15, 1, 5, 2))
 
             # 2**-16 / 2 should tie to 2**-16
-            res = APyFloat(0, 0, 1, 5, 2) / APyFloat(0, 16, 0, 5, 2)
-            assert res.is_identical(APyFloat(0, 0, 1, 5, 2))
+            res = apyfloat(0, 0, 1, 5, 2) / apyfloat(0, 16, 0, 5, 2)
+            assert res.is_identical(apyfloat(0, 0, 1, 5, 2))
 
             # -2**-16 / 2 should tie to 2**-16
-            res = APyFloat(1, 0, 1, 5, 2) / APyFloat(0, 16, 0, 5, 2)
-            assert res.is_identical(APyFloat(1, 0, 1, 5, 2))
+            res = apyfloat(1, 0, 1, 5, 2) / apyfloat(0, 16, 0, 5, 2)
+            assert res.is_identical(apyfloat(1, 0, 1, 5, 2))
 
             # 3*2**-16 / 2 should tie to 2*2**-16
-            res = APyFloat(0, 0, 3, 5, 2) / APyFloat(0, 16, 0, 5, 2)
-            assert res.is_identical(APyFloat(0, 0, 2, 5, 2))
+            res = apyfloat(0, 0, 3, 5, 2) / apyfloat(0, 16, 0, 5, 2)
+            assert res.is_identical(apyfloat(0, 0, 2, 5, 2))
 
             # -3*2**-16 / 2 should tie to -2*2**-16
-            res = APyFloat(1, 0, 3, 5, 2) / APyFloat(0, 16, 0, 5, 2)
-            assert res.is_identical(APyFloat(1, 0, 2, 5, 2))
+            res = apyfloat(1, 0, 3, 5, 2) / apyfloat(0, 16, 0, 5, 2)
+            assert res.is_identical(apyfloat(1, 0, 2, 5, 2))
 
             # Should become infinity
-            res = APyFloat(0, 30, 3, 5, 2) / APyFloat(0, 0, 3, 5, 2)
-            assert res.is_identical(APyFloat(0, 31, 0, 5, 2))
+            res = apyfloat(0, 30, 3, 5, 2) / apyfloat(0, 0, 3, 5, 2)
+            assert res.is_identical(apyfloat(0, 31, 0, 5, 2))
 
             # Should become infinity
-            res = APyFloat(0, 30, 3, 5, 2) / APyFloat(1, 0, 3, 5, 2)
-            assert res.is_identical(APyFloat(1, 31, 0, 5, 2))
+            res = apyfloat(0, 30, 3, 5, 2) / apyfloat(1, 0, 3, 5, 2)
+            assert res.is_identical(apyfloat(1, 31, 0, 5, 2), ignore_zero_sign=True)
 
     def test_jam(self):
+        # NOTE: not equal behaviour for real- and complex-valued floating-points
         with APyFloatQuantizationContext(QuantizationMode.JAM):
             # 1.5 / 1.25 (=1.2) should quantize to 1.25
             res = APyFloat(0, 15, 2, 5, 2) / APyFloat(0, 15, 1, 5, 2)
@@ -656,32 +679,34 @@ class TestAPyFloatQuantizationDiv:
             res = APyFloat(0, 30, 3, 5, 2) / APyFloat(1, 0, 3, 5, 2)
             assert res.is_identical(APyFloat(1, 30, 3, 5, 2))
 
-    def test_stoch_weighted(self):
+    @pytest.mark.parametrize("apyfloat", [APyFloat, APyCFloat])
+    def test_stoch_weighted(self, apyfloat: type[APyCFloat]):
         with APyFloatQuantizationContext(QuantizationMode.STOCH_WEIGHTED):
             # 1.5 / 1.25 (=1.2) should quantize to 1.0 or 1.25
-            res = APyFloat(0, 15, 2, 5, 2) / APyFloat(0, 15, 1, 5, 2)
-            assert res.is_identical(APyFloat(0, 15, 0, 5, 2)) or (
-                res.is_identical(APyFloat(0, 15, 1, 5, 2))
+            res = apyfloat(0, 15, 2, 5, 2) / apyfloat(0, 15, 1, 5, 2)
+            assert res.is_identical(apyfloat(0, 15, 0, 5, 2)) or (
+                res.is_identical(apyfloat(0, 15, 1, 5, 2))
             )
 
             # 1.something / 2 can round to either 0.5 or 0.5(something)
-            res = APyFloat(0, 1023, 1, 11, 52) / APyFloat(0, 1024, 0, 11, 52)
-            assert res.is_identical(APyFloat(0, 1022, 0, 11, 52)) or (
-                res.is_identical(APyFloat(0, 1022, 1, 11, 52))
+            res = apyfloat(0, 1023, 1, 11, 52) / apyfloat(0, 1024, 0, 11, 52)
+            assert res.is_identical(apyfloat(0, 1022, 0, 11, 52)) or (
+                res.is_identical(apyfloat(0, 1022, 1, 11, 52))
             )
 
-    def test_stoch_equal(self):
+    @pytest.mark.parametrize("apyfloat", [APyFloat, APyCFloat])
+    def test_stoch_equal(self, apyfloat: type[APyCFloat]):
         with APyFloatQuantizationContext(QuantizationMode.STOCH_EQUAL):
             # 1.5 / 1.25 (=1.2) should quantize to 1.0 or 1.25
-            res = APyFloat(0, 15, 2, 5, 2) / APyFloat(0, 15, 1, 5, 2)
-            assert res.is_identical(APyFloat(0, 15, 0, 5, 2)) or (
-                res.is_identical(APyFloat(0, 15, 1, 5, 2))
+            res = apyfloat(0, 15, 2, 5, 2) / apyfloat(0, 15, 1, 5, 2)
+            assert res.is_identical(apyfloat(0, 15, 0, 5, 2)) or (
+                res.is_identical(apyfloat(0, 15, 1, 5, 2))
             )
 
             # 1.something / 2 can quantize to either 0.5 or 0.5(something)
-            res = APyFloat(0, 1023, 1, 11, 52) / APyFloat(0, 1024, 0, 11, 52)
-            assert res.is_identical(APyFloat(0, 1022, 0, 11, 52)) or (
-                res.is_identical(APyFloat(0, 1022, 1, 11, 52))
+            res = apyfloat(0, 1023, 1, 11, 52) / apyfloat(0, 1024, 0, 11, 52)
+            assert res.is_identical(apyfloat(0, 1022, 0, 11, 52)) or (
+                res.is_identical(apyfloat(0, 1022, 1, 11, 52))
             )
 
 
@@ -690,7 +715,7 @@ class TestAPyFloatQuantization:
     Test class for the different quantization modes for APyFloat.
     """
 
-    default_mode = None
+    default_mode: QuantizationMode = QuantizationMode.TIES_EVEN
 
     def setup_class(self):
         """Save the current quantization mode so that it can be restored later for other tests."""
@@ -700,1274 +725,1289 @@ class TestAPyFloatQuantization:
         """Restore quantization mode."""
         apytypes.set_float_quantization_mode(self.default_mode)
 
-    def test_quantization_mantissa_overflow(self):
+    @pytest.mark.parametrize("apyfloat", [APyFloat, APyCFloat])
+    def test_quantization_mantissa_overflow(self, apyfloat: type[APyCFloat]):
         apytypes.set_float_quantization_mode(QuantizationMode.TO_POS)
         assert (
-            APyFloat(0, 5, 0b11111, 5, 5)
+            apyfloat(0, 5, 0b11111, 5, 5)
             .cast(5, 3)
-            .is_identical(APyFloat(0, 6, 0b000, 5, 3))
+            .is_identical(apyfloat(0, 6, 0b000, 5, 3))
         )
         assert (
-            APyFloat(0, 0b11110, 0b11111, 5, 5)
+            apyfloat(0, 0b11110, 0b11111, 5, 5)
             .cast(5, 3)
-            .is_identical(APyFloat(0, 0b11111, 0b000, 5, 3))
+            .is_identical(apyfloat(0, 0b11111, 0b000, 5, 3))
         )  # Quantization becomes inf
 
         apytypes.set_float_quantization_mode(QuantizationMode.TO_NEG)
         assert (
-            APyFloat(1, 5, 0b11111, 5, 5)
+            apyfloat(1, 5, 0b11111, 5, 5)
             .cast(5, 3)
-            .is_identical(APyFloat(1, 6, 0b000, 5, 3))
+            .is_identical(apyfloat(1, 6, 0b000, 5, 3))
         )
         assert (
-            APyFloat(1, 0b11110, 0b11111, 5, 5)
+            apyfloat(1, 0b11110, 0b11111, 5, 5)
             .cast(5, 3)
-            .is_identical(APyFloat(1, 0b11111, 0b000, 5, 3))
+            .is_identical(apyfloat(1, 0b11111, 0b000, 5, 3))
         )  # Quantization becomes -inf
 
-    def test_quantization_to_pos(self):
+    @pytest.mark.parametrize("apyfloat", [APyFloat, APyCFloat])
+    def test_quantization_to_pos(self, apyfloat: type[APyCFloat]):
         apytypes.set_float_quantization_mode(QuantizationMode.TO_POS)
         # Quantization from 0.xx
         assert (
-            APyFloat(0, 5, 0b10000, 5, 5)
+            apyfloat(0, 5, 0b10000, 5, 5)
             .cast(5, 3)
-            .is_identical(APyFloat(0, 5, 0b100, 5, 3))
+            .is_identical(apyfloat(0, 5, 0b100, 5, 3))
         )  # No quantization needed
         assert (
-            APyFloat(0, 5, 0b10001, 5, 5)
+            apyfloat(0, 5, 0b10001, 5, 5)
             .cast(5, 3)
-            .is_identical(APyFloat(0, 5, 0b101, 5, 3))
+            .is_identical(apyfloat(0, 5, 0b101, 5, 3))
         )  # Round up
         assert (
-            APyFloat(0, 5, 0b10010, 5, 5)
+            apyfloat(0, 5, 0b10010, 5, 5)
             .cast(5, 3)
-            .is_identical(APyFloat(0, 5, 0b101, 5, 3))
+            .is_identical(apyfloat(0, 5, 0b101, 5, 3))
         )  # Tie break, round up
         assert (
-            APyFloat(0, 5, 0b10011, 5, 5)
+            apyfloat(0, 5, 0b10011, 5, 5)
             .cast(5, 3)
-            .is_identical(APyFloat(0, 5, 0b101, 5, 3))
+            .is_identical(apyfloat(0, 5, 0b101, 5, 3))
         )  # Round up
 
         # Quantization from 1.xx
         assert (
-            APyFloat(0, 5, 0b10100, 5, 5)
+            apyfloat(0, 5, 0b10100, 5, 5)
             .cast(5, 3)
-            .is_identical(APyFloat(0, 5, 0b101, 5, 3))
+            .is_identical(apyfloat(0, 5, 0b101, 5, 3))
         )  # No quantization needed
         assert (
-            APyFloat(0, 5, 0b10101, 5, 5)
+            apyfloat(0, 5, 0b10101, 5, 5)
             .cast(5, 3)
-            .is_identical(APyFloat(0, 5, 0b110, 5, 3))
+            .is_identical(apyfloat(0, 5, 0b110, 5, 3))
         )  # Round up
         assert (
-            APyFloat(0, 5, 0b10110, 5, 5)
+            apyfloat(0, 5, 0b10110, 5, 5)
             .cast(5, 3)
-            .is_identical(APyFloat(0, 5, 0b110, 5, 3))
+            .is_identical(apyfloat(0, 5, 0b110, 5, 3))
         )  # Tie break, round up
         assert (
-            APyFloat(0, 5, 0b10111, 5, 5)
+            apyfloat(0, 5, 0b10111, 5, 5)
             .cast(5, 3)
-            .is_identical(APyFloat(0, 5, 0b110, 5, 3))
+            .is_identical(apyfloat(0, 5, 0b110, 5, 3))
         )  # Round up
 
         # Quantization from 0.xx, negative sign
         assert (
-            APyFloat(1, 5, 0b10000, 5, 5)
+            apyfloat(1, 5, 0b10000, 5, 5)
             .cast(5, 3)
-            .is_identical(APyFloat(1, 5, 0b100, 5, 3))
+            .is_identical(apyfloat(1, 5, 0b100, 5, 3))
         )  # No quantization needed
         assert (
-            APyFloat(1, 5, 0b10001, 5, 5)
+            apyfloat(1, 5, 0b10001, 5, 5)
             .cast(5, 3)
-            .is_identical(APyFloat(1, 5, 0b100, 5, 3))
+            .is_identical(apyfloat(1, 5, 0b100, 5, 3))
         )  # Round down
         assert (
-            APyFloat(1, 5, 0b10010, 5, 5)
+            apyfloat(1, 5, 0b10010, 5, 5)
             .cast(5, 3)
-            .is_identical(APyFloat(1, 5, 0b100, 5, 3))
+            .is_identical(apyfloat(1, 5, 0b100, 5, 3))
         )  # Tie break, round down
         assert (
-            APyFloat(1, 5, 0b10011, 5, 5)
+            apyfloat(1, 5, 0b10011, 5, 5)
             .cast(5, 3)
-            .is_identical(APyFloat(1, 5, 0b100, 5, 3))
+            .is_identical(apyfloat(1, 5, 0b100, 5, 3))
         )  # Round down
 
         # Quantization from 1.xx, negative sign
         assert (
-            APyFloat(1, 5, 0b10100, 5, 5)
+            apyfloat(1, 5, 0b10100, 5, 5)
             .cast(5, 3)
-            .is_identical(APyFloat(1, 5, 0b101, 5, 3))
+            .is_identical(apyfloat(1, 5, 0b101, 5, 3))
         )  # No quantization needed
         assert (
-            APyFloat(1, 5, 0b10101, 5, 5)
+            apyfloat(1, 5, 0b10101, 5, 5)
             .cast(5, 3)
-            .is_identical(APyFloat(1, 5, 0b101, 5, 3))
+            .is_identical(apyfloat(1, 5, 0b101, 5, 3))
         )  # Round down
         assert (
-            APyFloat(1, 5, 0b10110, 5, 5)
+            apyfloat(1, 5, 0b10110, 5, 5)
             .cast(5, 3)
-            .is_identical(APyFloat(1, 5, 0b101, 5, 3))
+            .is_identical(apyfloat(1, 5, 0b101, 5, 3))
         )  # Tie break, round down
         assert (
-            APyFloat(1, 5, 0b10111, 5, 5)
+            apyfloat(1, 5, 0b10111, 5, 5)
             .cast(5, 3)
-            .is_identical(APyFloat(1, 5, 0b101, 5, 3))
+            .is_identical(apyfloat(1, 5, 0b101, 5, 3))
         )  # Round down
 
         # Test handling of infinities
         assert (
-            APyFloat(0, 30, 0, 5, 5).cast(4, 3).is_identical(APyFloat(0, 15, 0, 4, 3))
+            apyfloat(0, 30, 0, 5, 5).cast(4, 3).is_identical(apyfloat(0, 15, 0, 4, 3))
         )  # Should become infinity
 
         assert (
-            APyFloat(1, 30, 0, 5, 5).cast(4, 3).is_identical(APyFloat(1, 14, 7, 4, 3))
+            apyfloat(1, 30, 0, 5, 5).cast(4, 3).is_identical(apyfloat(1, 14, 7, 4, 3))
         )  # Should saturate
 
-    def test_quantization_to_neg(self):
+    @pytest.mark.parametrize("apyfloat", [APyFloat, APyCFloat])
+    def test_quantization_to_neg(self, apyfloat: type[APyCFloat]):
         apytypes.set_float_quantization_mode(QuantizationMode.TO_NEG)
         # Quantization from 0.xx
         assert (
-            APyFloat(0, 5, 0b10000, 5, 5)
+            apyfloat(0, 5, 0b10000, 5, 5)
             .cast(5, 3)
-            .is_identical(APyFloat(0, 5, 0b100, 5, 3))
+            .is_identical(apyfloat(0, 5, 0b100, 5, 3))
         )  # No quantization needed
         assert (
-            APyFloat(0, 5, 0b10001, 5, 5)
+            apyfloat(0, 5, 0b10001, 5, 5)
             .cast(5, 3)
-            .is_identical(APyFloat(0, 5, 0b100, 5, 3))
+            .is_identical(apyfloat(0, 5, 0b100, 5, 3))
         )  # Round down
         assert (
-            APyFloat(0, 5, 0b10010, 5, 5)
+            apyfloat(0, 5, 0b10010, 5, 5)
             .cast(5, 3)
-            .is_identical(APyFloat(0, 5, 0b100, 5, 3))
+            .is_identical(apyfloat(0, 5, 0b100, 5, 3))
         )  # Tie break, round down
         assert (
-            APyFloat(0, 5, 0b10011, 5, 5)
+            apyfloat(0, 5, 0b10011, 5, 5)
             .cast(5, 3)
-            .is_identical(APyFloat(0, 5, 0b100, 5, 3))
+            .is_identical(apyfloat(0, 5, 0b100, 5, 3))
         )  # Round down
 
         # Quantization from 1.xx
         assert (
-            APyFloat(0, 5, 0b10100, 5, 5)
+            apyfloat(0, 5, 0b10100, 5, 5)
             .cast(5, 3)
-            .is_identical(APyFloat(0, 5, 0b101, 5, 3))
+            .is_identical(apyfloat(0, 5, 0b101, 5, 3))
         )  # No quantization needed
         assert (
-            APyFloat(0, 5, 0b10101, 5, 5)
+            apyfloat(0, 5, 0b10101, 5, 5)
             .cast(5, 3)
-            .is_identical(APyFloat(0, 5, 0b101, 5, 3))
+            .is_identical(apyfloat(0, 5, 0b101, 5, 3))
         )  # Round down
         assert (
-            APyFloat(0, 5, 0b10110, 5, 5)
+            apyfloat(0, 5, 0b10110, 5, 5)
             .cast(5, 3)
-            .is_identical(APyFloat(0, 5, 0b101, 5, 3))
+            .is_identical(apyfloat(0, 5, 0b101, 5, 3))
         )  # Tie break, round down
         assert (
-            APyFloat(0, 5, 0b10111, 5, 5)
+            apyfloat(0, 5, 0b10111, 5, 5)
             .cast(5, 3)
-            .is_identical(APyFloat(0, 5, 0b101, 5, 3))
+            .is_identical(apyfloat(0, 5, 0b101, 5, 3))
         )  # Round down
 
         # Quantization from 0.xx, negative sign
         assert (
-            APyFloat(1, 5, 0b10000, 5, 5)
+            apyfloat(1, 5, 0b10000, 5, 5)
             .cast(5, 3)
-            .is_identical(APyFloat(1, 5, 0b100, 5, 3))
+            .is_identical(apyfloat(1, 5, 0b100, 5, 3))
         )  # No quantization needed
         assert (
-            APyFloat(1, 5, 0b10001, 5, 5)
+            apyfloat(1, 5, 0b10001, 5, 5)
             .cast(5, 3)
-            .is_identical(APyFloat(1, 5, 0b101, 5, 3))
+            .is_identical(apyfloat(1, 5, 0b101, 5, 3))
         )  # Round down
         assert (
-            APyFloat(1, 5, 0b10010, 5, 5)
+            apyfloat(1, 5, 0b10010, 5, 5)
             .cast(5, 3)
-            .is_identical(APyFloat(1, 5, 0b101, 5, 3))
+            .is_identical(apyfloat(1, 5, 0b101, 5, 3))
         )  # Tie break, round down
         assert (
-            APyFloat(1, 5, 0b10011, 5, 5)
+            apyfloat(1, 5, 0b10011, 5, 5)
             .cast(5, 3)
-            .is_identical(APyFloat(1, 5, 0b101, 5, 3))
+            .is_identical(apyfloat(1, 5, 0b101, 5, 3))
         )  # Round down
 
         # Quantization from 1.xx, negative sign
         assert (
-            APyFloat(1, 5, 0b10100, 5, 5)
+            apyfloat(1, 5, 0b10100, 5, 5)
             .cast(5, 3)
-            .is_identical(APyFloat(1, 5, 0b101, 5, 3))
+            .is_identical(apyfloat(1, 5, 0b101, 5, 3))
         )  # No quantization needed
         assert (
-            APyFloat(1, 5, 0b10101, 5, 5)
+            apyfloat(1, 5, 0b10101, 5, 5)
             .cast(5, 3)
-            .is_identical(APyFloat(1, 5, 0b110, 5, 3))
+            .is_identical(apyfloat(1, 5, 0b110, 5, 3))
         )  # Round up
         assert (
-            APyFloat(1, 5, 0b10110, 5, 5)
+            apyfloat(1, 5, 0b10110, 5, 5)
             .cast(5, 3)
-            .is_identical(APyFloat(1, 5, 0b110, 5, 3))
+            .is_identical(apyfloat(1, 5, 0b110, 5, 3))
         )  # Tie break, round up
         assert (
-            APyFloat(1, 5, 0b10111, 5, 5)
+            apyfloat(1, 5, 0b10111, 5, 5)
             .cast(5, 3)
-            .is_identical(APyFloat(1, 5, 0b110, 5, 3))
+            .is_identical(apyfloat(1, 5, 0b110, 5, 3))
         )  # Round up
 
         # Test handling of infinities
         assert (
-            APyFloat(0, 30, 0, 5, 5).cast(4, 3).is_identical(APyFloat(0, 14, 7, 4, 3))
+            apyfloat(0, 30, 0, 5, 5).cast(4, 3).is_identical(apyfloat(0, 14, 7, 4, 3))
         )  # Should saturate
 
         assert (
-            APyFloat(1, 30, 0, 5, 5).cast(4, 3).is_identical(APyFloat(1, 15, 0, 4, 3))
+            apyfloat(1, 30, 0, 5, 5).cast(4, 3).is_identical(apyfloat(1, 15, 0, 4, 3))
         )  # Should become infinity
 
-    def test_quantization_to_away(self):
+    @pytest.mark.parametrize("apyfloat", [APyFloat, APyCFloat])
+    def test_quantization_to_away(self, apyfloat: type[APyCFloat]):
         apytypes.set_float_quantization_mode(QuantizationMode.TO_AWAY)
         # Quantization from 0.xx
         assert (
-            APyFloat(0, 5, 0b10000, 5, 5)
+            apyfloat(0, 5, 0b10000, 5, 5)
             .cast(5, 3)
-            .is_identical(APyFloat(0, 5, 0b100, 5, 3))
+            .is_identical(apyfloat(0, 5, 0b100, 5, 3))
         )  # No quantization needed
         assert (
-            APyFloat(0, 5, 0b10001, 5, 5)
+            apyfloat(0, 5, 0b10001, 5, 5)
             .cast(5, 3)
-            .is_identical(APyFloat(0, 5, 0b101, 5, 3))
+            .is_identical(apyfloat(0, 5, 0b101, 5, 3))
         )  # Round up
         assert (
-            APyFloat(0, 5, 0b10010, 5, 5)
+            apyfloat(0, 5, 0b10010, 5, 5)
             .cast(5, 3)
-            .is_identical(APyFloat(0, 5, 0b101, 5, 3))
+            .is_identical(apyfloat(0, 5, 0b101, 5, 3))
         )  # Tie break, round up
         assert (
-            APyFloat(0, 5, 0b10011, 5, 5)
+            apyfloat(0, 5, 0b10011, 5, 5)
             .cast(5, 3)
-            .is_identical(APyFloat(0, 5, 0b101, 5, 3))
+            .is_identical(apyfloat(0, 5, 0b101, 5, 3))
         )  # Round up
 
         # Quantization from 1.xx
         assert (
-            APyFloat(0, 5, 0b10100, 5, 5)
+            apyfloat(0, 5, 0b10100, 5, 5)
             .cast(5, 3)
-            .is_identical(APyFloat(0, 5, 0b101, 5, 3))
+            .is_identical(apyfloat(0, 5, 0b101, 5, 3))
         )  # No quantization needed
         assert (
-            APyFloat(0, 5, 0b10101, 5, 5)
+            apyfloat(0, 5, 0b10101, 5, 5)
             .cast(5, 3)
-            .is_identical(APyFloat(0, 5, 0b110, 5, 3))
+            .is_identical(apyfloat(0, 5, 0b110, 5, 3))
         )  # Round up
         assert (
-            APyFloat(0, 5, 0b10110, 5, 5)
+            apyfloat(0, 5, 0b10110, 5, 5)
             .cast(5, 3)
-            .is_identical(APyFloat(0, 5, 0b110, 5, 3))
+            .is_identical(apyfloat(0, 5, 0b110, 5, 3))
         )  # Tie break, round up
         assert (
-            APyFloat(0, 5, 0b10111, 5, 5)
+            apyfloat(0, 5, 0b10111, 5, 5)
             .cast(5, 3)
-            .is_identical(APyFloat(0, 5, 0b110, 5, 3))
+            .is_identical(apyfloat(0, 5, 0b110, 5, 3))
         )  # Round up
 
         # Quantization from 0.xx, negative sign
         assert (
-            APyFloat(1, 5, 0b10000, 5, 5)
+            apyfloat(1, 5, 0b10000, 5, 5)
             .cast(5, 3)
-            .is_identical(APyFloat(1, 5, 0b100, 5, 3))
+            .is_identical(apyfloat(1, 5, 0b100, 5, 3))
         )  # No quantization needed
         assert (
-            APyFloat(1, 5, 0b10001, 5, 5)
+            apyfloat(1, 5, 0b10001, 5, 5)
             .cast(5, 3)
-            .is_identical(APyFloat(1, 5, 0b101, 5, 3))
+            .is_identical(apyfloat(1, 5, 0b101, 5, 3))
         )  # Round down
         assert (
-            APyFloat(1, 5, 0b10010, 5, 5)
+            apyfloat(1, 5, 0b10010, 5, 5)
             .cast(5, 3)
-            .is_identical(APyFloat(1, 5, 0b101, 5, 3))
+            .is_identical(apyfloat(1, 5, 0b101, 5, 3))
         )  # Tie break, round down
         assert (
-            APyFloat(1, 5, 0b10011, 5, 5)
+            apyfloat(1, 5, 0b10011, 5, 5)
             .cast(5, 3)
-            .is_identical(APyFloat(1, 5, 0b101, 5, 3))
+            .is_identical(apyfloat(1, 5, 0b101, 5, 3))
         )  # Round down
 
         # Quantization from 1.xx, negative sign
         assert (
-            APyFloat(1, 5, 0b10100, 5, 5)
+            apyfloat(1, 5, 0b10100, 5, 5)
             .cast(5, 3)
-            .is_identical(APyFloat(1, 5, 0b101, 5, 3))
+            .is_identical(apyfloat(1, 5, 0b101, 5, 3))
         )  # No quantization needed
         assert (
-            APyFloat(1, 5, 0b10101, 5, 5)
+            apyfloat(1, 5, 0b10101, 5, 5)
             .cast(5, 3)
-            .is_identical(APyFloat(1, 5, 0b110, 5, 3))
+            .is_identical(apyfloat(1, 5, 0b110, 5, 3))
         )  # Round down
         assert (
-            APyFloat(1, 5, 0b10110, 5, 5)
+            apyfloat(1, 5, 0b10110, 5, 5)
             .cast(5, 3)
-            .is_identical(APyFloat(1, 5, 0b110, 5, 3))
+            .is_identical(apyfloat(1, 5, 0b110, 5, 3))
         )  # Tie break, round down
         assert (
-            APyFloat(1, 5, 0b10111, 5, 5)
+            apyfloat(1, 5, 0b10111, 5, 5)
             .cast(5, 3)
-            .is_identical(APyFloat(1, 5, 0b110, 5, 3))
+            .is_identical(apyfloat(1, 5, 0b110, 5, 3))
         )  # Round down
 
         # Test handling of infinities
         assert (
-            APyFloat(0, 30, 0, 5, 5).cast(4, 3).is_identical(APyFloat(0, 15, 0, 4, 3))
+            apyfloat(0, 30, 0, 5, 5).cast(4, 3).is_identical(apyfloat(0, 15, 0, 4, 3))
         )  # Should become infinity
 
         assert (
-            APyFloat(1, 30, 0, 5, 5).cast(4, 3).is_identical(APyFloat(1, 15, 0, 4, 3))
+            apyfloat(1, 30, 0, 5, 5).cast(4, 3).is_identical(apyfloat(1, 15, 0, 4, 3))
         )  # Should become infinity
 
-    def test_quantization_to_zero(self):
+    @pytest.mark.parametrize("apyfloat", [APyFloat, APyCFloat])
+    def test_quantization_to_zero(self, apyfloat: type[APyCFloat]):
         apytypes.set_float_quantization_mode(QuantizationMode.TO_ZERO)
         # Quantization from 0.xx
         assert (
-            APyFloat(0, 5, 0b10000, 5, 5)
+            apyfloat(0, 5, 0b10000, 5, 5)
             .cast(5, 3)
-            .is_identical(APyFloat(0, 5, 0b100, 5, 3))
+            .is_identical(apyfloat(0, 5, 0b100, 5, 3))
         )  # No quantization needed
         assert (
-            APyFloat(0, 5, 0b10001, 5, 5)
+            apyfloat(0, 5, 0b10001, 5, 5)
             .cast(5, 3)
-            .is_identical(APyFloat(0, 5, 0b100, 5, 3))
+            .is_identical(apyfloat(0, 5, 0b100, 5, 3))
         )  # Round down
         assert (
-            APyFloat(0, 5, 0b10010, 5, 5)
+            apyfloat(0, 5, 0b10010, 5, 5)
             .cast(5, 3)
-            .is_identical(APyFloat(0, 5, 0b100, 5, 3))
+            .is_identical(apyfloat(0, 5, 0b100, 5, 3))
         )  # Tie break, round down
         assert (
-            APyFloat(0, 5, 0b10011, 5, 5)
+            apyfloat(0, 5, 0b10011, 5, 5)
             .cast(5, 3)
-            .is_identical(APyFloat(0, 5, 0b100, 5, 3))
+            .is_identical(apyfloat(0, 5, 0b100, 5, 3))
         )  # Round down
 
         # Quantization from 1.xx
         assert (
-            APyFloat(0, 5, 0b10100, 5, 5)
+            apyfloat(0, 5, 0b10100, 5, 5)
             .cast(5, 3)
-            .is_identical(APyFloat(0, 5, 0b101, 5, 3))
+            .is_identical(apyfloat(0, 5, 0b101, 5, 3))
         )  # No quantization needed
         assert (
-            APyFloat(0, 5, 0b10101, 5, 5)
+            apyfloat(0, 5, 0b10101, 5, 5)
             .cast(5, 3)
-            .is_identical(APyFloat(0, 5, 0b101, 5, 3))
+            .is_identical(apyfloat(0, 5, 0b101, 5, 3))
         )  # Round down
         assert (
-            APyFloat(0, 5, 0b10110, 5, 5)
+            apyfloat(0, 5, 0b10110, 5, 5)
             .cast(5, 3)
-            .is_identical(APyFloat(0, 5, 0b101, 5, 3))
+            .is_identical(apyfloat(0, 5, 0b101, 5, 3))
         )  # Tie break, round down
         assert (
-            APyFloat(0, 5, 0b10111, 5, 5)
+            apyfloat(0, 5, 0b10111, 5, 5)
             .cast(5, 3)
-            .is_identical(APyFloat(0, 5, 0b101, 5, 3))
+            .is_identical(apyfloat(0, 5, 0b101, 5, 3))
         )  # Round down
 
         # Quantization from 0.xx, negative sign
         assert (
-            APyFloat(1, 5, 0b10000, 5, 5)
+            apyfloat(1, 5, 0b10000, 5, 5)
             .cast(5, 3)
-            .is_identical(APyFloat(1, 5, 0b100, 5, 3))
+            .is_identical(apyfloat(1, 5, 0b100, 5, 3))
         )  # No quantization needed
         assert (
-            APyFloat(1, 5, 0b10001, 5, 5)
+            apyfloat(1, 5, 0b10001, 5, 5)
             .cast(5, 3)
-            .is_identical(APyFloat(1, 5, 0b100, 5, 3))
+            .is_identical(apyfloat(1, 5, 0b100, 5, 3))
         )  # Round down
         assert (
-            APyFloat(1, 5, 0b10010, 5, 5)
+            apyfloat(1, 5, 0b10010, 5, 5)
             .cast(5, 3)
-            .is_identical(APyFloat(1, 5, 0b100, 5, 3))
+            .is_identical(apyfloat(1, 5, 0b100, 5, 3))
         )  # Tie break, round down
         assert (
-            APyFloat(1, 5, 0b10011, 5, 5)
+            apyfloat(1, 5, 0b10011, 5, 5)
             .cast(5, 3)
-            .is_identical(APyFloat(1, 5, 0b100, 5, 3))
+            .is_identical(apyfloat(1, 5, 0b100, 5, 3))
         )  # Round down
 
         # Quantization from 1.xx, negative sign
         assert (
-            APyFloat(1, 5, 0b10100, 5, 5)
+            apyfloat(1, 5, 0b10100, 5, 5)
             .cast(5, 3)
-            .is_identical(APyFloat(1, 5, 0b101, 5, 3))
+            .is_identical(apyfloat(1, 5, 0b101, 5, 3))
         )  # No quantization needed
         assert (
-            APyFloat(1, 5, 0b10101, 5, 5)
+            apyfloat(1, 5, 0b10101, 5, 5)
             .cast(5, 3)
-            .is_identical(APyFloat(1, 5, 0b101, 5, 3))
+            .is_identical(apyfloat(1, 5, 0b101, 5, 3))
         )  # Round down
         assert (
-            APyFloat(1, 5, 0b10110, 5, 5)
+            apyfloat(1, 5, 0b10110, 5, 5)
             .cast(5, 3)
-            .is_identical(APyFloat(1, 5, 0b101, 5, 3))
+            .is_identical(apyfloat(1, 5, 0b101, 5, 3))
         )  # Tie break, round down
         assert (
-            APyFloat(1, 5, 0b10111, 5, 5)
+            apyfloat(1, 5, 0b10111, 5, 5)
             .cast(5, 3)
-            .is_identical(APyFloat(1, 5, 0b101, 5, 3))
+            .is_identical(apyfloat(1, 5, 0b101, 5, 3))
         )  # Round down
 
         # Test handling of infinities
         assert (
-            APyFloat(0, 30, 0, 5, 5).cast(4, 3).is_identical(APyFloat(0, 14, 7, 4, 3))
+            apyfloat(0, 30, 0, 5, 5).cast(4, 3).is_identical(apyfloat(0, 14, 7, 4, 3))
         )  # Should saturate
 
         assert (
-            APyFloat(1, 30, 0, 5, 5).cast(4, 3).is_identical(APyFloat(1, 14, 7, 4, 3))
+            apyfloat(1, 30, 0, 5, 5).cast(4, 3).is_identical(apyfloat(1, 14, 7, 4, 3))
         )  # Should saturate
 
-    def test_quantization_ties_even(self):
+    @pytest.mark.parametrize("apyfloat", [APyFloat, APyCFloat])
+    def test_quantization_ties_even(self, apyfloat: type[APyCFloat]):
         apytypes.set_float_quantization_mode(QuantizationMode.TIES_EVEN)
         # Quantization from 0.xx
         assert (
-            APyFloat(0, 5, 0b10000, 5, 5)
+            apyfloat(0, 5, 0b10000, 5, 5)
             .cast(5, 3)
-            .is_identical(APyFloat(0, 5, 0b100, 5, 3))
+            .is_identical(apyfloat(0, 5, 0b100, 5, 3))
         )  # No quantization needed
         assert (
-            APyFloat(0, 5, 0b10001, 5, 5)
+            apyfloat(0, 5, 0b10001, 5, 5)
             .cast(5, 3)
-            .is_identical(APyFloat(0, 5, 0b100, 5, 3))
+            .is_identical(apyfloat(0, 5, 0b100, 5, 3))
         )  # Round down
         assert (
-            APyFloat(0, 5, 0b10010, 5, 5)
+            apyfloat(0, 5, 0b10010, 5, 5)
             .cast(5, 3)
-            .is_identical(APyFloat(0, 5, 0b100, 5, 3))
+            .is_identical(apyfloat(0, 5, 0b100, 5, 3))
         )  # Tie break, round down
         assert (
-            APyFloat(0, 5, 0b10011, 5, 5)
+            apyfloat(0, 5, 0b10011, 5, 5)
             .cast(5, 3)
-            .is_identical(APyFloat(0, 5, 0b101, 5, 3))
+            .is_identical(apyfloat(0, 5, 0b101, 5, 3))
         )  # Round up
 
         # Quantization from 1.xx
         assert (
-            APyFloat(0, 5, 0b10100, 5, 5)
+            apyfloat(0, 5, 0b10100, 5, 5)
             .cast(5, 3)
-            .is_identical(APyFloat(0, 5, 0b101, 5, 3))
+            .is_identical(apyfloat(0, 5, 0b101, 5, 3))
         )  # No quantization needed
         assert (
-            APyFloat(0, 5, 0b10101, 5, 5)
+            apyfloat(0, 5, 0b10101, 5, 5)
             .cast(5, 3)
-            .is_identical(APyFloat(0, 5, 0b101, 5, 3))
+            .is_identical(apyfloat(0, 5, 0b101, 5, 3))
         )  # Round down
         assert (
-            APyFloat(0, 5, 0b10110, 5, 5)
+            apyfloat(0, 5, 0b10110, 5, 5)
             .cast(5, 3)
-            .is_identical(APyFloat(0, 5, 0b110, 5, 3))
+            .is_identical(apyfloat(0, 5, 0b110, 5, 3))
         )  # Tie break, round up
         assert (
-            APyFloat(0, 5, 0b10111, 5, 5)
+            apyfloat(0, 5, 0b10111, 5, 5)
             .cast(5, 3)
-            .is_identical(APyFloat(0, 5, 0b110, 5, 3))
+            .is_identical(apyfloat(0, 5, 0b110, 5, 3))
         )  # Round up
 
         # Quantization from 0.xx, negative sign
         assert (
-            APyFloat(1, 5, 0b10000, 5, 5)
+            apyfloat(1, 5, 0b10000, 5, 5)
             .cast(5, 3)
-            .is_identical(APyFloat(1, 5, 0b100, 5, 3))
+            .is_identical(apyfloat(1, 5, 0b100, 5, 3))
         )  # No quantization needed
         assert (
-            APyFloat(1, 5, 0b10001, 5, 5)
+            apyfloat(1, 5, 0b10001, 5, 5)
             .cast(5, 3)
-            .is_identical(APyFloat(1, 5, 0b100, 5, 3))
+            .is_identical(apyfloat(1, 5, 0b100, 5, 3))
         )  # Round down
         assert (
-            APyFloat(1, 5, 0b10010, 5, 5)
+            apyfloat(1, 5, 0b10010, 5, 5)
             .cast(5, 3)
-            .is_identical(APyFloat(1, 5, 0b100, 5, 3))
+            .is_identical(apyfloat(1, 5, 0b100, 5, 3))
         )  # Tie break, round down
         assert (
-            APyFloat(1, 5, 0b10011, 5, 5)
+            apyfloat(1, 5, 0b10011, 5, 5)
             .cast(5, 3)
-            .is_identical(APyFloat(1, 5, 0b101, 5, 3))
+            .is_identical(apyfloat(1, 5, 0b101, 5, 3))
         )  # Round up
 
         # Quantization from 1.xx, negative sign
         assert (
-            APyFloat(1, 5, 0b10100, 5, 5)
+            apyfloat(1, 5, 0b10100, 5, 5)
             .cast(5, 3)
-            .is_identical(APyFloat(1, 5, 0b101, 5, 3))
+            .is_identical(apyfloat(1, 5, 0b101, 5, 3))
         )  # No quantization needed
         assert (
-            APyFloat(1, 5, 0b10101, 5, 5)
+            apyfloat(1, 5, 0b10101, 5, 5)
             .cast(5, 3)
-            .is_identical(APyFloat(1, 5, 0b101, 5, 3))
+            .is_identical(apyfloat(1, 5, 0b101, 5, 3))
         )  # Round down
         assert (
-            APyFloat(1, 5, 0b10110, 5, 5)
+            apyfloat(1, 5, 0b10110, 5, 5)
             .cast(5, 3)
-            .is_identical(APyFloat(1, 5, 0b110, 5, 3))
+            .is_identical(apyfloat(1, 5, 0b110, 5, 3))
         )  # Tie break, round up
         assert (
-            APyFloat(1, 5, 0b10111, 5, 5)
+            apyfloat(1, 5, 0b10111, 5, 5)
             .cast(5, 3)
-            .is_identical(APyFloat(1, 5, 0b110, 5, 3))
+            .is_identical(apyfloat(1, 5, 0b110, 5, 3))
         )  # Round up
 
         # Test handling of infinities
         assert (
-            APyFloat(0, 30, 0, 5, 5).cast(4, 3).is_identical(APyFloat(0, 15, 0, 4, 3))
+            apyfloat(0, 30, 0, 5, 5).cast(4, 3).is_identical(apyfloat(0, 15, 0, 4, 3))
         )  # Should become infinity
 
         assert (
-            APyFloat(1, 30, 0, 5, 5).cast(4, 3).is_identical(APyFloat(1, 15, 0, 4, 3))
+            apyfloat(1, 30, 0, 5, 5).cast(4, 3).is_identical(apyfloat(1, 15, 0, 4, 3))
         )  # Should become infinity
 
         # From https://github.com/apytypes/apytypes/issues/406
-        res = APyFloat(sign=0, exp=103, man=0, exp_bits=8, man_bits=23).cast(5, 10)
-        assert res.is_identical(APyFloat(sign=0, exp=0, man=1, exp_bits=5, man_bits=10))
+        res = apyfloat(sign=0, exp=103, man=0, exp_bits=8, man_bits=23).cast(5, 10)
+        assert res.is_identical(apyfloat(sign=0, exp=0, man=1, exp_bits=5, man_bits=10))
 
-        res = APyFloat(sign=0, exp=103, man=1, exp_bits=8, man_bits=23).cast(5, 10)
-        assert res.is_identical(APyFloat(sign=0, exp=0, man=1, exp_bits=5, man_bits=10))
+        res = apyfloat(sign=0, exp=103, man=1, exp_bits=8, man_bits=23).cast(5, 10)
+        assert res.is_identical(apyfloat(sign=0, exp=0, man=1, exp_bits=5, man_bits=10))
 
-    def test_quantization_ties_odd(self):
+    @pytest.mark.parametrize("apyfloat", [APyFloat, APyCFloat])
+    def test_quantization_ties_odd(self, apyfloat: type[APyCFloat]):
         apytypes.set_float_quantization_mode(QuantizationMode.TIES_ODD)
         # Quantization from 0.xx
         assert (
-            APyFloat(0, 5, 0b10000, 5, 5)
+            apyfloat(0, 5, 0b10000, 5, 5)
             .cast(5, 3)
-            .is_identical(APyFloat(0, 5, 0b100, 5, 3))
+            .is_identical(apyfloat(0, 5, 0b100, 5, 3))
         )  # No quantization needed
         assert (
-            APyFloat(0, 5, 0b10001, 5, 5)
+            apyfloat(0, 5, 0b10001, 5, 5)
             .cast(5, 3)
-            .is_identical(APyFloat(0, 5, 0b100, 5, 3))
+            .is_identical(apyfloat(0, 5, 0b100, 5, 3))
         )  # Round down
         assert (
-            APyFloat(0, 5, 0b10010, 5, 5)
+            apyfloat(0, 5, 0b10010, 5, 5)
             .cast(5, 3)
-            .is_identical(APyFloat(0, 5, 0b101, 5, 3))
+            .is_identical(apyfloat(0, 5, 0b101, 5, 3))
         )  # Tie break, round up
         assert (
-            APyFloat(0, 5, 0b10011, 5, 5)
+            apyfloat(0, 5, 0b10011, 5, 5)
             .cast(5, 3)
-            .is_identical(APyFloat(0, 5, 0b101, 5, 3))
+            .is_identical(apyfloat(0, 5, 0b101, 5, 3))
         )  # Round up
 
         # Quantization from 1.xx
         assert (
-            APyFloat(0, 5, 0b10100, 5, 5)
+            apyfloat(0, 5, 0b10100, 5, 5)
             .cast(5, 3)
-            .is_identical(APyFloat(0, 5, 0b101, 5, 3))
+            .is_identical(apyfloat(0, 5, 0b101, 5, 3))
         )  # No quantization needed
         assert (
-            APyFloat(0, 5, 0b10101, 5, 5)
+            apyfloat(0, 5, 0b10101, 5, 5)
             .cast(5, 3)
-            .is_identical(APyFloat(0, 5, 0b101, 5, 3))
+            .is_identical(apyfloat(0, 5, 0b101, 5, 3))
         )  # Round down
         assert (
-            APyFloat(0, 5, 0b10110, 5, 5)
+            apyfloat(0, 5, 0b10110, 5, 5)
             .cast(5, 3)
-            .is_identical(APyFloat(0, 5, 0b101, 5, 3))
+            .is_identical(apyfloat(0, 5, 0b101, 5, 3))
         )  # Tie break, round down
         assert (
-            APyFloat(0, 5, 0b10111, 5, 5)
+            apyfloat(0, 5, 0b10111, 5, 5)
             .cast(5, 3)
-            .is_identical(APyFloat(0, 5, 0b110, 5, 3))
+            .is_identical(apyfloat(0, 5, 0b110, 5, 3))
         )  # Round up
 
         # Quantization from 0.xx, negative sign
         assert (
-            APyFloat(1, 5, 0b10000, 5, 5)
+            apyfloat(1, 5, 0b10000, 5, 5)
             .cast(5, 3)
-            .is_identical(APyFloat(1, 5, 0b100, 5, 3))
+            .is_identical(apyfloat(1, 5, 0b100, 5, 3))
         )  # No quantization needed
         assert (
-            APyFloat(1, 5, 0b10001, 5, 5)
+            apyfloat(1, 5, 0b10001, 5, 5)
             .cast(5, 3)
-            .is_identical(APyFloat(1, 5, 0b100, 5, 3))
+            .is_identical(apyfloat(1, 5, 0b100, 5, 3))
         )  # Round down
         assert (
-            APyFloat(1, 5, 0b10010, 5, 5)
+            apyfloat(1, 5, 0b10010, 5, 5)
             .cast(5, 3)
-            .is_identical(APyFloat(1, 5, 0b101, 5, 3))
+            .is_identical(apyfloat(1, 5, 0b101, 5, 3))
         )  # Tie break, round down
         assert (
-            APyFloat(1, 5, 0b10011, 5, 5)
+            apyfloat(1, 5, 0b10011, 5, 5)
             .cast(5, 3)
-            .is_identical(APyFloat(1, 5, 0b101, 5, 3))
+            .is_identical(apyfloat(1, 5, 0b101, 5, 3))
         )  # Round up
 
         # Quantization from 1.xx, negative sign
         assert (
-            APyFloat(1, 5, 0b10100, 5, 5)
+            apyfloat(1, 5, 0b10100, 5, 5)
             .cast(5, 3)
-            .is_identical(APyFloat(1, 5, 0b101, 5, 3))
+            .is_identical(apyfloat(1, 5, 0b101, 5, 3))
         )  # No quantization needed
         assert (
-            APyFloat(1, 5, 0b10101, 5, 5)
+            apyfloat(1, 5, 0b10101, 5, 5)
             .cast(5, 3)
-            .is_identical(APyFloat(1, 5, 0b101, 5, 3))
+            .is_identical(apyfloat(1, 5, 0b101, 5, 3))
         )  # Round down
         assert (
-            APyFloat(1, 5, 0b10110, 5, 5)
+            apyfloat(1, 5, 0b10110, 5, 5)
             .cast(5, 3)
-            .is_identical(APyFloat(1, 5, 0b101, 5, 3))
+            .is_identical(apyfloat(1, 5, 0b101, 5, 3))
         )  # Tie break, round down
         assert (
-            APyFloat(1, 5, 0b10111, 5, 5)
+            apyfloat(1, 5, 0b10111, 5, 5)
             .cast(5, 3)
-            .is_identical(APyFloat(1, 5, 0b110, 5, 3))
+            .is_identical(apyfloat(1, 5, 0b110, 5, 3))
         )  # Round up
 
         # Test handling of infinities
         assert (
-            APyFloat(0, 30, 0, 5, 5).cast(4, 3).is_identical(APyFloat(0, 15, 0, 4, 3))
+            apyfloat(0, 30, 0, 5, 5).cast(4, 3).is_identical(apyfloat(0, 15, 0, 4, 3))
         )  # Should become infinity
 
         assert (
-            APyFloat(1, 30, 0, 5, 5).cast(4, 3).is_identical(APyFloat(1, 15, 0, 4, 3))
+            apyfloat(1, 30, 0, 5, 5).cast(4, 3).is_identical(apyfloat(1, 15, 0, 4, 3))
         )  # Should become infinity
 
-    def test_quantization_ties_pos(self):
+    @pytest.mark.parametrize("apyfloat", [APyFloat, APyCFloat])
+    def test_quantization_ties_pos(self, apyfloat: type[APyCFloat]):
         apytypes.set_float_quantization_mode(QuantizationMode.TIES_POS)
         # Quantization from 0.xx
         assert (
-            APyFloat(0, 5, 0b10000, 5, 5)
+            apyfloat(0, 5, 0b10000, 5, 5)
             .cast(5, 3)
-            .is_identical(APyFloat(0, 5, 0b100, 5, 3))
+            .is_identical(apyfloat(0, 5, 0b100, 5, 3))
         )  # No quantization needed
         assert (
-            APyFloat(0, 5, 0b10001, 5, 5)
+            apyfloat(0, 5, 0b10001, 5, 5)
             .cast(5, 3)
-            .is_identical(APyFloat(0, 5, 0b100, 5, 3))
+            .is_identical(apyfloat(0, 5, 0b100, 5, 3))
         )  # Round down
         assert (
-            APyFloat(0, 5, 0b10010, 5, 5)
+            apyfloat(0, 5, 0b10010, 5, 5)
             .cast(5, 3)
-            .is_identical(APyFloat(0, 5, 0b101, 5, 3))
+            .is_identical(apyfloat(0, 5, 0b101, 5, 3))
         )  # Tie break, round up
         assert (
-            APyFloat(0, 5, 0b10011, 5, 5)
+            apyfloat(0, 5, 0b10011, 5, 5)
             .cast(5, 3)
-            .is_identical(APyFloat(0, 5, 0b101, 5, 3))
+            .is_identical(apyfloat(0, 5, 0b101, 5, 3))
         )  # Round up
 
         # Quantization from 1.xx
         assert (
-            APyFloat(0, 5, 0b10100, 5, 5)
+            apyfloat(0, 5, 0b10100, 5, 5)
             .cast(5, 3)
-            .is_identical(APyFloat(0, 5, 0b101, 5, 3))
+            .is_identical(apyfloat(0, 5, 0b101, 5, 3))
         )  # No quantization needed
         assert (
-            APyFloat(0, 5, 0b10101, 5, 5)
+            apyfloat(0, 5, 0b10101, 5, 5)
             .cast(5, 3)
-            .is_identical(APyFloat(0, 5, 0b101, 5, 3))
+            .is_identical(apyfloat(0, 5, 0b101, 5, 3))
         )  # Round down
         assert (
-            APyFloat(0, 5, 0b10110, 5, 5)
+            apyfloat(0, 5, 0b10110, 5, 5)
             .cast(5, 3)
-            .is_identical(APyFloat(0, 5, 0b110, 5, 3))
+            .is_identical(apyfloat(0, 5, 0b110, 5, 3))
         )  # Tie break, round up
         assert (
-            APyFloat(0, 5, 0b10111, 5, 5)
+            apyfloat(0, 5, 0b10111, 5, 5)
             .cast(5, 3)
-            .is_identical(APyFloat(0, 5, 0b110, 5, 3))
+            .is_identical(apyfloat(0, 5, 0b110, 5, 3))
         )  # Round up
 
         # Quantization from 0.xx, negative sign
         assert (
-            APyFloat(1, 5, 0b10000, 5, 5)
+            apyfloat(1, 5, 0b10000, 5, 5)
             .cast(5, 3)
-            .is_identical(APyFloat(1, 5, 0b100, 5, 3))
+            .is_identical(apyfloat(1, 5, 0b100, 5, 3))
         )  # No quantization needed
         assert (
-            APyFloat(1, 5, 0b10001, 5, 5)
+            apyfloat(1, 5, 0b10001, 5, 5)
             .cast(5, 3)
-            .is_identical(APyFloat(1, 5, 0b100, 5, 3))
+            .is_identical(apyfloat(1, 5, 0b100, 5, 3))
         )  # Round down
         assert (
-            APyFloat(1, 5, 0b10010, 5, 5)
+            apyfloat(1, 5, 0b10010, 5, 5)
             .cast(5, 3)
-            .is_identical(APyFloat(1, 5, 0b100, 5, 3))
+            .is_identical(apyfloat(1, 5, 0b100, 5, 3))
         )  # Tie break, round up
         assert (
-            APyFloat(1, 5, 0b10011, 5, 5)
+            apyfloat(1, 5, 0b10011, 5, 5)
             .cast(5, 3)
-            .is_identical(APyFloat(1, 5, 0b101, 5, 3))
+            .is_identical(apyfloat(1, 5, 0b101, 5, 3))
         )  # Round up
 
         # Quantization from 1.xx, negative sign
         assert (
-            APyFloat(1, 5, 0b10100, 5, 5)
+            apyfloat(1, 5, 0b10100, 5, 5)
             .cast(5, 3)
-            .is_identical(APyFloat(1, 5, 0b101, 5, 3))
+            .is_identical(apyfloat(1, 5, 0b101, 5, 3))
         )  # No quantization needed
         assert (
-            APyFloat(1, 5, 0b10101, 5, 5)
+            apyfloat(1, 5, 0b10101, 5, 5)
             .cast(5, 3)
-            .is_identical(APyFloat(1, 5, 0b101, 5, 3))
+            .is_identical(apyfloat(1, 5, 0b101, 5, 3))
         )  # Round down
         assert (
-            APyFloat(1, 5, 0b10110, 5, 5)
+            apyfloat(1, 5, 0b10110, 5, 5)
             .cast(5, 3)
-            .is_identical(APyFloat(1, 5, 0b101, 5, 3))
+            .is_identical(apyfloat(1, 5, 0b101, 5, 3))
         )  # Tie break, round down
         assert (
-            APyFloat(1, 5, 0b10111, 5, 5)
+            apyfloat(1, 5, 0b10111, 5, 5)
             .cast(5, 3)
-            .is_identical(APyFloat(1, 5, 0b110, 5, 3))
+            .is_identical(apyfloat(1, 5, 0b110, 5, 3))
         )  # Round up
 
         # Test handling of infinities
         assert (
-            APyFloat(0, 30, 0, 5, 5).cast(4, 3).is_identical(APyFloat(0, 15, 0, 4, 3))
+            apyfloat(0, 30, 0, 5, 5).cast(4, 3).is_identical(apyfloat(0, 15, 0, 4, 3))
         )  # Should become infinity
 
         assert (
-            APyFloat(1, 30, 0, 5, 5).cast(4, 3).is_identical(APyFloat(1, 15, 0, 4, 3))
+            apyfloat(1, 30, 0, 5, 5).cast(4, 3).is_identical(apyfloat(1, 15, 0, 4, 3))
         )  # Should become infinity
 
-    def test_quantization_ties_neg(self):
+    @pytest.mark.parametrize("apyfloat", [APyFloat, APyCFloat])
+    def test_quantization_ties_neg(self, apyfloat: type[APyCFloat]):
         apytypes.set_float_quantization_mode(QuantizationMode.TIES_NEG)
         # Quantization from 0.xx
         assert (
-            APyFloat(0, 5, 0b10000, 5, 5)
+            apyfloat(0, 5, 0b10000, 5, 5)
             .cast(5, 3)
-            .is_identical(APyFloat(0, 5, 0b100, 5, 3))
+            .is_identical(apyfloat(0, 5, 0b100, 5, 3))
         )  # No quantization needed
         assert (
-            APyFloat(0, 5, 0b10001, 5, 5)
+            apyfloat(0, 5, 0b10001, 5, 5)
             .cast(5, 3)
-            .is_identical(APyFloat(0, 5, 0b100, 5, 3))
+            .is_identical(apyfloat(0, 5, 0b100, 5, 3))
         )  # Round down
         assert (
-            APyFloat(0, 5, 0b10010, 5, 5)
+            apyfloat(0, 5, 0b10010, 5, 5)
             .cast(5, 3)
-            .is_identical(APyFloat(0, 5, 0b100, 5, 3))
+            .is_identical(apyfloat(0, 5, 0b100, 5, 3))
         )  # Tie break, round down
         assert (
-            APyFloat(0, 5, 0b10011, 5, 5)
+            apyfloat(0, 5, 0b10011, 5, 5)
             .cast(5, 3)
-            .is_identical(APyFloat(0, 5, 0b101, 5, 3))
+            .is_identical(apyfloat(0, 5, 0b101, 5, 3))
         )  # Round up
 
         # Quantization from 1.xx
         assert (
-            APyFloat(0, 5, 0b10100, 5, 5)
+            apyfloat(0, 5, 0b10100, 5, 5)
             .cast(5, 3)
-            .is_identical(APyFloat(0, 5, 0b101, 5, 3))
+            .is_identical(apyfloat(0, 5, 0b101, 5, 3))
         )  # No quantization needed
         assert (
-            APyFloat(0, 5, 0b10101, 5, 5)
+            apyfloat(0, 5, 0b10101, 5, 5)
             .cast(5, 3)
-            .is_identical(APyFloat(0, 5, 0b101, 5, 3))
+            .is_identical(apyfloat(0, 5, 0b101, 5, 3))
         )  # Round down
         assert (
-            APyFloat(0, 5, 0b10110, 5, 5)
+            apyfloat(0, 5, 0b10110, 5, 5)
             .cast(5, 3)
-            .is_identical(APyFloat(0, 5, 0b101, 5, 3))
+            .is_identical(apyfloat(0, 5, 0b101, 5, 3))
         )  # Tie break, round down
         assert (
-            APyFloat(0, 5, 0b10111, 5, 5)
+            apyfloat(0, 5, 0b10111, 5, 5)
             .cast(5, 3)
-            .is_identical(APyFloat(0, 5, 0b110, 5, 3))
+            .is_identical(apyfloat(0, 5, 0b110, 5, 3))
         )  # Round up
 
         # Quantization from 0.xx, negative sign
         assert (
-            APyFloat(1, 5, 0b10000, 5, 5)
+            apyfloat(1, 5, 0b10000, 5, 5)
             .cast(5, 3)
-            .is_identical(APyFloat(1, 5, 0b100, 5, 3))
+            .is_identical(apyfloat(1, 5, 0b100, 5, 3))
         )  # No quantization needed
         assert (
-            APyFloat(1, 5, 0b10001, 5, 5)
+            apyfloat(1, 5, 0b10001, 5, 5)
             .cast(5, 3)
-            .is_identical(APyFloat(1, 5, 0b100, 5, 3))
+            .is_identical(apyfloat(1, 5, 0b100, 5, 3))
         )  # Round down
         assert (
-            APyFloat(1, 5, 0b10010, 5, 5)
+            apyfloat(1, 5, 0b10010, 5, 5)
             .cast(5, 3)
-            .is_identical(APyFloat(1, 5, 0b101, 5, 3))
+            .is_identical(apyfloat(1, 5, 0b101, 5, 3))
         )  # Tie break, round down
         assert (
-            APyFloat(1, 5, 0b10011, 5, 5)
+            apyfloat(1, 5, 0b10011, 5, 5)
             .cast(5, 3)
-            .is_identical(APyFloat(1, 5, 0b101, 5, 3))
+            .is_identical(apyfloat(1, 5, 0b101, 5, 3))
         )  # Round up
 
         # Quantization from 1.xx, negative sign
         assert (
-            APyFloat(1, 5, 0b10100, 5, 5)
+            apyfloat(1, 5, 0b10100, 5, 5)
             .cast(5, 3)
-            .is_identical(APyFloat(1, 5, 0b101, 5, 3))
+            .is_identical(apyfloat(1, 5, 0b101, 5, 3))
         )  # No quantization needed
         assert (
-            APyFloat(1, 5, 0b10101, 5, 5)
+            apyfloat(1, 5, 0b10101, 5, 5)
             .cast(5, 3)
-            .is_identical(APyFloat(1, 5, 0b101, 5, 3))
+            .is_identical(apyfloat(1, 5, 0b101, 5, 3))
         )  # Round down
         assert (
-            APyFloat(1, 5, 0b10110, 5, 5)
+            apyfloat(1, 5, 0b10110, 5, 5)
             .cast(5, 3)
-            .is_identical(APyFloat(1, 5, 0b110, 5, 3))
+            .is_identical(apyfloat(1, 5, 0b110, 5, 3))
         )  # Tie break, round down
         assert (
-            APyFloat(1, 5, 0b10111, 5, 5)
+            apyfloat(1, 5, 0b10111, 5, 5)
             .cast(5, 3)
-            .is_identical(APyFloat(1, 5, 0b110, 5, 3))
+            .is_identical(apyfloat(1, 5, 0b110, 5, 3))
         )  # Round up
 
         # Test handling of infinities
         assert (
-            APyFloat(0, 30, 0, 5, 5).cast(4, 3).is_identical(APyFloat(0, 15, 0, 4, 3))
+            apyfloat(0, 30, 0, 5, 5).cast(4, 3).is_identical(apyfloat(0, 15, 0, 4, 3))
         )  # Should become infinity
 
         assert (
-            APyFloat(1, 30, 0, 5, 5).cast(4, 3).is_identical(APyFloat(1, 15, 0, 4, 3))
+            apyfloat(1, 30, 0, 5, 5).cast(4, 3).is_identical(apyfloat(1, 15, 0, 4, 3))
         )  # Should become infinity
 
-    def test_quantization_ties_away(self):
+    @pytest.mark.parametrize("apyfloat", [APyFloat, APyCFloat])
+    def test_quantization_ties_away(self, apyfloat: type[APyCFloat]):
         apytypes.set_float_quantization_mode(QuantizationMode.TIES_AWAY)
         # Quantization from 0.xx
         assert (
-            APyFloat(0, 5, 0b10000, 5, 5)
+            apyfloat(0, 5, 0b10000, 5, 5)
             .cast(5, 3)
-            .is_identical(APyFloat(0, 5, 0b100, 5, 3))
+            .is_identical(apyfloat(0, 5, 0b100, 5, 3))
         )  # No quantization needed
         assert (
-            APyFloat(0, 5, 0b10001, 5, 5)
+            apyfloat(0, 5, 0b10001, 5, 5)
             .cast(5, 3)
-            .is_identical(APyFloat(0, 5, 0b100, 5, 3))
+            .is_identical(apyfloat(0, 5, 0b100, 5, 3))
         )  # Round down
         assert (
-            APyFloat(0, 5, 0b10010, 5, 5)
+            apyfloat(0, 5, 0b10010, 5, 5)
             .cast(5, 3)
-            .is_identical(APyFloat(0, 5, 0b101, 5, 3))
+            .is_identical(apyfloat(0, 5, 0b101, 5, 3))
         )  # Tie break, round up
         assert (
-            APyFloat(0, 5, 0b10011, 5, 5)
+            apyfloat(0, 5, 0b10011, 5, 5)
             .cast(5, 3)
-            .is_identical(APyFloat(0, 5, 0b101, 5, 3))
+            .is_identical(apyfloat(0, 5, 0b101, 5, 3))
         )  # Round up
 
         # Quantization from 1.xx
         assert (
-            APyFloat(0, 5, 0b10100, 5, 5)
+            apyfloat(0, 5, 0b10100, 5, 5)
             .cast(5, 3)
-            .is_identical(APyFloat(0, 5, 0b101, 5, 3))
+            .is_identical(apyfloat(0, 5, 0b101, 5, 3))
         )  # No quantization needed
         assert (
-            APyFloat(0, 5, 0b10101, 5, 5)
+            apyfloat(0, 5, 0b10101, 5, 5)
             .cast(5, 3)
-            .is_identical(APyFloat(0, 5, 0b101, 5, 3))
+            .is_identical(apyfloat(0, 5, 0b101, 5, 3))
         )  # Round down
         assert (
-            APyFloat(0, 5, 0b10110, 5, 5)
+            apyfloat(0, 5, 0b10110, 5, 5)
             .cast(5, 3)
-            .is_identical(APyFloat(0, 5, 0b110, 5, 3))
+            .is_identical(apyfloat(0, 5, 0b110, 5, 3))
         )  # Tie break, round up
         assert (
-            APyFloat(0, 5, 0b10111, 5, 5)
+            apyfloat(0, 5, 0b10111, 5, 5)
             .cast(5, 3)
-            .is_identical(APyFloat(0, 5, 0b110, 5, 3))
+            .is_identical(apyfloat(0, 5, 0b110, 5, 3))
         )  # Round up
 
         # Quantization from 0.xx, negative sign
         assert (
-            APyFloat(1, 5, 0b10000, 5, 5)
+            apyfloat(1, 5, 0b10000, 5, 5)
             .cast(5, 3)
-            .is_identical(APyFloat(1, 5, 0b100, 5, 3))
+            .is_identical(apyfloat(1, 5, 0b100, 5, 3))
         )  # No quantization needed
         assert (
-            APyFloat(1, 5, 0b10001, 5, 5)
+            apyfloat(1, 5, 0b10001, 5, 5)
             .cast(5, 3)
-            .is_identical(APyFloat(1, 5, 0b100, 5, 3))
+            .is_identical(apyfloat(1, 5, 0b100, 5, 3))
         )  # Round down
         assert (
-            APyFloat(1, 5, 0b10010, 5, 5)
+            apyfloat(1, 5, 0b10010, 5, 5)
             .cast(5, 3)
-            .is_identical(APyFloat(1, 5, 0b101, 5, 3))
+            .is_identical(apyfloat(1, 5, 0b101, 5, 3))
         )  # Tie break, round up
         assert (
-            APyFloat(1, 5, 0b10011, 5, 5)
+            apyfloat(1, 5, 0b10011, 5, 5)
             .cast(5, 3)
-            .is_identical(APyFloat(1, 5, 0b101, 5, 3))
+            .is_identical(apyfloat(1, 5, 0b101, 5, 3))
         )  # Round up
 
         # Quantization from 1.xx, negative sign
         assert (
-            APyFloat(1, 5, 0b10100, 5, 5)
+            apyfloat(1, 5, 0b10100, 5, 5)
             .cast(5, 3)
-            .is_identical(APyFloat(1, 5, 0b101, 5, 3))
+            .is_identical(apyfloat(1, 5, 0b101, 5, 3))
         )  # No quantization needed
         assert (
-            APyFloat(1, 5, 0b10101, 5, 5)
+            apyfloat(1, 5, 0b10101, 5, 5)
             .cast(5, 3)
-            .is_identical(APyFloat(1, 5, 0b101, 5, 3))
+            .is_identical(apyfloat(1, 5, 0b101, 5, 3))
         )  # Round down
         assert (
-            APyFloat(1, 5, 0b10110, 5, 5)
+            apyfloat(1, 5, 0b10110, 5, 5)
             .cast(5, 3)
-            .is_identical(APyFloat(1, 5, 0b110, 5, 3))
+            .is_identical(apyfloat(1, 5, 0b110, 5, 3))
         )  # Tie break, round up
         assert (
-            APyFloat(1, 5, 0b10111, 5, 5)
+            apyfloat(1, 5, 0b10111, 5, 5)
             .cast(5, 3)
-            .is_identical(APyFloat(1, 5, 0b110, 5, 3))
+            .is_identical(apyfloat(1, 5, 0b110, 5, 3))
         )  # Round up
 
         # Test handling of infinities
         assert (
-            APyFloat(0, 30, 0, 5, 5).cast(4, 3).is_identical(APyFloat(0, 15, 0, 4, 3))
+            apyfloat(0, 30, 0, 5, 5).cast(4, 3).is_identical(apyfloat(0, 15, 0, 4, 3))
         )  # Should become infinity
 
         assert (
-            APyFloat(1, 30, 0, 5, 5).cast(4, 3).is_identical(APyFloat(1, 15, 0, 4, 3))
+            apyfloat(1, 30, 0, 5, 5).cast(4, 3).is_identical(apyfloat(1, 15, 0, 4, 3))
         )  # Should become infinity
 
-    def test_quantization_ties_to_zero(self):
+    @pytest.mark.parametrize("apyfloat", [APyFloat, APyCFloat])
+    def test_quantization_ties_to_zero(self, apyfloat: type[APyCFloat]):
         apytypes.set_float_quantization_mode(QuantizationMode.TIES_ZERO)
         # Quantization from 0.xx
         assert (
-            APyFloat(0, 5, 0b10000, 5, 5)
+            apyfloat(0, 5, 0b10000, 5, 5)
             .cast(5, 3)
-            .is_identical(APyFloat(0, 5, 0b100, 5, 3))
+            .is_identical(apyfloat(0, 5, 0b100, 5, 3))
         )  # No quantization needed
         assert (
-            APyFloat(0, 5, 0b10001, 5, 5)
+            apyfloat(0, 5, 0b10001, 5, 5)
             .cast(5, 3)
-            .is_identical(APyFloat(0, 5, 0b100, 5, 3))
+            .is_identical(apyfloat(0, 5, 0b100, 5, 3))
         )  # Round down
         assert (
-            APyFloat(0, 5, 0b10010, 5, 5)
+            apyfloat(0, 5, 0b10010, 5, 5)
             .cast(5, 3)
-            .is_identical(APyFloat(0, 5, 0b100, 5, 3))
+            .is_identical(apyfloat(0, 5, 0b100, 5, 3))
         )  # Tie break, round down
         assert (
-            APyFloat(0, 5, 0b10011, 5, 5)
+            apyfloat(0, 5, 0b10011, 5, 5)
             .cast(5, 3)
-            .is_identical(APyFloat(0, 5, 0b101, 5, 3))
+            .is_identical(apyfloat(0, 5, 0b101, 5, 3))
         )  # Round up
 
         # Quantization from 1.xx
         assert (
-            APyFloat(0, 5, 0b10100, 5, 5)
+            apyfloat(0, 5, 0b10100, 5, 5)
             .cast(5, 3)
-            .is_identical(APyFloat(0, 5, 0b101, 5, 3))
+            .is_identical(apyfloat(0, 5, 0b101, 5, 3))
         )  # No quantization needed
         assert (
-            APyFloat(0, 5, 0b10101, 5, 5)
+            apyfloat(0, 5, 0b10101, 5, 5)
             .cast(5, 3)
-            .is_identical(APyFloat(0, 5, 0b101, 5, 3))
+            .is_identical(apyfloat(0, 5, 0b101, 5, 3))
         )  # Round down
         assert (
-            APyFloat(0, 5, 0b10110, 5, 5)
+            apyfloat(0, 5, 0b10110, 5, 5)
             .cast(5, 3)
-            .is_identical(APyFloat(0, 5, 0b101, 5, 3))
+            .is_identical(apyfloat(0, 5, 0b101, 5, 3))
         )  # Tie break, round down
         assert (
-            APyFloat(0, 5, 0b10111, 5, 5)
+            apyfloat(0, 5, 0b10111, 5, 5)
             .cast(5, 3)
-            .is_identical(APyFloat(0, 5, 0b110, 5, 3))
+            .is_identical(apyfloat(0, 5, 0b110, 5, 3))
         )  # Round up
 
         # Quantization from 0.xx, negative sign
         assert (
-            APyFloat(1, 5, 0b10000, 5, 5)
+            apyfloat(1, 5, 0b10000, 5, 5)
             .cast(5, 3)
-            .is_identical(APyFloat(1, 5, 0b100, 5, 3))
+            .is_identical(apyfloat(1, 5, 0b100, 5, 3))
         )  # No quantization needed
         assert (
-            APyFloat(1, 5, 0b10001, 5, 5)
+            apyfloat(1, 5, 0b10001, 5, 5)
             .cast(5, 3)
-            .is_identical(APyFloat(1, 5, 0b100, 5, 3))
+            .is_identical(apyfloat(1, 5, 0b100, 5, 3))
         )  # Round down
         assert (
-            APyFloat(1, 5, 0b10010, 5, 5)
+            apyfloat(1, 5, 0b10010, 5, 5)
             .cast(5, 3)
-            .is_identical(APyFloat(1, 5, 0b100, 5, 3))
+            .is_identical(apyfloat(1, 5, 0b100, 5, 3))
         )  # Tie break, round down
         assert (
-            APyFloat(1, 5, 0b10011, 5, 5)
+            apyfloat(1, 5, 0b10011, 5, 5)
             .cast(5, 3)
-            .is_identical(APyFloat(1, 5, 0b101, 5, 3))
+            .is_identical(apyfloat(1, 5, 0b101, 5, 3))
         )  # Round up
 
         # Quantization from 1.xx, negative sign
         assert (
-            APyFloat(1, 5, 0b10100, 5, 5)
+            apyfloat(1, 5, 0b10100, 5, 5)
             .cast(5, 3)
-            .is_identical(APyFloat(1, 5, 0b101, 5, 3))
+            .is_identical(apyfloat(1, 5, 0b101, 5, 3))
         )  # No quantization needed
         assert (
-            APyFloat(1, 5, 0b10101, 5, 5)
+            apyfloat(1, 5, 0b10101, 5, 5)
             .cast(5, 3)
-            .is_identical(APyFloat(1, 5, 0b101, 5, 3))
+            .is_identical(apyfloat(1, 5, 0b101, 5, 3))
         )  # Round down
         assert (
-            APyFloat(1, 5, 0b10110, 5, 5)
+            apyfloat(1, 5, 0b10110, 5, 5)
             .cast(5, 3)
-            .is_identical(APyFloat(1, 5, 0b101, 5, 3))
+            .is_identical(apyfloat(1, 5, 0b101, 5, 3))
         )  # Tie break, round down
         assert (
-            APyFloat(1, 5, 0b10111, 5, 5)
+            apyfloat(1, 5, 0b10111, 5, 5)
             .cast(5, 3)
-            .is_identical(APyFloat(1, 5, 0b110, 5, 3))
+            .is_identical(apyfloat(1, 5, 0b110, 5, 3))
         )  # Round up
 
         # Test handling of infinities
         assert (
-            APyFloat(0, 30, 0, 5, 5).cast(4, 3).is_identical(APyFloat(0, 15, 0, 4, 3))
+            apyfloat(0, 30, 0, 5, 5).cast(4, 3).is_identical(apyfloat(0, 15, 0, 4, 3))
         )  # Should become infinity
 
         assert (
-            APyFloat(1, 30, 0, 5, 5).cast(4, 3).is_identical(APyFloat(1, 15, 0, 4, 3))
+            apyfloat(1, 30, 0, 5, 5).cast(4, 3).is_identical(apyfloat(1, 15, 0, 4, 3))
         )  # Should become infinity
 
-    def test_quantization_jamming(self):
+    @pytest.mark.parametrize("apyfloat", [APyFloat, APyCFloat])
+    def test_quantization_jamming(self, apyfloat: type[APyCFloat]):
         apytypes.set_float_quantization_mode(QuantizationMode.JAM)
         # Quantization from 0.xx
         assert (
-            APyFloat(0, 5, 0b10000, 5, 5)
+            apyfloat(0, 5, 0b10000, 5, 5)
             .cast(5, 3)
-            .is_identical(APyFloat(0, 5, 0b101, 5, 3))
+            .is_identical(apyfloat(0, 5, 0b101, 5, 3))
         )
         assert (
-            APyFloat(0, 5, 0b10001, 5, 5)
+            apyfloat(0, 5, 0b10001, 5, 5)
             .cast(5, 3)
-            .is_identical(APyFloat(0, 5, 0b101, 5, 3))
+            .is_identical(apyfloat(0, 5, 0b101, 5, 3))
         )
         assert (
-            APyFloat(0, 5, 0b10010, 5, 5)
+            apyfloat(0, 5, 0b10010, 5, 5)
             .cast(5, 3)
-            .is_identical(APyFloat(0, 5, 0b101, 5, 3))
+            .is_identical(apyfloat(0, 5, 0b101, 5, 3))
         )
         assert (
-            APyFloat(0, 5, 0b10011, 5, 5)
+            apyfloat(0, 5, 0b10011, 5, 5)
             .cast(5, 3)
-            .is_identical(APyFloat(0, 5, 0b101, 5, 3))
+            .is_identical(apyfloat(0, 5, 0b101, 5, 3))
         )
 
         # Quantization from 1.xx
         assert (
-            APyFloat(0, 5, 0b10100, 5, 5)
+            apyfloat(0, 5, 0b10100, 5, 5)
             .cast(5, 3)
-            .is_identical(APyFloat(0, 5, 0b101, 5, 3))
+            .is_identical(apyfloat(0, 5, 0b101, 5, 3))
         )
         assert (
-            APyFloat(0, 5, 0b10101, 5, 5)
+            apyfloat(0, 5, 0b10101, 5, 5)
             .cast(5, 3)
-            .is_identical(APyFloat(0, 5, 0b101, 5, 3))
+            .is_identical(apyfloat(0, 5, 0b101, 5, 3))
         )
         assert (
-            APyFloat(0, 5, 0b10110, 5, 5)
+            apyfloat(0, 5, 0b10110, 5, 5)
             .cast(5, 3)
-            .is_identical(APyFloat(0, 5, 0b101, 5, 3))
+            .is_identical(apyfloat(0, 5, 0b101, 5, 3))
         )
         assert (
-            APyFloat(0, 5, 0b10111, 5, 5)
+            apyfloat(0, 5, 0b10111, 5, 5)
             .cast(5, 3)
-            .is_identical(APyFloat(0, 5, 0b101, 5, 3))
+            .is_identical(apyfloat(0, 5, 0b101, 5, 3))
         )
 
         # Quantization from 0.xx, negative sign
         assert (
-            APyFloat(1, 5, 0b10000, 5, 5)
+            apyfloat(1, 5, 0b10000, 5, 5)
             .cast(5, 3)
-            .is_identical(APyFloat(1, 5, 0b101, 5, 3))
+            .is_identical(apyfloat(1, 5, 0b101, 5, 3))
         )
         assert (
-            APyFloat(1, 5, 0b10001, 5, 5)
+            apyfloat(1, 5, 0b10001, 5, 5)
             .cast(5, 3)
-            .is_identical(APyFloat(1, 5, 0b101, 5, 3))
+            .is_identical(apyfloat(1, 5, 0b101, 5, 3))
         )
         assert (
-            APyFloat(1, 5, 0b10010, 5, 5)
+            apyfloat(1, 5, 0b10010, 5, 5)
             .cast(5, 3)
-            .is_identical(APyFloat(1, 5, 0b101, 5, 3))
+            .is_identical(apyfloat(1, 5, 0b101, 5, 3))
         )
         assert (
-            APyFloat(1, 5, 0b10011, 5, 5)
+            apyfloat(1, 5, 0b10011, 5, 5)
             .cast(5, 3)
-            .is_identical(APyFloat(1, 5, 0b101, 5, 3))
+            .is_identical(apyfloat(1, 5, 0b101, 5, 3))
         )
 
         # Quantization from 1.xx, negative sign
         assert (
-            APyFloat(1, 5, 0b10100, 5, 5)
+            apyfloat(1, 5, 0b10100, 5, 5)
             .cast(5, 3)
-            .is_identical(APyFloat(1, 5, 0b101, 5, 3))
+            .is_identical(apyfloat(1, 5, 0b101, 5, 3))
         )
         assert (
-            APyFloat(1, 5, 0b10101, 5, 5)
+            apyfloat(1, 5, 0b10101, 5, 5)
             .cast(5, 3)
-            .is_identical(APyFloat(1, 5, 0b101, 5, 3))
+            .is_identical(apyfloat(1, 5, 0b101, 5, 3))
         )
         assert (
-            APyFloat(1, 5, 0b10110, 5, 5)
+            apyfloat(1, 5, 0b10110, 5, 5)
             .cast(5, 3)
-            .is_identical(APyFloat(1, 5, 0b101, 5, 3))
+            .is_identical(apyfloat(1, 5, 0b101, 5, 3))
         )
         assert (
-            APyFloat(1, 5, 0b10111, 5, 5)
+            apyfloat(1, 5, 0b10111, 5, 5)
             .cast(5, 3)
-            .is_identical(APyFloat(1, 5, 0b101, 5, 3))
+            .is_identical(apyfloat(1, 5, 0b101, 5, 3))
         )
 
         # Test handling of infinities
         assert (
-            APyFloat(0, 30, 0, 5, 5).cast(4, 3).is_identical(APyFloat(0, 14, 7, 4, 3))
+            apyfloat(0, 30, 0, 5, 5).cast(4, 3).is_identical(apyfloat(0, 14, 7, 4, 3))
         )  # Should saturate
 
         assert (
-            APyFloat(1, 30, 0, 5, 5).cast(4, 3).is_identical(APyFloat(1, 14, 7, 4, 3))
+            apyfloat(1, 30, 0, 5, 5).cast(4, 3).is_identical(apyfloat(1, 14, 7, 4, 3))
         )  # Should saturate
 
-    def test_quantization_unbiased_jamming(self):
+    @pytest.mark.parametrize("apyfloat", [APyFloat, APyCFloat])
+    def test_quantization_unbiased_jamming(self, apyfloat: type[APyCFloat]):
         apytypes.set_float_quantization_mode(QuantizationMode.JAM_UNBIASED)
         # Quantization from 0.xx
         assert (
-            APyFloat(0, 5, 0b10000, 5, 5)
+            apyfloat(0, 5, 0b10000, 5, 5)
             .cast(5, 3)
-            .is_identical(APyFloat(0, 5, 0b100, 5, 3))
+            .is_identical(apyfloat(0, 5, 0b100, 5, 3))
         )
         assert (
-            APyFloat(0, 5, 0b10001, 5, 5)
+            apyfloat(0, 5, 0b10001, 5, 5)
             .cast(5, 3)
-            .is_identical(APyFloat(0, 5, 0b101, 5, 3))
+            .is_identical(apyfloat(0, 5, 0b101, 5, 3))
         )
 
         # Quantization from 1.xx
         assert (
-            APyFloat(0, 5, 0b10100, 5, 5)
+            apyfloat(0, 5, 0b10100, 5, 5)
             .cast(5, 3)
-            .is_identical(APyFloat(0, 5, 0b101, 5, 3))
+            .is_identical(apyfloat(0, 5, 0b101, 5, 3))
         )
         assert (
-            APyFloat(0, 5, 0b10101, 5, 5)
+            apyfloat(0, 5, 0b10101, 5, 5)
             .cast(5, 3)
-            .is_identical(APyFloat(0, 5, 0b101, 5, 3))
+            .is_identical(apyfloat(0, 5, 0b101, 5, 3))
         )
 
         # Test handling of infinities
         assert (
-            APyFloat(0, 30, 0, 5, 5).cast(4, 3).is_identical(APyFloat(0, 14, 7, 4, 3))
+            apyfloat(0, 30, 0, 5, 5).cast(4, 3).is_identical(apyfloat(0, 14, 7, 4, 3))
         )  # Should saturate
 
         assert (
-            APyFloat(1, 30, 0, 5, 5).cast(4, 3).is_identical(APyFloat(1, 14, 7, 4, 3))
+            apyfloat(1, 30, 0, 5, 5).cast(4, 3).is_identical(apyfloat(1, 14, 7, 4, 3))
         )  # Should saturate
 
-    def test_quantization_magnitude_truncation(self):
+    @pytest.mark.parametrize("apyfloat", [APyFloat, APyCFloat])
+    def test_quantization_magnitude_truncation(self, apyfloat: type[APyCFloat]):
         # Shouldn't be used for floating-point
         apytypes.set_float_quantization_mode(QuantizationMode.TRN_MAG)
         # Quantization from 0.xx
         assert (
-            APyFloat(0, 5, 0b10000, 5, 5)
+            apyfloat(0, 5, 0b10000, 5, 5)
             .cast(5, 3)
-            .is_identical(APyFloat(0, 5, 0b100, 5, 3))
+            .is_identical(apyfloat(0, 5, 0b100, 5, 3))
         )
         assert (
-            APyFloat(0, 5, 0b10001, 5, 5)
+            apyfloat(0, 5, 0b10001, 5, 5)
             .cast(5, 3)
-            .is_identical(APyFloat(0, 5, 0b100, 5, 3))
+            .is_identical(apyfloat(0, 5, 0b100, 5, 3))
         )
         assert (
-            APyFloat(0, 5, 0b10010, 5, 5)
+            apyfloat(0, 5, 0b10010, 5, 5)
             .cast(5, 3)
-            .is_identical(APyFloat(0, 5, 0b100, 5, 3))
+            .is_identical(apyfloat(0, 5, 0b100, 5, 3))
         )
         assert (
-            APyFloat(0, 5, 0b10011, 5, 5)
+            apyfloat(0, 5, 0b10011, 5, 5)
             .cast(5, 3)
-            .is_identical(APyFloat(0, 5, 0b100, 5, 3))
+            .is_identical(apyfloat(0, 5, 0b100, 5, 3))
         )
 
         # Quantization from 1.xx
         assert (
-            APyFloat(0, 5, 0b10100, 5, 5)
+            apyfloat(0, 5, 0b10100, 5, 5)
             .cast(5, 3)
-            .is_identical(APyFloat(0, 5, 0b101, 5, 3))
+            .is_identical(apyfloat(0, 5, 0b101, 5, 3))
         )
         assert (
-            APyFloat(0, 5, 0b10101, 5, 5)
+            apyfloat(0, 5, 0b10101, 5, 5)
             .cast(5, 3)
-            .is_identical(APyFloat(0, 5, 0b101, 5, 3))
+            .is_identical(apyfloat(0, 5, 0b101, 5, 3))
         )
         assert (
-            APyFloat(0, 5, 0b10110, 5, 5)
+            apyfloat(0, 5, 0b10110, 5, 5)
             .cast(5, 3)
-            .is_identical(APyFloat(0, 5, 0b101, 5, 3))
+            .is_identical(apyfloat(0, 5, 0b101, 5, 3))
         )
         assert (
-            APyFloat(0, 5, 0b10111, 5, 5)
+            apyfloat(0, 5, 0b10111, 5, 5)
             .cast(5, 3)
-            .is_identical(APyFloat(0, 5, 0b101, 5, 3))
+            .is_identical(apyfloat(0, 5, 0b101, 5, 3))
         )
 
         # Quantization from 0.xx, negative sign
         assert (
-            APyFloat(1, 5, 0b10000, 5, 5)
+            apyfloat(1, 5, 0b10000, 5, 5)
             .cast(5, 3)
-            .is_identical(APyFloat(1, 5, 0b101, 5, 3))
+            .is_identical(apyfloat(1, 5, 0b101, 5, 3))
         )
         assert (
-            APyFloat(1, 5, 0b10001, 5, 5)
+            apyfloat(1, 5, 0b10001, 5, 5)
             .cast(5, 3)
-            .is_identical(APyFloat(1, 5, 0b101, 5, 3))
+            .is_identical(apyfloat(1, 5, 0b101, 5, 3))
         )
         assert (
-            APyFloat(1, 5, 0b10010, 5, 5)
+            apyfloat(1, 5, 0b10010, 5, 5)
             .cast(5, 3)
-            .is_identical(APyFloat(1, 5, 0b101, 5, 3))
+            .is_identical(apyfloat(1, 5, 0b101, 5, 3))
         )
         assert (
-            APyFloat(1, 5, 0b10011, 5, 5)
+            apyfloat(1, 5, 0b10011, 5, 5)
             .cast(5, 3)
-            .is_identical(APyFloat(1, 5, 0b101, 5, 3))
+            .is_identical(apyfloat(1, 5, 0b101, 5, 3))
         )
 
         # Quantization from 1.xx, negative sign
         assert (
-            APyFloat(1, 5, 0b10100, 5, 5)
+            apyfloat(1, 5, 0b10100, 5, 5)
             .cast(5, 3)
-            .is_identical(APyFloat(1, 5, 0b110, 5, 3))
+            .is_identical(apyfloat(1, 5, 0b110, 5, 3))
         )
         assert (
-            APyFloat(1, 5, 0b10101, 5, 5)
+            apyfloat(1, 5, 0b10101, 5, 5)
             .cast(5, 3)
-            .is_identical(APyFloat(1, 5, 0b110, 5, 3))
+            .is_identical(apyfloat(1, 5, 0b110, 5, 3))
         )
         assert (
-            APyFloat(1, 5, 0b10110, 5, 5)
+            apyfloat(1, 5, 0b10110, 5, 5)
             .cast(5, 3)
-            .is_identical(APyFloat(1, 5, 0b110, 5, 3))
+            .is_identical(apyfloat(1, 5, 0b110, 5, 3))
         )
         assert (
-            APyFloat(1, 5, 0b10111, 5, 5)
+            apyfloat(1, 5, 0b10111, 5, 5)
             .cast(5, 3)
-            .is_identical(APyFloat(1, 5, 0b110, 5, 3))
+            .is_identical(apyfloat(1, 5, 0b110, 5, 3))
         )
 
         # Test handling of infinities
         assert (
-            APyFloat(0, 30, 0, 5, 5).cast(4, 3).is_identical(APyFloat(0, 15, 0, 4, 3))
+            apyfloat(0, 30, 0, 5, 5).cast(4, 3).is_identical(apyfloat(0, 15, 0, 4, 3))
         )  # Should become infinity
 
         assert (
-            APyFloat(1, 30, 0, 5, 5).cast(4, 3).is_identical(APyFloat(1, 15, 0, 4, 3))
+            apyfloat(1, 30, 0, 5, 5).cast(4, 3).is_identical(apyfloat(1, 15, 0, 4, 3))
         )  # Should become infinity
 
-    def test_quantization_stochastic_weighted(self):
+    @pytest.mark.parametrize("apyfloat", [APyFloat, APyCFloat])
+    def test_quantization_stochastic_weighted(self, apyfloat: type[APyCFloat]):
         """
         A bit naive, but test that a value can be rounded both up and down in 1000 tries.
         An exact value should however not be rounded.
         """
         apytypes.set_float_quantization_mode(QuantizationMode.STOCH_WEIGHTED)
-        larger_format = APyFloat(0, 5, 0b10000, 5, 5)
-        assert larger_format.cast(5, 3).is_identical(APyFloat(0, 5, 0b100, 5, 3))
+        larger_format = apyfloat(0, 5, 0b10000, 5, 5)
+        assert larger_format.cast(5, 3).is_identical(apyfloat(0, 5, 0b100, 5, 3))
 
-        larger_format = APyFloat(0, 5, 0b10001, 5, 5)
-        rounded_down = APyFloat(0, 5, 0b100, 5, 3)
-        rounded_up = APyFloat(0, 5, 0b101, 5, 3)
+        larger_format = apyfloat(0, 5, 0b10001, 5, 5)
+        rounded_down = apyfloat(0, 5, 0b100, 5, 3)
+        rounded_up = apyfloat(0, 5, 0b101, 5, 3)
 
         done_up = False
         done_down = False
@@ -1982,18 +2022,19 @@ class TestAPyFloatQuantization:
             if done_down and done_up:
                 break
 
-    def test_quantization_stochastic_equal(self):
+    @pytest.mark.parametrize("apyfloat", [APyFloat, APyCFloat])
+    def test_quantization_stochastic_equal(self, apyfloat: type[APyCFloat]):
         """
         A bit naive, but test that a value can be rounded both up and down in 1000 tries.
         An exact value should however not be rounded.
         """
         apytypes.set_float_quantization_mode(QuantizationMode.STOCH_EQUAL)
-        larger_format = APyFloat(0, 5, 0b10000, 5, 5)
-        assert larger_format.cast(5, 3).is_identical(APyFloat(0, 5, 0b100, 5, 3))
+        larger_format = apyfloat(0, 5, 0b10000, 5, 5)
+        assert larger_format.cast(5, 3).is_identical(apyfloat(0, 5, 0b100, 5, 3))
 
-        larger_format = APyFloat(0, 5, 0b10001, 5, 5)
-        rounded_down = APyFloat(0, 5, 0b100, 5, 3)
-        rounded_up = APyFloat(0, 5, 0b101, 5, 3)
+        larger_format = apyfloat(0, 5, 0b10001, 5, 5)
+        rounded_down = apyfloat(0, 5, 0b100, 5, 3)
+        rounded_up = apyfloat(0, 5, 0b101, 5, 3)
 
         done_up = False
         done_down = False
@@ -2008,10 +2049,11 @@ class TestAPyFloatQuantization:
             if done_down and done_up:
                 break
 
-    def test_quantization_subnormal_shift(self):
+    @pytest.mark.parametrize("apyfloat", [APyFloat, APyCFloat])
+    def test_quantization_subnormal_shift(self, apyfloat: type[APyCFloat]):
         """Result will be subnormal but require a left shift."""
-        assert (_ := APyFloat(0, 0, 1, 4, 4).cast(4, 10)).is_identical(
-            APyFloat(sign=0, exp=0, man=64, exp_bits=4, man_bits=10)
+        assert (_ := apyfloat(0, 0, 1, 4, 4).cast(4, 10)).is_identical(
+            apyfloat(sign=0, exp=0, man=64, exp_bits=4, man_bits=10)
         )
 
 
@@ -2040,20 +2082,22 @@ def test_convenience_cast():
     )
 
 
-def test_issue_188():
+@pytest.mark.parametrize("apyfloat, py_type", [(APyFloat, float), (APyCFloat, complex)])
+def test_issue_188(apyfloat: type[APyCFloat], py_type: type[complex]):
     # Actually tests the rounding upon construction from float
-    x = APyFloat(sign=0, exp=0, man=1, exp_bits=4, man_bits=3)
-    y = APyFloat(sign=0, exp=7, man=1, exp_bits=4, man_bits=3)
+    x = apyfloat(sign=0, exp=0, man=1, exp_bits=4, man_bits=3)
+    y = apyfloat(sign=0, exp=7, man=1, exp_bits=4, man_bits=3)
 
     res1 = x / y
-    res2 = APyFloat.from_float(float(x) / float(y), exp_bits=4, man_bits=3)
+    res2 = apyfloat.from_float(py_type(x) / py_type(y), exp_bits=4, man_bits=3)
 
     assert res1 == res2
 
 
-def test_cast_only_one_size():
-    x = APyFloat(0, 5, 10, 5, 5)
-    assert (x.cast(4)).is_identical(APyFloat(0, 0, 3, 4, 5))
-    assert (x.cast(6)).is_identical(APyFloat(0, 21, 10, 6, 5))
-    assert (x.cast(man_bits=4)).is_identical(APyFloat(0, 5, 5, 5, 4))
-    assert (x.cast(man_bits=6)).is_identical(APyFloat(0, 5, 20, 5, 6))
+@pytest.mark.parametrize("apyfloat", [APyFloat, APyCFloat])
+def test_cast_only_one_size(apyfloat: type[APyCFloat]):
+    x = apyfloat(0, 5, 10, 5, 5)
+    assert (x.cast(4)).is_identical(apyfloat(0, 0, 3, 4, 5))
+    assert (x.cast(6)).is_identical(apyfloat(0, 21, 10, 6, 5))
+    assert (x.cast(man_bits=4)).is_identical(apyfloat(0, 5, 5, 5, 4))
+    assert (x.cast(man_bits=6)).is_identical(apyfloat(0, 5, 20, 5, 6))

--- a/lib/test/apyfloatarray/test_constructors.py
+++ b/lib/test/apyfloatarray/test_constructors.py
@@ -5,49 +5,49 @@ from apytypes import APyFloatArray
 @pytest.mark.float_array
 def test_constructor_raises():
     with pytest.raises(ValueError, match="Shape mismatch"):
-        APyFloatArray([1], [5, 2], [4], 10, 10)
+        _ = APyFloatArray([1], [5, 2], [4], 10, 10)
     with pytest.raises(ValueError, match="Inhomogeneous sequence"):
-        APyFloatArray([1, 2], [5, 2], [4, "str"], 10, 10)
+        _ = APyFloatArray([1, 2], [5, 2], [4, "str"], 10, 10)
     with pytest.raises(ValueError, match="python_sequence_extract_shape"):
-        APyFloatArray(["foo"], [5], [4], 10, 10)
+        _ = APyFloatArray(["foo"], [5], [4], 10, 10)
     with pytest.raises(ValueError, match="python_sequence_extract_shape"):
-        APyFloatArray([1], ["foo"], [4], 10, 10)
+        _ = APyFloatArray([1], ["foo"], [4], 10, 10)
     with pytest.raises(ValueError, match="python_sequence_extract_shape"):
-        APyFloatArray([1], [5], ["foo"], 10, 10)
+        _ = APyFloatArray([1], [5], ["foo"], 10, 10)
     with pytest.raises(
         ValueError, match="Non <type>/sequence found when walking: '1.0'"
     ):
-        APyFloatArray([1.0], [4], [4], 10, 10)
+        _ = APyFloatArray([1.0], [4], [4], 10, 10)
     with pytest.raises(
         ValueError, match="Non <type>/sequence found when walking: '<class 'range'>'"
     ):
-        APyFloatArray([True], [range], [4], 10, 10)
+        _ = APyFloatArray([True], [range], [4], 10, 10)
     with pytest.raises(
         ValueError,
         match="Non <type>/sequence found when walking: '<class 'apytypes._apytypes.APyFloatArray'>'",
     ):
-        APyFloatArray([True], [4], [APyFloatArray], 10, 10)
+        _ = APyFloatArray([True], [4], [APyFloatArray], 10, 10)
     with pytest.raises(
         ValueError,
-        match="Exponent bits must be a non-negative integer less or equal to .. but 300 was given",
+        match=r"APyFloatArray\.__init__: exponent bits must be a non-negative integer less or equal to .. but 300 was given",
     ):
-        APyFloatArray([0], [0], [0], 300, 5)
+        _ = APyFloatArray([0], [0], [0], 300, 5)
     with pytest.raises(
         ValueError,
-        match="Exponent bits must be a non-negative integer less or equal to .. but -300 was given",
+        match=r"APyFloatArray\.__init__: exponent bits must be a non-negative integer less or equal to .. but -300 was given",
     ):
-        APyFloatArray([0], [0], [0], -300, 5)
+        _ = APyFloatArray([0], [0], [0], -300, 5)
     # Too many mantissa bits
     with pytest.raises(
         ValueError,
-        match="Mantissa bits must be a non-negative integer less or equal to .. but 300 was given",
+        match=r"APyFloatArray.__init__: mantissa bits must be a non-negative integer less or equal to .. but 300 was given",
     ):
-        APyFloatArray([0], [0], [0], 5, 300)
+        _ = APyFloatArray([0], [0], [0], 5, 300)
     with pytest.raises(
         ValueError,
-        match="Mantissa bits must be a non-negative integer less or equal to .. but -300 was given",
+        match=r"APyFloatArray.__init__: mantissa bits must be a non-negative integer less or equal to .. but -300 was given",
     ):
-        APyFloatArray([0], [0], [0], 5, -300)
+        _ = APyFloatArray([0], [0], [0], 5, -300)
 
 
 @pytest.mark.float_array

--- a/lib/test/apyfloatarray/test_methods.py
+++ b/lib/test/apyfloatarray/test_methods.py
@@ -61,25 +61,29 @@ def test_array_from_float_raises():
     # Too many exponent bits
     with pytest.raises(
         ValueError,
-        match="Exponent bits must be a non-negative integer less or equal to .. but 300 was given",
+        match=r"APyFloatArray.from_integer: exponent bits must be a non-negative integer less or equal to .. but 300 was given",
     ):
         APyFloatArray.from_float([0], 300, 5)
+
     with pytest.raises(
         ValueError,
-        match="Exponent bits must be a non-negative integer less or equal to .. but -300 was given",
+        match=r"APyFloatArray.from_integer: exponent bits must be a non-negative integer less or equal to .. but -300 was given",
     ):
         APyFloatArray.from_float([0], -300, 5)
+
     # Too many mantissa bits
     with pytest.raises(
         ValueError,
-        match="Mantissa bits must be a non-negative integer less or equal to .. but 300 was given",
+        match="APyFloatArray.from_integer: mantissa bits must be a non-negative integer less or equal to .. but 300 was given",
     ):
         APyFloatArray.from_float([0], 5, 300)
+
     with pytest.raises(
         ValueError,
-        match="Mantissa bits must be a non-negative integer less or equal to .. but -300 was given",
+        match="APyFloatArray.from_integer: mantissa bits must be a non-negative integer less or equal to .. but -300 was given",
     ):
         APyFloatArray.from_float([0], 5, -300)
+
     with pytest.raises(
         ValueError,
         match="python_sequence_extract_shape",
@@ -195,23 +199,23 @@ def test_array_cast_raises():
     # Too many exponent bits
     with pytest.raises(
         ValueError,
-        match="Exponent bits must be a non-negative integer less or equal to .. but 300 was given",
+        match=r"APyFloatArray\.cast: exponent bits must be a non-negative integer less or equal to .. but 300 was given",
     ):
         APyFloatArray([0], [0], [0], 5, 5).cast(300, 5)
     with pytest.raises(
         ValueError,
-        match="Exponent bits must be a non-negative integer less or equal to .. but -300 was given",
+        match=r"APyFloatArray\.cast: exponent bits must be a non-negative integer less or equal to .. but -300 was given",
     ):
         APyFloatArray([0], [0], [0], 5, 5).cast(-300, 5)
     # Too many mantissa bits
     with pytest.raises(
         ValueError,
-        match="Mantissa bits must be a non-negative integer less or equal to .. but 300 was given",
+        match=r"APyFloatArray\.cast: mantissa bits must be a non-negative integer less or equal to .. but 300 was given",
     ):
         APyFloatArray([0], [0], [0], 5, 5).cast(5, 300)
     with pytest.raises(
         ValueError,
-        match="Mantissa bits must be a non-negative integer less or equal to .. but -300 was given",
+        match=r"APyFloatArray\.cast: mantissa bits must be a non-negative integer less or equal to .. but -300 was given",
     ):
         APyFloatArray([0], [0], [0], 5, 5).cast(5, -300)
 
@@ -223,25 +227,25 @@ def test_array_from_array_raises():
     # Too many exponent bits
     with pytest.raises(
         ValueError,
-        match="Exponent bits must be a non-negative integer less or equal to .. but 300 was given",
+        match=r"APyFloatArray\.cast: exponent bits must be a non-negative integer less or equal to .. but 300 was given",
     ):
-        APyFloatArray.from_array(np.array([[1, 2, 3, 4]]), 5, 5).cast(300, 5)
+        _ = APyFloatArray.from_array(np.array([[1, 2, 3, 4]]), 5, 5).cast(300, 5)
     with pytest.raises(
         ValueError,
-        match="Exponent bits must be a non-negative integer less or equal to .. but -300 was given",
+        match=r"APyFloatArray\.cast: exponent bits must be a non-negative integer less or equal to .. but -300 was given",
     ):
-        APyFloatArray.from_array(np.array([[1, 2, 3, 4]]), 5, 5).cast(-300, 5)
+        _ = APyFloatArray.from_array(np.array([[1, 2, 3, 4]]), 5, 5).cast(-300, 5)
     # Too many mantissa bits
     with pytest.raises(
         ValueError,
-        match="Mantissa bits must be a non-negative integer less or equal to .. but 300 was given",
+        match=r"APyFloatArray\.cast: mantissa bits must be a non-negative integer less or equal to .. but 300 was given",
     ):
-        APyFloatArray.from_array(np.array([[1, 2, 3, 4]]), 5, 5).cast(5, 300)
+        _ = APyFloatArray.from_array(np.array([[1, 2, 3, 4]]), 5, 5).cast(5, 300)
     with pytest.raises(
         ValueError,
-        match="Mantissa bits must be a non-negative integer less or equal to .. but -300 was given",
+        match=r"APyFloatArray\.cast: mantissa bits must be a non-negative integer less or equal to .. but -300 was given",
     ):
-        APyFloatArray.from_array(np.array([[1, 2, 3, 4]]), 5, 5).cast(5, -300)
+        _ = APyFloatArray.from_array(np.array([[1, 2, 3, 4]]), 5, 5).cast(5, -300)
 
 
 @pytest.mark.float_array
@@ -249,7 +253,7 @@ def test_from_bits():
     # Test raises
     with pytest.raises(
         ValueError,
-        match="Exponent bits must be a non-negative integer less or equal to .. but 300 was given",
+        match=r"APyFloatArray\.from_bits: exponent bits must be a non-negative integer less or equal to .. but 300 was given",
     ):
         APyFloatArray.from_bits([0], 300, 5)
 

--- a/lib/test/test_contextmanagers.py
+++ b/lib/test/test_contextmanagers.py
@@ -231,25 +231,25 @@ class TestAccumulatorContext:
 
         with pytest.raises(
             ValueError,
-            match="Exponent bits must be a non-negative integer less or equal to .. but 300 was given",
+            match="APyFloatAccumulatorContext: exponent bits must be a non-negative integer less or equal to .. but 300 was given",
         ):
-            APyFloatAccumulatorContext(exp_bits=300, man_bits=5)
+            _ = APyFloatAccumulatorContext(exp_bits=300, man_bits=5)
         with pytest.raises(
             ValueError,
-            match="Exponent bits must be a non-negative integer less or equal to .. but -300 was given",
+            match="APyFloatAccumulatorContext: exponent bits must be a non-negative integer less or equal to .. but -300 was given",
         ):
-            APyFloatAccumulatorContext(exp_bits=-300, man_bits=5)
+            _ = APyFloatAccumulatorContext(exp_bits=-300, man_bits=5)
         # Too many mantissa bits
         with pytest.raises(
             ValueError,
-            match="Mantissa bits must be a non-negative integer less or equal to .. but 300 was given",
+            match="APyFloatAccumulatorContext: mantissa bits must be a non-negative integer less or equal to .. but 300 was given",
         ):
-            APyFloatAccumulatorContext(exp_bits=5, man_bits=300)
+            _ = APyFloatAccumulatorContext(exp_bits=5, man_bits=300)
         with pytest.raises(
             ValueError,
-            match="Mantissa bits must be a non-negative integer less or equal to .. but -300 was given",
+            match="APyFloatAccumulatorContext: mantissa bits must be a non-negative integer less or equal to .. but -300 was given",
         ):
-            APyFloatAccumulatorContext(exp_bits=5, man_bits=-300)
+            _ = APyFloatAccumulatorContext(exp_bits=5, man_bits=-300)
 
     def test_with_quantization_context(self):
         """Test that the APyFloatAccumulatorContext interacts correctly with the APyFloatQuanizationContext."""

--- a/src/apyarray.h
+++ b/src/apyarray.h
@@ -149,7 +149,7 @@ public:
                     );
                     throw nb::value_error(msg.c_str());
                 } else {
-                    // Found first ellipsis, fill missing dimesnsions with full slices
+                    // Found first ellipsis, fill missing dimensions with full slices
                     ellipsis_found = true;
                     std::size_t n_fill = _ndim - key.size() + 1;
                     for (std::size_t j = 0; j < n_fill; j++) {

--- a/src/apycfixed.h
+++ b/src/apycfixed.h
@@ -328,6 +328,7 @@ private:
      * ****************************************************************************** */
 public:
     friend class APyCFixedArray;
+    friend class APyCFloat;
 };
 
 #endif

--- a/src/apycfixed_wrapper.cc
+++ b/src/apycfixed_wrapper.cc
@@ -50,7 +50,18 @@ static auto L_OP(const APyCFixed& lhs, const R_TYPE& rhs) -> decltype(OP()(lhs, 
     }
 }
 
-using std::complex;
+// Mark a non-implicit conversion argument
+#define NARG(name) nb::arg(name).noconvert()
+
+// Mark a special double-underscore marker (e.g., `__add__`). Returns `NotImplemented`
+// rather than raising `TypeError`
+#define IS_OP(args) nb::is_operator(args)
+
+// Short-hand C++ arithmetic functors
+#define ADD std::plus
+#define SUB std::minus
+#define MUL std::multiplies
+#define DIV std::divides
 
 void bind_cfixed(nb::module_& m)
 {
@@ -119,14 +130,14 @@ void bind_cfixed(nb::module_& m)
         .def(nb::self == nb::int_())
         .def(nb::self != nb::int_())
 
-        .def("__add__", L_OP<std::plus<>, nb::int_>, nb::is_operator())
-        .def("__sub__", L_OP<std::minus<>, nb::int_>, nb::is_operator())
-        .def("__mul__", L_OP<std::multiplies<>, nb::int_>, nb::is_operator())
-        .def("__truediv__", L_OP<std::divides<>, nb::int_>, nb::is_operator())
-        .def("__radd__", R_OP<std::plus<>, nb::int_>, nb::is_operator())
-        .def("__rsub__", R_OP<std::minus<>, nb::int_>, nb::is_operator())
-        .def("__rmul__", R_OP<std::multiplies<>, nb::int_>, nb::is_operator())
-        .def("__rtruediv__", R_OP<std::divides<>, nb::int_>, nb::is_operator())
+        .def("__add__", L_OP<ADD<>, nb::int_>, IS_OP(), NARG())
+        .def("__sub__", L_OP<SUB<>, nb::int_>, IS_OP(), NARG())
+        .def("__mul__", L_OP<MUL<>, nb::int_>, IS_OP(), NARG())
+        .def("__truediv__", L_OP<DIV<>, nb::int_>, IS_OP(), NARG())
+        .def("__radd__", R_OP<ADD<>, nb::int_>, IS_OP(), NARG())
+        .def("__rsub__", R_OP<SUB<>, nb::int_>, IS_OP(), NARG())
+        .def("__rmul__", R_OP<MUL<>, nb::int_>, IS_OP(), NARG())
+        .def("__rtruediv__", R_OP<DIV<>, nb::int_>, IS_OP(), NARG())
 
         /*
          * Arithmetic operations with floats
@@ -134,44 +145,44 @@ void bind_cfixed(nb::module_& m)
         .def(nb::self == double())
         .def(nb::self != double())
 
-        .def("__add__", L_OP<std::plus<>, double>, nb::is_operator())
-        .def("__radd__", R_OP<std::plus<>, double>, nb::is_operator())
-        .def("__sub__", L_OP<std::minus<>, double>, nb::is_operator())
-        .def("__rsub__", R_OP<std::minus<>, double>, nb::is_operator())
-        .def("__mul__", L_OP<std::multiplies<>, double>, nb::is_operator())
-        .def("__rmul__", R_OP<std::multiplies<>, double>, nb::is_operator())
-        .def("__truediv__", L_OP<std::divides<>, double>, nb::is_operator())
-        .def("__rtruediv__", R_OP<std::divides<>, double>, nb::is_operator())
+        .def("__add__", L_OP<ADD<>, double>, IS_OP(), NARG())
+        .def("__radd__", R_OP<ADD<>, double>, IS_OP(), NARG())
+        .def("__sub__", L_OP<SUB<>, double>, IS_OP(), NARG())
+        .def("__rsub__", R_OP<SUB<>, double>, IS_OP(), NARG())
+        .def("__mul__", L_OP<MUL<>, double>, IS_OP(), NARG())
+        .def("__rmul__", R_OP<MUL<>, double>, IS_OP(), NARG())
+        .def("__truediv__", L_OP<DIV<>, double>, IS_OP(), NARG())
+        .def("__rtruediv__", R_OP<DIV<>, double>, IS_OP(), NARG())
 
         /*
-         * Arithmetic operations with complex
+         * Arithmetic operations with Python complex
          */
-        .def(nb::self == complex<double>())
-        .def(nb::self != complex<double>())
+        .def(nb::self == std::complex<double>())
+        .def(nb::self != std::complex<double>())
 
-        .def("__add__", L_OP<std::plus<>, complex<double>>, nb::is_operator())
-        .def("__radd__", R_OP<std::plus<>, complex<double>>, nb::is_operator())
-        .def("__sub__", L_OP<std::minus<>, complex<double>>, nb::is_operator())
-        .def("__rsub__", R_OP<std::minus<>, complex<double>>, nb::is_operator())
-        .def("__mul__", L_OP<std::multiplies<>, complex<double>>, nb::is_operator())
-        .def("__rmul__", R_OP<std::multiplies<>, complex<double>>, nb::is_operator())
-        .def("__truediv__", L_OP<std::divides<>, complex<double>>, nb::is_operator())
-        .def("__rtruediv__", R_OP<std::divides<>, complex<double>>, nb::is_operator())
+        .def("__add__", L_OP<ADD<>, std::complex<double>>, IS_OP(), NARG())
+        .def("__radd__", R_OP<ADD<>, std::complex<double>>, IS_OP(), NARG())
+        .def("__sub__", L_OP<SUB<>, std::complex<double>>, IS_OP(), NARG())
+        .def("__rsub__", R_OP<SUB<>, std::complex<double>>, IS_OP(), NARG())
+        .def("__mul__", L_OP<MUL<>, std::complex<double>>, IS_OP(), NARG())
+        .def("__rmul__", R_OP<MUL<>, std::complex<double>>, IS_OP(), NARG())
+        .def("__truediv__", L_OP<DIV<>, std::complex<double>>, IS_OP(), NARG())
+        .def("__rtruediv__", R_OP<DIV<>, std::complex<double>>, IS_OP(), NARG())
 
         /*
-         * Arithmetic operations with APyFixed
+         * Arithmetic operations with `APyFixed`
          */
-        .def("__eq__", L_OP<std::equal_to<>, APyFixed>, nb::is_operator())
-        .def("__ne__", L_OP<std::not_equal_to<>, APyFixed>, nb::is_operator())
+        .def("__eq__", L_OP<std::equal_to<>, APyFixed>, IS_OP())
+        .def("__ne__", L_OP<std::not_equal_to<>, APyFixed>, IS_OP())
 
-        .def("__add__", L_OP<std::plus<>, APyFixed>, nb::is_operator())
-        .def("__radd__", R_OP<std::plus<>, APyFixed>, nb::is_operator())
-        .def("__sub__", L_OP<std::minus<>, APyFixed>, nb::is_operator())
-        .def("__rsub__", R_OP<std::minus<>, APyFixed>, nb::is_operator())
-        .def("__mul__", L_OP<std::multiplies<>, APyFixed>, nb::is_operator())
-        .def("__rmul__", R_OP<std::multiplies<>, APyFixed>, nb::is_operator())
-        .def("__truediv__", L_OP<std::divides<>, APyFixed>, nb::is_operator())
-        .def("__rtruediv__", R_OP<std::divides<>, APyFixed>, nb::is_operator())
+        .def("__add__", L_OP<ADD<>, APyFixed>, IS_OP(), NARG())
+        .def("__radd__", R_OP<ADD<>, APyFixed>, IS_OP(), NARG())
+        .def("__sub__", L_OP<SUB<>, APyFixed>, IS_OP(), NARG())
+        .def("__rsub__", R_OP<SUB<>, APyFixed>, IS_OP(), NARG())
+        .def("__mul__", L_OP<MUL<>, APyFixed>, IS_OP(), NARG())
+        .def("__rmul__", R_OP<MUL<>, APyFixed>, IS_OP(), NARG())
+        .def("__truediv__", L_OP<DIV<>, APyFixed>, IS_OP(), NARG())
+        .def("__rtruediv__", R_OP<DIV<>, APyFixed>, IS_OP(), NARG())
 
         /*
          * Logic operations
@@ -364,10 +375,13 @@ void bind_cfixed(nb::module_& m)
             Create an :class:`APyCFixed` object from an :class:`int`, :class:`float`,
             :class:`complex`, :class:`APyFixed`, :class:`APyFloat`, or :class:`APyCFixed`.
 
-            .. note:: It is in all cases better to use :func:`~apytypes.APyCFixed.cast` to create an :class:`APyCFixed` from an :class:`APyCFixed`.
+            .. attention::
+                It is in all cases better to use :func:`~apytypes.APyCFixed.cast` to
+                create an :class:`APyCFixed` from an :class:`APyCFixed`.
 
-            The input is quantized using :class:`QuantizationMode.RND_INF` and overflow is handled using the :class:`OverflowMode.WRAP` mode.
-            Exactly two of the three bit-specifiers (`bits`, `int_bits`, `frac_bits`) must be set.
+            The input is quantized using :class:`QuantizationMode.RND_INF` and overflow
+            is handled using the :class:`OverflowMode.WRAP` mode. Exactly two of the
+            three bit-specifiers (`bits`, `int_bits`, `frac_bits`) must be set.
 
             Parameters
             ----------
@@ -406,10 +420,13 @@ void bind_cfixed(nb::module_& m)
             nb::arg("bits") = nb::none(),
             R"pbdoc(
             Create an :class:`APyCFixed` object from an :class:`int`, :class:`float`,
-            :class:`complex`, :class:`APyFixed`, :class:`APyFloat`, or :class:`APyCFixed`.
-            This is an alias for :func:`~apytypes.APyCFixed.from_complex`, look there for more documentation.
+            :class:`complex`, :class:`APyFixed`, :class:`APyFloat`, or
+            :class:`APyCFixed`. This is an alias for
+            :func:`~apytypes.APyCFixed.from_complex`, look there for more documentation.
 
-            .. attention:: It is in all cases better to use :func:`~apytypes.APyCFixed.cast` to create an :class:`APyCFixed` from anpther :class:`APyCFixed`.
+            .. attention::
+                It is in all cases better to use :func:`~apytypes.APyCFixed.cast` to
+                create an :class:`APyCFixed` from anpther :class:`APyCFixed`.
 
             Parameters
             ----------

--- a/src/apycfixedarray_wrapper.cc
+++ b/src/apycfixedarray_wrapper.cc
@@ -890,10 +890,13 @@ void bind_cfixed_array(nb::module_& m)
             nb::arg("frac_bits") = nb::none(),
             nb::arg("bits") = nb::none(),
             R"pbdoc(
-            Create an :class:`APyCFixedArray` object from a sequence of :class:`int`, :class:`float`, :class:`complex`, :class:`APyFixed`, :class:`APyFloat`, or :class:`APyCFixed`.
+            Create an :class:`APyCFixedArray` object from a sequence of :class:`int`,
+            :class:`float`, :class:`complex`, :class:`APyFixed`, :class:`APyFloat`, or
+            :class:`APyCFixed`.
 
-            The input is quantized using :class:`QuantizationMode.RND_INF` and overflow is handled using the :class:`OverflowMode.WRAP` mode.
-            Exactly two of the three bit-specifiers (`bits`, `int_bits`, `frac_bits`) must be set.
+            The input is quantized using :class:`QuantizationMode.RND_INF` and overflow
+            is handled using the :class:`OverflowMode.WRAP` mode. Exactly two of the
+            three bit-specifiers (`bits`, `int_bits`, `frac_bits`) must be set.
 
             Using NumPy arrays as input is in general faster than e.g. lists.
 
@@ -942,8 +945,11 @@ void bind_cfixed_array(nb::module_& m)
             nb::arg("frac_bits") = nb::none(),
             nb::arg("bits") = nb::none(),
             R"pbdoc(
-            Create an :class:`APyCFixedArray` object from a sequence of :class:`int`, :class:`float`, :class:`complex`, :class:`APyFixed`, :class:`APyFloat`, or :class:`APyCFixed`.
-            This is an alias for :func:`~apytypes.APyCFixedArray.from_complex`, look there for more documentation.
+            Create an :class:`APyCFixedArray` object from a sequence of :class:`int`,
+            :class:`float`, :class:`complex`, :class:`APyFixed`, :class:`APyFloat`, or
+            :class:`APyCFixed`. This is an alias for
+            :func:`~apytypes.APyCFixedArray.from_complex`, look there for more
+            documentation.
 
             Parameters
             ----------

--- a/src/apycfloat.cc
+++ b/src/apycfloat.cc
@@ -1,92 +1,574 @@
 #include "apycfloat.h"
-#include "apyfixed.h"
+#include "apycfixed.h"
+#include "apycfloat_util.h"
+#include "apyfloat.h"
 #include "apyfloat_util.h"
+#include "apytypes_common.h"
+#include "ieee754.h"
+
+#include <nanobind/nanobind.h>
+#include <nanobind/stl/optional.h>
+#include <nanobind/stl/variant.h>
+
+#include <fmt/format.h>
+#include <variant>
+
+/* ********************************************************************************** *
+ * *                       More C++ accessible constructors                         * *
+ * ********************************************************************************** */
+
+APyCFloat::APyCFloat(std::uint8_t exp_bits, std::uint8_t man_bits, exp_t bias)
+    : exp_bits(exp_bits)
+    , man_bits(man_bits)
+    , bias(bias)
+    , _data {}
+{
+}
+
+APyCFloat::APyCFloat(
+    const APyFloatData& real_data,
+    std::uint8_t exp_bits,
+    std::uint8_t man_bits,
+    exp_t bias
+)
+    : exp_bits(exp_bits)
+    , man_bits(man_bits)
+    , bias(bias)
+    , _data { real_data }
+{
+}
+
+APyCFloat::APyCFloat(
+    const APyFloatData& real_data,
+    const APyFloatData& imag_data,
+    std::uint8_t exp_bits,
+    std::uint8_t man_bits,
+    exp_t bias
+)
+    : exp_bits(exp_bits)
+    , man_bits(man_bits)
+    , bias(bias)
+    , _data { real_data, imag_data }
+{
+}
+
+/* ********************************************************************************** *
+ * *                       Python accessible constructions                          * *
+ * ********************************************************************************** */
+
+APyCFloat::APyCFloat(
+    const nb::int_& exp_bits,
+    const nb::int_& man_bits,
+    const std::optional<nb::int_>& bias
+)
+    : exp_bits(check_exponent_format(static_cast<int>(exp_bits), "APyCFloat.__init__"))
+    , man_bits(check_mantissa_format(static_cast<int>(man_bits), "APyCFloat.__init__"))
+    , bias(bias.has_value() ? static_cast<int>(*bias) : ieee_bias(APyCFloat::exp_bits))
+    , _data {}
+{
+}
+
+APyCFloat::APyCFloat(
+    const std::variant<nb::bool_, nb::int_>& sign,
+    const nb::int_& exp,
+    const nb::int_& man,
+    const nb::int_& exp_bits,
+    const nb::int_& man_bits,
+    const std::optional<nb::int_>& bias
+)
+    : APyCFloat(exp_bits, man_bits, bias)
+{
+    exp_t real_exp = static_cast<exp_t>(exp);
+    man_t real_man = static_cast<man_t>(man);
+    bool real_sign;
+    if (std::holds_alternative<nb::bool_>(sign)) {
+        real_sign = nb::cast<bool>(std::get<nb::bool_>(sign));
+    } else { /* std::holds_alternative<nb::int_>(sign) */
+        real_sign = nb::cast<int>(std::get<nb::int_>(sign));
+    }
+    real() = { real_sign, real_exp, real_man };
+}
+
+APyCFloat::APyCFloat(
+    const nb::tuple& sign_tuple,
+    const nb::tuple& exp_tuple,
+    const nb::tuple& man_tuple,
+    const nb::int_& exp_bits,
+    const nb::int_& man_bits,
+    const std::optional<nb::int_>& bias
+)
+    : APyCFloat(exp_bits, man_bits, bias)
+{
+    // Sanitize input: all tuples have equally many items
+    if (sign_tuple.size() != exp_tuple.size()
+        || sign_tuple.size() != man_tuple.size()) {
+        throw nb::value_error(
+            "APyCFloat.__init__: different sized initialization tuples"
+        );
+    }
+    std::size_t n_tuple_elements = sign_tuple.size();
+
+    // Sanitize input: at least a single element in all tuples
+    if (n_tuple_elements == 0) {
+        throw nb::value_error(
+            "APyCFloat.__init__: less than one element in initialization tuples"
+        );
+    }
+
+    // Sanitize input: no more than two values in all tuples
+    if (n_tuple_elements > 2) {
+        throw nb::value_error(
+            "APyCFloat.__init__: more than two elements in initializetion tuples"
+        );
+    }
+
+    // Sign extraction helper (extract from `nb::int_` or `nb::bool_`)
+    auto GET_SIGN = [](auto&& obj) -> bool {
+        nb::bool_ b_sign;
+        nb::int_ i_sign;
+        if (nb::try_cast<nb::bool_>(obj, b_sign)) {
+            return bool(b_sign);
+        } else if (nb::try_cast<nb::int_>(obj, i_sign)) {
+            return bool(int(i_sign));
+        } else {
+            throw nb::value_error("APyCFloat.__init__: sign is non-bool/non-integer");
+        }
+    };
+
+    bool re_sign, im_sign;
+    nb::int_ re_exp, re_man, im_exp, im_man;
+
+    re_sign = GET_SIGN(sign_tuple[0]);
+    if (!nb::try_cast<nb::int_>(exp_tuple[0], re_exp)) {
+        throw nb::value_error("APyCFloat.__init__: exponent is non-integer");
+    }
+    if (!nb::try_cast<nb::int_>(man_tuple[0], re_man)) {
+        throw nb::value_error("APyCFloat.__init__: mantissa is non-integer");
+    }
+    real() = { re_sign, static_cast<exp_t>(re_exp), static_cast<man_t>(re_man) };
+
+    if (n_tuple_elements == 2) {
+        // Two elements in all tuples, also initialize the imaginary part
+        im_sign = GET_SIGN(sign_tuple[1]);
+        if (!nb::try_cast<nb::int_>(exp_tuple[1], im_exp)) {
+            throw nb::value_error("APyCFloat.__init__: exponent is non-integer");
+        }
+        if (!nb::try_cast<nb::int_>(man_tuple[1], im_man)) {
+            throw nb::value_error("APyCFloat.__init__: mantissa is non-integer");
+        }
+        imag() = { im_sign, static_cast<exp_t>(im_exp), static_cast<man_t>(im_man) };
+    }
+}
+
+/* ********************************************************************************** *
+ * *                      Static conversion from other types                        * *
+ * ********************************************************************************** */
 
 APyCFloat APyCFloat::from_number(
     const nb::object& py_obj, int exp_bits, int man_bits, std::optional<exp_t> bias
 )
 {
-    return APyCFloat();
-    // check_exponent_format(exp_bits);
-    // check_mantissa_format(man_bits);
-
-    // if (nb::isinstance<nb::int_>(py_obj)) {
-    //     return APyCFloat::from_integer(
-    //         nb::cast<nb::int_>(py_obj), exp_bits, man_bits, bias
-    //     );
-    // } else if (nb::isinstance<nb::float_>(py_obj)) {
-    //     const auto d = static_cast<double>(nb::cast<nb::float_>(py_obj));
-    //     return APyCFloat::from_double(d, exp_bits, man_bits, bias);
-    // } else {
-    //     const nb::type_object type = nb::cast<nb::type_object>(py_obj.type());
-    //     const nb::str type_string = nb::str(type);
-    //     throw std::domain_error(
-    //         std::string("Non supported type: ") + type_string.c_str()
-    //     );
-    // }
+    if (nb::isinstance<nb::int_>(py_obj)) {
+        const nb::int_& py_int = nb::cast<nb::int_>(py_obj);
+        return APyCFloat::from_integer(py_int, exp_bits, man_bits, bias);
+    } else if (nb::isinstance<nb::float_>(py_obj)) {
+        double d = static_cast<double>(nb::cast<nb::float_>(py_obj));
+        return APyCFloat::from_double(d, exp_bits, man_bits, bias);
+    } else if (nb::isinstance<std::complex<double>>(py_obj)) {
+        std::complex<double> c = nb::cast<std::complex<double>>(py_obj);
+        return APyCFloat::from_complex(c, exp_bits, man_bits, bias);
+    } else if (nb::isinstance<APyFloat>(py_obj)) {
+        exp_t res_bias = bias.value_or(ieee_bias(exp_bits));
+        APyFloatSpec res_spec { std::uint8_t(exp_bits),
+                                std::uint8_t(man_bits),
+                                res_bias };
+        APyFloat c = nb::cast<APyFloat>(py_obj);
+        if (res_spec != c.spec()) {
+            c = c.cast(exp_bits, man_bits, res_bias, QuantizationMode::RND_CONV);
+        }
+        return APyCFloat(c.get_data(), exp_bits, man_bits, res_bias);
+    } else {
+        const nb::type_object type = nb::cast<nb::type_object>(py_obj.type());
+        const nb::str type_string = nb::str(type);
+        throw std::domain_error(
+            std::string("Non supported type: ") + type_string.c_str()
+        );
+    }
 }
 
-// APyCFloat APyCFloat::from_double(
-//     double value, int exp_bits, int man_bits, std::optional<exp_t> bias
-// )
-// {
-//     APyCFloat apytypes_double(
-//         sign_of_double(value), exp_of_double(value), man_of_double(value), 11, 52,
-//         1023
-//     );
-//     return apytypes_double.cast_from_double(
-//         exp_bits, man_bits, bias.value_or(APyCFloat::ieee_bias(exp_bits))
-//     );
-// }
-//
-// APyCFloat APyCFloat::from_integer(
-//     const nb::int_ value, int exp_bits, int man_bits, std::optional<exp_t> bias
-// )
-// {
-//     APyFixed apyfixed = APyFixed::from_unspecified_integer(value);
-//     // Custom version of 'from_fixed' since we know certain properties
-//
-//     const exp_t actual_bias = bias.value_or(APyCFloat::ieee_bias(exp_bits));
-//
-//     if (apyfixed.is_zero()) {
-//         return APyCFloat(0, 0, 0, exp_bits, man_bits, actual_bias);
-//     }
-//
-//     APyCFloat res(exp_bits, man_bits, actual_bias);
-//
-//     // Get sign
-//     if (apyfixed.is_negative()) {
-//         res.sign = true;
-//         apyfixed = apyfixed.abs();
-//     } else {
-//         res.sign = false;
-//     }
-//
-//     // Calculate exponent
-//     const exp_t target_exp
-//         = apyfixed.bits() - apyfixed.leading_zeros() - 1; // The bit width minus 1
-//     std::uint64_t tmp_exp = target_exp + res.bias;
-//
-//     // Calculate mantissa
-//     apyfixed >>= target_exp;
-//     apyfixed = apyfixed.cast(3, man_bits, QuantizationMode::RND_CONV);
-//
-//     // Check for overflow
-//     if (apyfixed.positive_greater_than_equal_pow2(1)) {
-//         ++tmp_exp;
-//         apyfixed >>= 1;
-//     }
-//
-//     // Check for overflow
-//     if (tmp_exp >= res.max_exponent()) {
-//         res.exp = res.max_exponent();
-//         res.man = 0;
-//     } else {
-//         res.exp = tmp_exp;
-//         // Remove leading one
-//         apyfixed = apyfixed - fx_one;
-//         res.man = apyfixed.get_lsbs();
-//     }
-//
-//     return res;
-// }
+APyCFloat APyCFloat::from_double(
+    double value, int exp_bits, int man_bits, std::optional<exp_t> bias
+)
+{
+    check_exponent_format(exp_bits, "APyCFloat.from_float");
+    check_mantissa_format(man_bits, "APyCFloat.from_float");
+
+    APyFloat real(
+        sign_of_double(value), exp_of_double(value), man_of_double(value), 11, 52, 1023
+    );
+
+    const exp_t res_bias = bias.value_or(ieee_bias(exp_bits));
+    return APyCFloat(
+        real.cast_from_double(exp_bits, man_bits, res_bias).get_data(),
+        exp_bits,
+        man_bits,
+        res_bias
+    );
+}
+
+APyCFloat APyCFloat::from_integer(
+    const nb::int_& value, int exp_bits, int man_bits, std::optional<exp_t> bias
+)
+{
+    check_exponent_format(exp_bits, "APyCFloat.from_integer");
+    check_mantissa_format(man_bits, "APyCFloat.from_integer");
+
+    const exp_t res_bias = bias.value_or(ieee_bias(exp_bits));
+    return APyCFloat(
+        APyFloat::from_integer(value, exp_bits, man_bits, res_bias).get_data(),
+        exp_bits,
+        man_bits,
+        res_bias
+    );
+}
+
+APyCFloat APyCFloat::from_complex(
+    std::complex<double> value, int exp_bits, int man_bits, std::optional<exp_t> bias
+)
+{
+    check_exponent_format(exp_bits, "APyCFloat.from_complex");
+    check_mantissa_format(man_bits, "APyCFloat.from_complex");
+
+    const double real = value.real();
+    const double imag = value.imag();
+    const APyFloat apy_real(
+        sign_of_double(real), exp_of_double(real), man_of_double(real), 11, 52, 1023
+    );
+    const APyFloat apy_imag(
+        sign_of_double(imag), exp_of_double(imag), man_of_double(imag), 11, 52, 1023
+    );
+
+    const exp_t res_bias = bias.value_or(ieee_bias(exp_bits));
+    return APyCFloat(
+        apy_real.cast_from_double(exp_bits, man_bits, res_bias).get_data(),
+        apy_imag.cast_from_double(exp_bits, man_bits, res_bias).get_data(),
+        exp_bits,
+        man_bits,
+        res_bias
+    );
+}
+
+APyCFloat APyCFloat::from_fixed(
+    const APyCFixed& fixed, int exp_bits, int man_bits, std::optional<exp_t> opt_bias
+)
+{
+    check_exponent_format(exp_bits, "APyCFloat.from_fixed");
+    check_mantissa_format(man_bits, "APyCFloat.from_fixed");
+
+    const exp_t bias = opt_bias.value_or(ieee_bias(exp_bits));
+    APyFloatData re = floating_point_from_fixed_point(
+        fixed.real_cbegin(), // src_cbegin
+        fixed.real_cend(),   // src_cend
+        fixed.bits(),        // bits
+        fixed.int_bits(),    // int_bits
+        exp_bits,            // exp_bits
+        man_bits,            // man_bits
+        bias                 // bias
+    );
+    APyFloatData im = floating_point_from_fixed_point(
+        fixed.imag_cbegin(), // src_cbegin
+        fixed.imag_cend(),   // src_cend
+        fixed.bits(),        // bits
+        fixed.int_bits(),    // int_bits
+        exp_bits,            // exp_bits
+        man_bits,            // man_bits
+        bias                 // bias
+    );
+
+    return APyCFloat(re, im, exp_bits, man_bits, bias);
+}
+
+APyCFloat APyCFloat::from_fixed(
+    const APyFixed& fixed, int exp_bits, int man_bits, std::optional<exp_t> opt_bias
+)
+{
+    check_exponent_format(exp_bits, "APyCFloat.from_fixed");
+    check_mantissa_format(man_bits, "APyCFloat.from_fixed");
+
+    const exp_t bias = opt_bias.value_or(ieee_bias(exp_bits));
+    APyFloatData re = floating_point_from_fixed_point(
+        std::begin(fixed._data), // src_cbegin_it
+        std::end(fixed._data),   // src_cend_it
+        fixed.bits(),            // bits
+        fixed.int_bits(),        // int_bits
+        exp_bits,                // exp_bits
+        man_bits,                // man_bits
+        bias                     // bias
+    );
+
+    return APyCFloat(re, exp_bits, man_bits, bias);
+}
+
+/* ********************************************************************************** *
+ * *                        Binary comparison operators                             * *
+ * ********************************************************************************** */
+
+bool APyCFloat::operator==(const APyCFloat& rhs) const
+{
+    return APyFloat(real(), exp_bits, man_bits, bias)
+        == APyFloat(rhs.real(), rhs.exp_bits, rhs.man_bits, rhs.bias)
+        && APyFloat(imag(), exp_bits, man_bits, bias)
+        == APyFloat(rhs.imag(), rhs.exp_bits, rhs.man_bits, rhs.bias);
+}
+
+bool APyCFloat::operator!=(const APyCFloat& rhs) const { return !(*this == rhs); }
+
+bool APyCFloat::operator==(const APyFloat& rhs) const
+{
+    return ::is_zero(imag()) && APyFloat(real(), exp_bits, man_bits, bias) == rhs;
+}
+
+bool APyCFloat::operator!=(const APyFloat& rhs) const { return !(*this == rhs); }
+
+bool APyCFloat::operator==(double rhs) const
+{
+    APyFloat rhs_fp(
+        sign_of_double(rhs), exp_of_double(rhs), man_of_double(rhs), 11, 52, 1023
+    );
+    return (*this == rhs_fp);
+}
+
+bool APyCFloat::operator!=(double rhs) const { return !(*this == rhs); }
+
+bool APyCFloat::operator==(const APyCFixed& rhs) const
+{
+    if (is_max_exponent(real(), spec()) || is_max_exponent(imag(), spec())) {
+        return false;
+    }
+
+    return get_real().to_fixed() == rhs.get_real()
+        && get_imag().to_fixed() == rhs.get_imag();
+}
+
+bool APyCFloat::operator!=(const APyCFixed& rhs) const { return !(*this == rhs); }
+
+bool APyCFloat::operator==(const APyFixed& rhs) const
+{
+    if (is_max_exponent(real(), spec())) {
+        return false;
+    }
+
+    return ::is_zero(imag()) && (get_real().to_fixed() == rhs);
+}
+
+bool APyCFloat::operator!=(const APyFixed& rhs) const { return !(*this == rhs); }
+
+/* ********************************************************************************** *
+ * *                        Binary arithmetic operators                             * *
+ * ********************************************************************************** */
+
+APyCFloat APyCFloat::operator+(const APyCFloat& rhs) const
+{
+    const std::uint8_t res_exp_bits = std::max(exp_bits, rhs.exp_bits);
+    const std::uint8_t res_man_bits = std::max(man_bits, rhs.man_bits);
+    const exp_t res_bias = calc_bias(res_exp_bits, spec(), rhs.spec());
+    APyCFloat res(res_exp_bits, res_man_bits, res_bias);
+    QuantizationMode qntz = get_float_quantization_mode();
+
+    // Perform the addition
+    FloatingPointAdder<> add(spec(), rhs.spec(), res.spec(), qntz);
+    add(_data, rhs._data, res._data, /* nitems = */ 2);
+
+    return res;
+}
+
+APyCFloat APyCFloat::operator-(const APyCFloat& rhs) const
+{
+    const std::uint8_t res_exp_bits = std::max(exp_bits, rhs.exp_bits);
+    const std::uint8_t res_man_bits = std::max(man_bits, rhs.man_bits);
+    const exp_t res_bias = calc_bias(res_exp_bits, spec(), rhs.spec());
+    APyCFloat res(res_exp_bits, res_man_bits, res_bias);
+    QuantizationMode qntz = get_float_quantization_mode();
+
+    // Perform the subtraction
+    FloatingPointSubtractor<> sub(spec(), rhs.spec(), res.spec(), qntz);
+    sub(_data, rhs._data, res._data, /* nitems = */ 2);
+
+    return res;
+}
+
+APyCFloat APyCFloat::operator*(const APyCFloat& rhs) const
+{
+    const std::uint8_t res_exp_bits = std::max(exp_bits, rhs.exp_bits);
+    const std::uint8_t res_man_bits = std::max(man_bits, rhs.man_bits);
+    const exp_t res_bias = calc_bias(res_exp_bits, spec(), rhs.spec());
+    APyCFloat res(res_exp_bits, res_man_bits, res_bias);
+    QuantizationMode qntz = get_float_quantization_mode();
+
+    // Perform the product
+    FloatingPointComplexMultiplier<> complex_mul(spec(), rhs.spec(), res.spec(), qntz);
+    complex_mul(_data, rhs._data, res._data);
+
+    return res;
+}
+
+APyCFloat APyCFloat::operator/(const APyCFloat& rhs) const
+{
+    const std::uint8_t res_exp_bits = std::max(exp_bits, rhs.exp_bits);
+    const std::uint8_t res_man_bits = std::max(man_bits, rhs.man_bits);
+    const exp_t res_bias = calc_bias(res_exp_bits, spec(), rhs.spec());
+    APyCFloat res(res_exp_bits, res_man_bits, res_bias);
+    QuantizationMode qntz = get_float_quantization_mode();
+
+    // Perform the division
+    FloatingPointComplexDivider<> complex_div(spec(), rhs.spec(), res.spec(), qntz);
+    complex_div(_data, rhs._data, res._data);
+
+    return res;
+}
+
+APyCFloat APyCFloat::operator-() const
+{
+    APyFloatData real_data = real();
+    APyFloatData imag_data = imag();
+    real_data.sign ^= 1;
+    imag_data.sign ^= 1;
+    return APyCFloat(real_data, imag_data, exp_bits, man_bits, bias);
+}
+
+/* ********************************************************************************** *
+ * *                        Other public member functions                           * *
+ * ********************************************************************************** */
+
+APyCFloat APyCFloat::cast(
+    std::optional<int> new_exp_bits,
+    std::optional<int> new_man_bits,
+    std::optional<exp_t> new_bias,
+    std::optional<QuantizationMode> quantization
+) const
+{
+    const auto actual_exp_bits = new_exp_bits.value_or(exp_bits);
+    const auto actual_man_bits = new_man_bits.value_or(man_bits);
+
+    check_exponent_format(actual_exp_bits, "APyCFloat.cast");
+    check_mantissa_format(actual_man_bits, "APyCFloat.cast");
+
+    return checked_cast(
+        actual_exp_bits,
+        actual_man_bits,
+        new_bias.value_or(ieee_bias(actual_exp_bits)),
+        quantization.value_or(get_float_quantization_mode())
+    );
+}
+
+APyCFloat APyCFloat::checked_cast(
+    std::uint8_t exp_bits, std::uint8_t man_bits, exp_t bias, QuantizationMode qntz
+) const
+{
+    const auto qntz_func = get_qntz_func(qntz);
+    APyCFloat res(exp_bits, man_bits, bias);
+    res.real() = floating_point_cast(real(), spec(), res.spec(), qntz, qntz_func);
+    res.imag() = floating_point_cast(imag(), spec(), res.spec(), qntz, qntz_func);
+    return res;
+}
+
+std::string APyCFloat::repr() const
+{
+    return fmt::format(
+        "APyCFloat(sign=({}, {}), exp=({}, {}), man=({}, {}), exp_bits={}, "
+        "man_bits={}{})",
+        real().sign ? '1' : '0',
+        imag().sign ? '1' : '0',
+        real().exp,
+        imag().exp,
+        real().man,
+        imag().man,
+        exp_bits,
+        man_bits,
+        bias == ieee_bias(exp_bits) ? "" : fmt::format(", bias={}", bias)
+    );
+}
+
+std::complex<double> APyCFloat::to_complex() const
+{
+    return std::complex<double>(
+        APyFloat(real(), exp_bits, man_bits, bias).to_double(),
+        APyFloat(imag(), exp_bits, man_bits, bias).to_double()
+    );
+}
+
+std::string APyCFloat::to_string(int base) const
+{
+    switch (base) {
+    case 8:
+        return to_string_oct();
+        break;
+    case 16:
+        return to_string_hex();
+        break;
+    case 10:
+        return to_string_dec();
+        break;
+    default:
+        throw nb::value_error(
+            fmt::format("APyCFloat::to_string(base={}): base is not supported", base)
+                .c_str()
+        );
+        break;
+    }
+}
+
+std::string APyCFloat::to_string_dec() const
+{
+    // NOTE:
+    // Python, unlike C++, unconditionally encodes the string of a floating-point NaN
+    // without a minus sign.
+    const std::complex<double> cplx = to_complex();
+    const auto& re_str
+        = is_nan(real(), spec()) ? "nan" : fmt::format("{}", cplx.real());
+
+    if (is_nan(imag(), spec())) {
+        return fmt::format("({}+nanj)", re_str);
+    } else {
+        return fmt::format("({}{}{}j)", re_str, imag().sign ? "" : "+", cplx.imag());
+    }
+}
+
+std::string APyCFloat::to_string_hex() const
+{
+    throw NotImplementedException("APyCFloat::to_string_hex()");
+}
+
+std::string APyCFloat::to_string_oct() const
+{
+    throw NotImplementedException("APyCFloat::to_string_oct()");
+}
+
+bool APyCFloat::is_identical(const APyCFloat& other, bool ignore_zero_sign) const
+{
+    if (ignore_zero_sign) {
+        if (is_zero() && other.is_zero()) {
+            return spec() == other.spec();
+        } else if (::is_zero(real()) && ::is_zero(other.real())) {
+            return spec() == other.spec() && imag() == other.imag();
+        } else if (::is_zero(imag()) && ::is_zero(other.imag())) {
+            return spec() == other.spec() && real() == other.real();
+        }
+    }
+
+    return spec() == other.spec() && real() == other.real() && imag() == other.imag();
+}
+
+APyFloat APyCFloat::get_real() const
+{
+    APyFloat result(exp_bits, man_bits, bias);
+    result.set_data(real());
+    return result;
+}
+
+APyFloat APyCFloat::get_imag() const
+{
+    APyFloat result(exp_bits, man_bits, bias);
+    result.set_data(imag());
+    return result;
+}

--- a/src/apycfloat.h
+++ b/src/apycfloat.h
@@ -2,7 +2,11 @@
 #define _APYCFLOAT_H
 
 #include "apyfloat.h"
-#include "apyfloat_util.h"
+#include "nanobind/nanobind.h"
+
+#include <nanobind/stl/complex.h>
+#include <nanobind/stl/optional.h>
+#include <nanobind/stl/variant.h>
 
 class APyCFloat {
 
@@ -17,8 +21,13 @@ private:
     exp_t bias;
 
     // Data of the `APyCFloat`
-    APyFloatData real;
-    APyFloatData imag;
+    APyFloatData _data[2]; // { real, imag }
+
+    // Access real/imag
+    const APyFloatData& real() const noexcept { return _data[0]; }
+    const APyFloatData& imag() const noexcept { return _data[1]; }
+    APyFloatData& real() noexcept { return _data[0]; }
+    APyFloatData& imag() noexcept { return _data[1]; }
 
     /* ****************************************************************************** *
      * *                              CRTP methods                                  * *
@@ -27,26 +36,29 @@ private:
 public:
     //! Copy `n` items from `it` into `*this`
     template <typename RANDOM_ACCESS_ITERATOR>
-    void copy_n_from(RANDOM_ACCESS_ITERATOR src_it, std::size_t n) noexcept
+    void
+    copy_n_from(RANDOM_ACCESS_ITERATOR src_it, [[maybe_unused]] std::size_t n) noexcept
     {
         using iterator_value_type = typename RANDOM_ACCESS_ITERATOR::value_type;
         static_assert(std::is_same_v<iterator_value_type, APyFloatData>);
         assert(n == 2);
 
-        real = src_it[0];
-        imag = src_it[1];
+        real() = src_it[0];
+        imag() = src_it[1];
     }
 
     //! Copy `n` items from `*this` into `it`
     template <typename RANDOM_ACCESS_ITERATOR>
-    void copy_n_to(RANDOM_ACCESS_ITERATOR dst_it, std::size_t n) const noexcept
+    void copy_n_to(
+        RANDOM_ACCESS_ITERATOR dst_it, [[maybe_unused]] std::size_t n
+    ) const noexcept
     {
         using iterator_value_type = typename RANDOM_ACCESS_ITERATOR::value_type;
         static_assert(std::is_same_v<iterator_value_type, APyFloatData>);
         assert(n == 2);
 
-        dst_it[0] = real;
-        dst_it[1] = imag;
+        dst_it[0] = real();
+        dst_it[1] = imag();
     }
 
     //! Test if two floating-point numbers have the same bit specifiers
@@ -56,11 +68,74 @@ public:
             && bias == other.bias;
     }
 
+    //! Retrieve the bit specification
+    APY_INLINE APyFloatSpec spec() const noexcept
+    {
+        return { exp_bits, man_bits, bias };
+    }
+
+    /* ****************************************************************************** *
+     * *                              Constructors                                  * *
+     * ****************************************************************************** */
+
+public:
+    //! Constructor only specifying the format, data fields are initialized to zero
+    APyCFloat(std::uint8_t exp_bits, std::uint8_t man_bits, exp_t bias);
+
+    //! Constructor setting data fields using a struct
+    APyCFloat(
+        const APyFloatData& real_data,
+        std::uint8_t exp_bits,
+        std::uint8_t man_bits,
+        exp_t bias
+    );
+
+    //! Constructor setting data fields using a struct
+    APyCFloat(
+        const APyFloatData& real_data,
+        const APyFloatData& imag_data,
+        std::uint8_t exp_bits,
+        std::uint8_t man_bits,
+        exp_t bias
+    );
+
+    /* ****************************************************************************** *
+     * *                       Python exposed constructors                          * *
+     * ****************************************************************************** */
+
+    //! Zero-initialization from Python type bit-specification
+    APyCFloat(
+        const nb::int_& exp_bits,
+        const nb::int_& man_bits,
+        const std::optional<nb::int_>& bias
+    );
+
+    //! Python constructor setting the real field
+    APyCFloat(
+        const std::variant<nb::bool_, nb::int_>& sign,
+        const nb::int_& exp,
+        const nb::int_& man,
+        const nb::int_& exp_bits,
+        const nb::int_& man_bits,
+        const std::optional<nb::int_>& bias
+    );
+
+    //! Python constructor setting both real and imaginary field
+    APyCFloat(
+        const nb::tuple& sign,
+        const nb::tuple& exp,
+        const nb::tuple& man,
+        const nb::int_& exp_bits,
+        const nb::int_& man_bits,
+        const std::optional<nb::int_>& bias
+    );
+
     /* ****************************************************************************** *
      * *                      Static conversion from other types                    * *
      * ****************************************************************************** */
 
-    //! Create APyCFloat from Python object
+public:
+    //! Create `APyCFloat` from Python object
     static APyCFloat from_number(
         const nb::object& py_obj,
         int exp_bits,
@@ -68,7 +143,7 @@ public:
         std::optional<exp_t> bias = std::nullopt
     );
 
-    //! Create APyCFloat from double
+    //! Create `APyCFloat` from double
     static APyCFloat from_double(
         double value,
         int exp_bits,
@@ -76,13 +151,137 @@ public:
         std::optional<exp_t> bias = std::nullopt
     );
 
-    //! Create APyCFloat from Python integer
+    //! Create `APyCFloat` from Python integer
     static APyCFloat from_integer(
-        const nb::int_ value,
+        const nb::int_& value,
         int exp_bits,
         int man_bits,
         std::optional<exp_t> bias = std::nullopt
     );
+
+    //! Create `APyCFloat` from Python complex
+    static APyCFloat from_complex(
+        std::complex<double> value,
+        int exp_bits,
+        int man_bits,
+        std::optional<exp_t> bias = std::nullopt
+    );
+
+    //! Create `APyCFloat` from `APyCFixed`
+    static APyCFloat from_fixed(
+        const APyCFixed& value,
+        int exp_bits,
+        int man_bits,
+        std::optional<exp_t> bias = std::nullopt
+    );
+
+    //! Create `APyCFloat` from `APyFixed`
+    static APyCFloat from_fixed(
+        const APyFixed& value,
+        int exp_bits,
+        int man_bits,
+        std::optional<exp_t> bias = std::nullopt
+    );
+
+    /* ****************************************************************************** *
+     * *                         Binary comparison operators                        * *
+     * ****************************************************************************** */
+
+public:
+    bool operator==(const APyCFloat& rhs) const;
+    bool operator!=(const APyCFloat& rhs) const;
+
+    bool operator==(const APyFloat& rhs) const;
+    bool operator!=(const APyFloat& rhs) const;
+
+    bool operator==(double rhs) const;
+    bool operator!=(double rhs) const;
+
+    bool operator==(const APyCFixed& rhs) const;
+    bool operator!=(const APyCFixed& rhs) const;
+
+    bool operator==(const APyFixed& rhs) const;
+    bool operator!=(const APyFixed& rhs) const;
+
+    /* ****************************************************************************** *
+     * *                     Unary/binary arithmetic operators                      * *
+     * ****************************************************************************** */
+
+    // Unary negation
+    APyCFloat operator+(const APyCFloat& rhs) const;
+    APyCFloat operator-(const APyCFloat& rhs) const;
+    APyCFloat operator*(const APyCFloat& rhs) const;
+    APyCFloat operator/(const APyCFloat& rhs) const;
+
+    // Unary negation
+    APyCFloat operator-() const;
+    APyCFloat operator+() const { return *this; };
+
+    /* ****************************************************************************** *
+     * *                       Non-computational functions                          * *
+     * ****************************************************************************** */
+
+public:
+    //! Return the bit width of the mantissa field
+    APY_INLINE std::uint8_t get_man_bits() const { return man_bits; }
+
+    //! Return the bit width of the exponent field
+    APY_INLINE std::uint8_t get_exp_bits() const { return exp_bits; }
+
+    //! Return the bit width of the entire floating-point format
+    APY_INLINE std::uint8_t get_bits() const { return man_bits + exp_bits + 1; }
+
+    /* ****************************************************************************** *
+     * *                       Other public member functions                        * *
+     * ****************************************************************************** */
+
+public:
+    //! Retrieve the Python string representation
+    APyCFloat cast(
+        std::optional<int> new_exp_bits,
+        std::optional<int> new_man_bits,
+        std::optional<exp_t> new_bias,
+        std::optional<QuantizationMode> quantization
+    ) const;
+
+    //! Core cast method when it is known that the bit widths are not the same
+    APyCFloat checked_cast(
+        std::uint8_t exp_bits,
+        std::uint8_t man_bits,
+        exp_t bias,
+        QuantizationMode quantization
+    ) const;
+
+    //! Retrieve the Python string representation
+    std::string repr() const;
+
+    //! Conversion to string
+    std::string to_string(int base = 10) const;
+    std::string to_string_hex() const;
+    std::string to_string_oct() const;
+    std::string to_string_dec() const;
+
+    //! Retrieve a `std::complex<double>`
+    std::complex<double> to_complex() const;
+
+    //! Test if two floating-point numbers are identical, i.e., has the same values, the
+    //! same number of exponent bits, and the same number of mantissa bits
+    bool is_identical(const APyCFloat& other, bool ignore_zero_sign = false) const;
+
+    //! Retrieve real part
+    APyFloat get_real() const;
+
+    //! Retrieve imaginary part
+    APyFloat get_imag() const;
+
+    //! Retrieve the bias
+    exp_t get_bias() const noexcept { return bias; }
+
+    //! True if and only if value is zero.
+    APY_INLINE bool is_zero() const
+    {
+        return real().exp == 0 && real().man == 0 && imag().exp == 0 && imag().man == 0;
+    }
 
     /* ****************************************************************************** *
      * *                           Friends of `APyCFloat`                           * *

--- a/src/apycfloat_util.h
+++ b/src/apycfloat_util.h
@@ -1,0 +1,281 @@
+/*
+ * Arithmetic and utility functions for APyTypes complex-valued floating-point types
+ */
+
+#include "apyfloat_util.h"
+#include "apytypes_fwd.h"
+
+#include <cstddef>    // std::size_t
+#include <functional> // std::invoke
+
+/* ********************************************************************************** *
+ * *              Floating-point iterator-based arithmetic functors                 * *
+ * ********************************************************************************** */
+
+template <std::size_t SRC1_INC = 1, std::size_t SRC2_INC = 1, std::size_t DST_INC = 1>
+struct FloatingPointComplexMultiplier {
+    /*
+     * GENERAL COMPLEX-VALUED MULTIPLICATION FORMULA:
+     *
+     *  (a + bi) * (c + di) = (ac - bd) + (ad + bc)i
+     *
+     */
+    explicit FloatingPointComplexMultiplier(
+        const APyFloatSpec& src1_spec,
+        const APyFloatSpec& src2_spec,
+        const APyFloatSpec& dst_spec,
+        const QuantizationMode& qntz
+    )
+        : mul(src1_spec, src2_spec, dst_spec, qntz)
+        , add(dst_spec, dst_spec, dst_spec, qntz)
+        , sub(dst_spec, dst_spec, dst_spec, qntz)
+    {
+    }
+
+    // Perform floating-point complex multiplications
+    void operator()(
+        const APyFloatData* src1,
+        const APyFloatData* src2,
+        APyFloatData* dst,
+        std::size_t nitems = 1
+    ) const
+    {
+        APyFloatData ac, ad, bc, bd;
+        for (std::size_t i = 0; i < nitems; i++) {
+            const APyFloatData* a = src1 + 2 * i * SRC1_INC + 0;
+            const APyFloatData* b = src1 + 2 * i * SRC1_INC + 1;
+            const APyFloatData* c = src2 + 2 * i * SRC2_INC + 0;
+            const APyFloatData* d = src2 + 2 * i * SRC2_INC + 1;
+
+            // Perform partial products: a*c, a*d, b*c, b*d
+            mul(a, c, &ac);
+            mul(a, d, &ad);
+            mul(b, c, &bc);
+            mul(b, d, &bd);
+
+            // Perform additions: ac - bd, ad + bc
+            sub(&ac, &bd, dst + 2 * i * DST_INC + 0);
+            add(&ad, &bc, dst + 2 * i * DST_INC + 1);
+        }
+    }
+
+private:
+    // Set first during functor initialization
+    FloatingPointMultiplier<> mul;
+    FloatingPointAdder<> add;
+    FloatingPointSubtractor<> sub;
+};
+
+template <std::size_t SRC1_INC = 1, std::size_t SRC2_INC = 1, std::size_t DST_INC = 1>
+struct FloatingPointComplexDivider {
+    /*
+     * For valuable information on floating-point complex-valued division arithmetic,
+     * read ``Annex G, IEC 60559-compatibale complex arithmetic'' of the C99 standard:
+     * https://open-std.org/JTC1/SC22/WG14/www/docs/n1256.pdf
+     *
+     * The used complex-valued division formula (algorithm) can be found here:
+     * https://dl.acm.org/doi/pdf/10.1145/368637.368661
+     *
+     * Normalization is especially important to achieve equivilance between real-valued
+     * floating-point division and complex-valued floating-point division of real-valued
+     * operands. Logic for restoring proper NaNs and infs is further needed to have
+     * equivalent behaviour between real-valued and complex-valued divisions.
+     *
+     * GENERAL COMPLEX-VALUED DIVISION FORMULA:
+     *
+     *   a + bi        ac + bd       bc - ad
+     *  --------  =  ----------- + ----------- i
+     *   c + di       c^2 + d^2     c^2 + d^2
+     *
+     */
+    explicit FloatingPointComplexDivider(
+        const APyFloatSpec& src1_spec,
+        const APyFloatSpec& src2_spec,
+        const APyFloatSpec& dst_spec,
+        const QuantizationMode& qntz
+    )
+        : src1_spec(src1_spec)
+        , src2_spec(src2_spec)
+        , dst_spec(dst_spec)
+        , qntz(qntz)
+        , qntz_f(get_qntz_func(qntz))
+        , add(dst_spec, dst_spec, dst_spec, qntz)
+        , sub(dst_spec, dst_spec, dst_spec, qntz)
+        , mul(dst_spec, dst_spec, dst_spec, qntz)
+        , div(dst_spec, dst_spec, dst_spec, qntz)
+    {
+        using F = FloatingPointComplexDivider<SRC1_INC, SRC2_INC, DST_INC>;
+        if (src1_spec == dst_spec && src2_spec == dst_spec) {
+            f = &F::template complex_div</* PROMOTE_RHS = */ false>;
+        } else { /* SUM_MAN_BITS > _MAN_LIMIT_BITS */
+            f = &F::template complex_div</* PROMOTE_RHS = */ true>;
+        }
+    }
+
+    // Perform floating-point complex divisions
+    void operator()(
+        const APyFloatData* src1,
+        const APyFloatData* src2,
+        APyFloatData* dst,
+        std::size_t nitems = 1
+    ) const
+    {
+        std::invoke(f, this, src1, src2, dst, nitems);
+    }
+
+private:
+    // Set first during functor initialization
+    const APyFloatSpec src1_spec, src2_spec, dst_spec;
+    const QuantizationMode qntz;
+
+    // Pointer to quantization function
+    decltype(get_qntz_func(qntz)) qntz_f;
+
+    FloatingPointAdder<> add;
+    FloatingPointSubtractor<> sub;
+    FloatingPointMultiplier<> mul;
+    FloatingPointDivider<> div;
+
+    // Pointer `f` to the correct function based on the floating-point specs
+    void (FloatingPointComplexDivider::*f)(
+        const APyFloatData* src1,
+        const APyFloatData* src2,
+        APyFloatData* dst,
+        std::size_t nitems
+    ) const {};
+
+    template <bool PROMOTE_RHS>
+    void complex_div(
+        const APyFloatData* src1,
+        const APyFloatData* src2,
+        APyFloatData* dst,
+        std::size_t nitems
+    ) const
+    {
+
+        APyFloatData r;
+        APyFloatData den;
+        APyFloatData ar, br, cr, dr;
+        APyFloatData num_real, num_imag;
+
+        for (std::size_t i = 0; i < nitems; i++) {
+            auto caster = floating_point_cast<decltype(get_qntz_func(qntz))>;
+
+            // Operands: a, b, c, d; (a + bi) / (c + di)
+            const APyFloatData& a = PROMOTE_RHS
+                ? caster(
+                      *(src1 + 2 * i * SRC1_INC + 0), src1_spec, dst_spec, qntz, qntz_f
+                  )
+                : *(src1 + 2 * i * SRC1_INC + 0);
+            const APyFloatData& b = PROMOTE_RHS
+                ? caster(
+                      *(src1 + 2 * i * SRC1_INC + 1), src1_spec, dst_spec, qntz, qntz_f
+                  )
+                : *(src1 + 2 * i * SRC1_INC + 1);
+            const APyFloatData& c = PROMOTE_RHS
+                ? caster(
+                      *(src2 + 2 * i * SRC2_INC + 0), src2_spec, dst_spec, qntz, qntz_f
+                  )
+                : *(src2 + 2 * i * SRC2_INC + 0);
+            const APyFloatData& d = PROMOTE_RHS
+                ? caster(
+                      *(src2 + 2 * i * SRC2_INC + 1), src2_spec, dst_spec, qntz, qntz_f
+                  )
+                : *(src2 + 2 * i * SRC2_INC + 1);
+
+            // Destination
+            APyFloatData& dst_real = *(dst + 2 * i * DST_INC + 0);
+            APyFloatData& dst_imag = *(dst + 2 * i * DST_INC + 1);
+
+            if (is_zero(c) && is_zero(d)
+                && (!is_nan(a, src1_spec) || !is_nan(b, src1_spec))) {
+                // This branch should be removed once the zeros and infs recovery logic
+                // is added to floating-point complex division.
+                const exp_t DST_MAX_EXP = exp_t((1ULL << dst_spec.exp_bits) - 1);
+                bool re = a.sign ^ c.sign;
+                bool im = b.sign ^ c.sign;
+                dst_real = { re, DST_MAX_EXP, is_zero(a) || is_nan(a, src1_spec) };
+                dst_imag = { im, DST_MAX_EXP, is_zero(b) || is_nan(b, src1_spec) };
+                continue;
+#if PY_VERSION_HEX >= 0x030E0000
+                /*
+                 * Recovering-zeros-and-infs logic was added to Python in Python 3.14:
+                 * See: ``gh-119372: Recover inf's and zeros in _Py_c_quot (GH-119457)''
+                 * (*) https://github.com/python/cpython/pull/119457
+                 */
+            } else if (is_nan(c, dst_spec) && is_nan(d, dst_spec)) {
+#else
+            } else if (is_nan(c, dst_spec) || is_nan(d, dst_spec)) {
+#endif
+                const exp_t DST_MAX_EXP = exp_t((1ULL << dst_spec.exp_bits) - 1);
+                dst_real = { 0, DST_MAX_EXP, 1 }; // NaN
+                dst_imag = { 0, DST_MAX_EXP, 1 }; // NaN
+                continue;
+            } else if (!floating_point_less_than_abs_same_wl(c, d)) { /* |c| >= |d| */
+                div(d, c, r);
+                mul(a, r, ar);
+                mul(b, r, br);
+                mul(d, r, dr);
+                add(c, dr, den);
+                add(a, br, num_real);
+                sub(b, ar, num_imag);
+                div(num_real, den, dst_real);
+                div(num_imag, den, dst_imag);
+            } else { /* floating_point_less_than_abs_same_wl(c, d) */
+                // |c| < |d|
+                div(c, d, r);
+                mul(a, r, ar);
+                mul(b, r, br);
+                mul(c, r, cr);
+                add(cr, d, den);
+                add(ar, b, num_real);
+                sub(br, a, num_imag);
+                div(num_real, den, dst_real);
+                div(num_imag, den, dst_imag);
+            }
+
+#if PY_VERSION_HEX >= 0x030E0000
+            /*
+             * Recovering-zeros-and-infs logic was added to Python in Python 3.14:
+             * See: ``gh-119372: Recover inf's and zeros in _Py_c_quot (GH-119457)''
+             * (*) https://github.com/python/cpython/pull/119457
+             */
+            if (is_nan(dst_real, dst_spec) && is_nan(dst_imag, dst_spec)) {
+                if ((is_inf(a, dst_spec) || is_inf(b, dst_spec))
+                    && is_finite(c, dst_spec) && is_finite(d, dst_spec)) {
+                    APyFloatData INF = { 0, exp_t((1ULL << dst_spec.exp_bits)) - 1, 0 };
+                    APyFloatData xc, xd, yc, yd, xc_yd, yc_xd;
+                    exp_t x_exp = is_inf(a, dst_spec) ? dst_spec.bias : exp_t(0);
+                    exp_t y_exp = is_inf(b, dst_spec) ? dst_spec.bias : exp_t(0);
+                    APyFloatData x { a.sign, x_exp, 0 };
+                    APyFloatData y { b.sign, y_exp, 0 };
+                    mul(x, c, xc);
+                    mul(y, d, yd);
+                    mul(y, c, yc);
+                    mul(x, d, xd);
+                    add(xc, yd, xc_yd);
+                    sub(yc, xd, yc_xd);
+                    mul(INF, xc_yd, dst_real);
+                    mul(INF, yc_xd, dst_imag);
+                } else if ((is_inf(c, dst_spec) || is_inf(d, dst_spec))
+                           && is_finite(a, dst_spec) && is_finite(b, dst_spec)) {
+                    APyFloatData ZERO = { 0, 0, 0 };
+                    APyFloatData ax, ay, bx, by, ax_by, bx_ay;
+                    exp_t x_exp = is_inf(c, dst_spec) ? dst_spec.bias : exp_t(0);
+                    exp_t y_exp = is_inf(d, dst_spec) ? dst_spec.bias : exp_t(0);
+                    APyFloatData x { c.sign, x_exp, 0 };
+                    APyFloatData y { d.sign, y_exp, 0 };
+                    mul(a, x, ax);
+                    mul(a, y, ay);
+                    mul(b, x, bx);
+                    mul(b, y, by);
+                    add(ax, by, ax_by);
+                    sub(bx, ay, bx_ay);
+                    mul(ZERO, ax_by, dst_real);
+                    mul(ZERO, bx_ay, dst_imag);
+                }
+            }
+#endif
+        }
+    }
+};

--- a/src/apycfloat_wrapper.cc
+++ b/src/apycfloat_wrapper.cc
@@ -1,55 +1,103 @@
+#include "apycfixed.h"
 #include "apycfloat.h"
+#include "apyfixed.h"
 
 #include <nanobind/nanobind.h>
 #include <nanobind/operators.h>
 #include <nanobind/stl/complex.h>
 #include <nanobind/stl/optional.h>
+#include <nanobind/stl/variant.h>
+#include <optional>
+#include <type_traits>
+#include <variant>
 
 namespace nb = nanobind;
 
-// /*
-//  * Binding function of a custom R-operator (e.g., `__rmul__`) with non APyCFloat type
-//  */
-// template <typename OP, typename L_TYPE>
-// static auto R_OP(const APyCFloat& rhs, const L_TYPE& lhs) -> decltype(OP()(rhs, rhs))
-// {
-//     [[maybe_unused]] int exp_bits = rhs.get_exp_bits();
-//     [[maybe_unused]] int man_bits = rhs.get_man_bits();
-//     [[maybe_unused]] exp_t bias = rhs.get_bias();
-//     if constexpr (std::is_floating_point_v<L_TYPE>) {
-//         return OP()(APyCFloat::from_double(lhs, exp_bits, man_bits, bias), rhs);
-//     } else {
-//         return OP()(APyCFloat::from_integer(lhs, exp_bits, man_bits, bias), rhs);
-//     }
-// }
-//
-// /*
-//  * Binding function of a custom L-operator (e.g., `__sub__`) with non APyCFloat type
-//  */
-// template <typename OP, typename R_TYPE>
-// static auto L_OP(const APyCFloat& lhs, const R_TYPE& rhs) -> decltype(OP()(lhs, lhs))
-// {
-//     [[maybe_unused]] int exp_bits = lhs.get_exp_bits();
-//     [[maybe_unused]] int man_bits = lhs.get_man_bits();
-//     [[maybe_unused]] exp_t bias = lhs.get_bias();
-//     if constexpr (std::is_floating_point_v<R_TYPE>) {
-//         return OP()(lhs, APyCFloat::from_double(rhs, exp_bits, man_bits, bias));
-//     } else {
-//         return OP()(lhs, APyCFloat::from_integer(rhs, exp_bits, man_bits, bias));
-//     }
-// }
-//
-// template <typename OP, typename TYPE>
-// static auto UN_OP(const TYPE& in) -> decltype(OP()(in))
-// {
-//     return OP()(in);
-// }
-//
-// template <typename OP, typename L_TYPE, typename R_TYPE>
-// static auto BIN_OP(const L_TYPE& lhs, const R_TYPE& rhs) -> decltype(OP()(lhs, rhs))
-//{
-//    return OP()(lhs, rhs);
-//}
+template <typename T> struct is_complex : public std::false_type { };
+
+template <typename T> struct is_complex<std::complex<T>> : public std::true_type { };
+
+template <typename T> constexpr bool is_complex_v = is_complex<T>::value;
+
+/*
+ * Binding function of a custom R-operator (e.g., `__rmul__`) with non APyCFloat type
+ */
+template <typename OP, typename L_TYPE>
+static auto R_OP(const APyCFloat& rhs, const L_TYPE& lhs) -> decltype(OP()(rhs, rhs))
+{
+    [[maybe_unused]] int exp_bits = rhs.get_exp_bits();
+    [[maybe_unused]] int man_bits = rhs.get_man_bits();
+    [[maybe_unused]] exp_t bias = rhs.get_bias();
+    if constexpr (is_complex_v<L_TYPE>) {
+        return OP()(APyCFloat::from_complex(lhs, exp_bits, man_bits, bias), rhs);
+    } else if constexpr (std::is_floating_point_v<L_TYPE>) {
+        return OP()(APyCFloat::from_double(lhs, exp_bits, man_bits, bias), rhs);
+    } else if constexpr (std::is_same_v<L_TYPE, APyFloat>) {
+        APyFloatData data = lhs.get_data();
+        APyFloatSpec spec = lhs.spec();
+        APyCFloat operand = APyCFloat(data, spec.exp_bits, spec.man_bits, spec.bias);
+        return OP()(operand, rhs);
+    } else if constexpr (std::is_same_v<L_TYPE, APyFixed>) {
+        APyCFloat operand = APyCFloat::from_fixed(lhs, exp_bits, man_bits, bias);
+        return OP()(operand, rhs);
+    } else {
+        return OP()(APyCFloat::from_integer(lhs, exp_bits, man_bits, bias), rhs);
+    }
+}
+
+/*
+ * Binding function of a custom L-operator (e.g., `__sub__`) with non APyCFloat type
+ */
+template <typename OP, typename R_TYPE>
+static auto L_OP(const APyCFloat& lhs, const R_TYPE& rhs) -> decltype(OP()(lhs, lhs))
+{
+    [[maybe_unused]] int exp_bits = lhs.get_exp_bits();
+    [[maybe_unused]] int man_bits = lhs.get_man_bits();
+    [[maybe_unused]] exp_t bias = lhs.get_bias();
+    if constexpr (is_complex_v<R_TYPE>) {
+        return OP()(lhs, APyCFloat::from_complex(rhs, exp_bits, man_bits, bias));
+    } else if constexpr (std::is_floating_point_v<R_TYPE>) {
+        return OP()(lhs, APyCFloat::from_double(rhs, exp_bits, man_bits, bias));
+    } else if constexpr (std::is_same_v<R_TYPE, APyFloat>) {
+        APyFloatData data = rhs.get_data();
+        APyFloatSpec spec = rhs.spec();
+        APyCFloat operand = APyCFloat(data, spec.exp_bits, spec.man_bits, spec.bias);
+        return OP()(lhs, operand);
+    } else if constexpr (std::is_same_v<R_TYPE, APyCFixed>) {
+        APyCFloat operand = APyCFloat::from_fixed(rhs, exp_bits, man_bits, bias);
+        return OP()(lhs, operand);
+    } else if constexpr (std::is_same_v<R_TYPE, APyFixed>) {
+        APyCFloat operand = APyCFloat::from_fixed(rhs, exp_bits, man_bits, bias);
+        return OP()(lhs, operand);
+    } else {
+        return OP()(lhs, APyCFloat::from_integer(rhs, exp_bits, man_bits, bias));
+    }
+}
+
+template <typename OP, typename TYPE>
+static auto UN_OP(const TYPE& in) -> decltype(OP()(in))
+{
+    return OP()(in);
+}
+
+template <typename OP, typename L_TYPE, typename R_TYPE>
+static auto BIN_OP(const L_TYPE& lhs, const R_TYPE& rhs) -> decltype(OP()(lhs, rhs))
+{
+    return OP()(lhs, rhs);
+}
+
+// Mark a non-implicit conversion argument
+#define NARG(name) nb::arg(name).noconvert()
+
+// Mark a special double-underscore marker (e.g., `__add__`). Returns `NotImplemented`
+// rather than raising `TypeError`
+#define IS_OP(args) nb::is_operator(args)
+
+// Short-hand C++ arithmetic functors
+#define ADD std::plus
+#define SUB std::minus
+#define MUL std::multiplies
+#define DIV std::divides
 
 void bind_cfloat(nb::module_& m)
 {
@@ -57,125 +105,218 @@ void bind_cfloat(nb::module_& m)
         /*
          * Constructor
          */
-        // .def(
-        //     "__init__",
-        //     &APyCFloat::create_in_place,
-        //     nb::arg("sign"),
-        //     nb::arg("exp"),
-        //     nb::arg("man"),
-        //     nb::arg("exp_bits"),
-        //     nb::arg("man_bits"),
-        //     nb::arg("bias") = nb::none(),
-        //     R"pbdoc(
-        //     Create an :class:`APyCFloat` object.
+        .def(
+            nb::init<
+                std::variant<nb::bool_, nb::int_>,
+                nb::int_,
+                nb::int_,
+                nb::int_,
+                nb::int_,
+                std::optional<nb::int_>>(),
+            nb::arg("sign"),
+            nb::arg("exp"),
+            nb::arg("man"),
+            nb::arg("exp_bits"),
+            nb::arg("man_bits"),
+            nb::arg("bias") = nb::none(),
+            R"pbdoc(
+            Create an :class:`APyCFloat` object and initialize its real part.
 
-        //     Parameters
-        //     ----------
-        //     sign : :class:`bool` or int
-        //         The sign of the float. False/0 means positive. True/non-zero means
-        //         negative.
-        //     exp : :class:`int`
-        //         Exponent of the float as stored, i.e., actual value + bias.
-        //     man : :class:`int`
-        //         Mantissa of the float as stored, i.e., without a hidden one.
-        //     exp_bits : :class:`int`
-        //         Number of exponent bits.
-        //     man_bits : :class:`int`
-        //         Number of mantissa bits.
-        //     bias : :class:`int`, optional
-        //         Exponent bias. If not provided, *bias* is ``2**exp_bits - 1``.
+            The imaginary part is zero initialized.
 
-        //     Returns
-        //     -------
-        //     :class:`APyCFloat`
-        //     )pbdoc"
-        // )
+            Parameters
+            ----------
+            sign : :class:`bool` or :class:`int`
+                Sign of real part. `True`/non-zero equals negative.
+            exp : :class:`int`
+                Exponent of real part as stored, i.e., actual value + bias.
+            man : :class:`int`
+                Mantissa of the float as stored, i.e., without a hidden one.
+            exp_bits : :class:`int`
+                Number of exponent bits.
+            man_bits : :class:`int`
+                Number of mantissa bits.
+            bias : :class:`int`, optional
+                Exponent bias. If not provided, *bias* is ``2**exp_bits - 1``.
 
-        // /*
-        //  * Arithmetic operations
-        //  */
-        // .def(nb::self == nb::self)
-        // .def(nb::self != nb::self)
-        // .def(nb::self < nb::self)
-        // .def(nb::self > nb::self)
-        // .def(nb::self <= nb::self)
-        // .def(nb::self >= nb::self)
+            Returns
+            -------
+            :class:`APyCFloat`
+            )pbdoc"
+        )
 
-        // .def(nb::self + nb::self)
-        // .def(nb::self - nb::self)
-        // .def(nb::self * nb::self)
-        // .def(nb::self / nb::self)
-        // .def(-nb::self)
+        .def(
+            nb::init<
+                nb::tuple,
+                nb::tuple,
+                nb::tuple,
+                nb::int_,
+                nb::int_,
+                std::optional<nb::int_>>(),
+            nb::arg("sign"),
+            nb::arg("exp"),
+            nb::arg("man"),
+            nb::arg("exp_bits"),
+            nb::arg("man_bits"),
+            nb::arg("bias") = nb::none(),
+            R"pbdoc(
+            Create an :class:`APyCFloat` object and initialize both real and imaginary
+            part.
 
-        // .def("__abs__", &APyCFloat::abs)
-        // .def("__pow__", &APyCFloat::pow)
-        // .def("__pow__", &APyCFloat::pown)
+            Parameters
+            ----------
+            sign : :class:`tuple` of :class:`int` or :class:`bool`
+                Sign of real/imaginary parts. `True`/non-zero equals negative.
+            exp : :class:`tuple` of :class:`int`
+                Exponent of real/imaginary parts as stored, i.e., actual value + bias.
+            man : :class:`tuple` of :class:`int`
+                Mantissa of the real/imaginary parts as stored, i.e., without a hidden
+                one.
+            exp_bits : :class:`int`
+                Number of exponent bits.
+            man_bits : :class:`int`
+                Number of mantissa bits.
+            bias : :class:`int`, optional
+                Exponent bias. If not provided, *bias* is ``2**exp_bits - 1``.
 
-        // .def("__and__", BIN_OP<std::bit_and<>, APyCFloat, APyCFloat>)
-        // .def("__or__", BIN_OP<std::bit_or<>, APyCFloat, APyCFloat>)
-        // .def("__xor__", BIN_OP<std::bit_xor<>, APyCFloat, APyCFloat>)
-        // .def("__invert__", UN_OP<std::bit_not<>, APyCFloat>)
+            Returns
+            -------
+            :class:`APyCFloat`
+            )pbdoc"
+        )
 
-        // /*
-        //  * Arithmetic operations with integers
-        //  */
-        // .def("__add__", L_OP<std::plus<>, nb::int_>, nb::is_operator())
-        // .def("__radd__", R_OP<std::plus<>, nb::int_>, nb::is_operator())
-        // .def("__sub__", L_OP<std::minus<>, nb::int_>, nb::is_operator())
-        // .def("__rsub__", R_OP<std::minus<>, nb::int_>, nb::is_operator())
-        // .def("__mul__", L_OP<std::multiplies<>, nb::int_>, nb::is_operator())
-        // .def("__rmul__", R_OP<std::multiplies<>, nb::int_>, nb::is_operator())
-        // .def("__truediv__", L_OP<std::divides<>, nb::int_>, nb::is_operator())
-        // .def("__rtruediv__", R_OP<std::divides<>, nb::int_>, nb::is_operator())
+        /*
+         * Arithmetic operations
+         */
+        .def(nb::self == nb::self)
+        .def(nb::self != nb::self)
 
-        // /*
-        //  * Arithmetic with floats
-        //  */
-        // .def(nb::self == double())
-        // .def(nb::self != double())
-        // .def(nb::self < double())
-        // .def(nb::self > double())
-        // .def(nb::self <= double())
-        // .def(nb::self >= double())
+        .def(nb::self + nb::self)
+        .def(nb::self - nb::self)
+        .def(nb::self * nb::self)
+        .def(nb::self / nb::self)
+        .def(-nb::self)
+        .def(+nb::self)
 
-        // .def("__add__", L_OP<std::plus<>, double>, nb::is_operator())
-        // .def("__radd__", R_OP<std::plus<>, double>, nb::is_operator())
-        // .def("__sub__", L_OP<std::minus<>, double>, nb::is_operator())
-        // .def("__rsub__", R_OP<std::minus<>, double>, nb::is_operator())
-        // .def("__mul__", L_OP<std::multiplies<>, double>, nb::is_operator())
-        // .def("__rmul__", R_OP<std::multiplies<>, double>, nb::is_operator())
-        // .def("__truediv__", L_OP<std::divides<>, double>, nb::is_operator())
-        // .def("__rtruediv__", R_OP<std::divides<>, double>, nb::is_operator())
+        /*
+         * Arithmetic operations with `int`
+         */
+        .def("__add__", L_OP<ADD<>, nb::int_>, IS_OP(), NARG())
+        .def("__radd__", R_OP<ADD<>, nb::int_>, IS_OP(), NARG())
+        .def("__sub__", L_OP<SUB<>, nb::int_>, IS_OP(), NARG())
+        .def("__rsub__", R_OP<SUB<>, nb::int_>, IS_OP(), NARG())
+        .def("__mul__", L_OP<MUL<>, nb::int_>, IS_OP(), NARG())
+        .def("__rmul__", R_OP<MUL<>, nb::int_>, IS_OP(), NARG())
+        .def("__truediv__", L_OP<DIV<>, nb::int_>, IS_OP(), NARG())
+        .def("__rtruediv__", R_OP<DIV<>, nb::int_>, IS_OP(), NARG())
 
-        // /*
-        //  * Arithmetic operations with APyFixed
-        //  */
-        // .def("__eq__", BIN_OP<std::equal_to<>, APyCFloat, APyFixed>)
-        // .def("__ne__", BIN_OP<std::not_equal_to<>, APyCFloat, APyFixed>)
-        // .def("__le__", BIN_OP<std::less_equal<>, APyCFloat, APyFixed>)
-        // .def("__lt__", BIN_OP<std::less<>, APyCFloat, APyFixed>)
-        // .def("__ge__", BIN_OP<std::greater_equal<>, APyCFloat, APyFixed>)
-        // .def("__gt__", BIN_OP<std::greater<>, APyCFloat, APyFixed>)
+        /*
+         * Arithmetic operations with `APyFloat`
+         */
+        .def("__eq__", BIN_OP<std::equal_to<>, APyCFloat, APyFloat>)
+        .def("__ne__", BIN_OP<std::not_equal_to<>, APyCFloat, APyFloat>)
+
+        .def("__add__", L_OP<ADD<>, APyFloat>, IS_OP(), NARG())
+        .def("__radd__", R_OP<ADD<>, APyFloat>, IS_OP(), NARG())
+        .def("__sub__", L_OP<SUB<>, APyFloat>, IS_OP(), NARG())
+        .def("__rsub__", R_OP<SUB<>, APyFloat>, IS_OP(), NARG())
+        .def("__mul__", L_OP<MUL<>, APyFloat>, IS_OP(), NARG())
+        .def("__rmul__", R_OP<MUL<>, APyFloat>, IS_OP(), NARG())
+        .def("__truediv__", L_OP<DIV<>, APyFloat>, IS_OP(), NARG())
+        .def("__rtruediv__", R_OP<DIV<>, APyFloat>, IS_OP(), NARG())
+
+        /*
+         * Arithmetic operations with `APyFixed`
+         */
+        .def("__eq__", BIN_OP<std::equal_to<>, APyCFloat, APyFixed>)
+        .def("__ne__", BIN_OP<std::not_equal_to<>, APyCFloat, APyFixed>)
+
+        .def("__add__", L_OP<ADD<>, APyFixed>, IS_OP(), NARG())
+        .def("__radd__", R_OP<ADD<>, APyFixed>, IS_OP(), NARG())
+        .def("__sub__", L_OP<SUB<>, APyFixed>, IS_OP(), NARG())
+        .def("__rsub__", R_OP<SUB<>, APyFixed>, IS_OP(), NARG())
+        .def("__mul__", L_OP<MUL<>, APyFixed>, IS_OP(), NARG())
+        .def("__rmul__", R_OP<MUL<>, APyFixed>, IS_OP(), NARG())
+        .def("__truediv__", L_OP<DIV<>, APyFixed>, IS_OP(), NARG())
+        .def("__rtruediv__", R_OP<DIV<>, APyFixed>, IS_OP(), NARG())
+
+        /*
+         * Arithmetic operations with `APyCFixed`
+         */
+        .def("__eq__", BIN_OP<std::equal_to<>, APyCFloat, APyCFixed>)
+        .def("__ne__", BIN_OP<std::not_equal_to<>, APyCFloat, APyCFixed>)
+
+        .def("__add__", L_OP<ADD<>, APyCFixed>, IS_OP(), NARG())
+        .def("__sub__", L_OP<SUB<>, APyCFixed>, IS_OP(), NARG())
+        .def("__mul__", L_OP<MUL<>, APyCFixed>, IS_OP(), NARG())
+        .def("__truediv__", L_OP<DIV<>, APyCFixed>, IS_OP(), NARG())
+
+        /*
+         * Arithmetic with `float`
+         */
+        .def(nb::self == double())
+        .def(nb::self != double())
+
+        .def("__add__", L_OP<ADD<>, double>, IS_OP(), NARG())
+        .def("__radd__", R_OP<ADD<>, double>, IS_OP(), NARG())
+        .def("__sub__", L_OP<SUB<>, double>, IS_OP(), NARG())
+        .def("__rsub__", R_OP<SUB<>, double>, IS_OP(), NARG())
+        .def("__mul__", L_OP<MUL<>, double>, IS_OP(), NARG())
+        .def("__rmul__", R_OP<MUL<>, double>, IS_OP(), NARG())
+        .def("__truediv__", L_OP<DIV<>, double>, IS_OP(), NARG())
+        .def("__rtruediv__", R_OP<DIV<>, double>, IS_OP(), NARG())
+
+        /*
+         * Arithmetic operations with Python `complex`
+         */
+        .def("__add__", L_OP<ADD<>, std::complex<double>>, IS_OP(), NARG())
+        .def("__radd__", R_OP<ADD<>, std::complex<double>>, IS_OP(), NARG())
+        .def("__sub__", L_OP<SUB<>, std::complex<double>>, IS_OP(), NARG())
+        .def("__rsub__", R_OP<SUB<>, std::complex<double>>, IS_OP(), NARG())
+        .def("__mul__", L_OP<MUL<>, std::complex<double>>, IS_OP(), NARG())
+        .def("__rmul__", R_OP<MUL<>, std::complex<double>>, IS_OP(), NARG())
+        .def("__truediv__", L_OP<DIV<>, std::complex<double>>, IS_OP(), NARG())
+        .def("__rtruediv__", R_OP<DIV<>, std::complex<double>>, IS_OP(), NARG())
+
+        /*
+         * Get real and imaginary part
+         */
+        .def_prop_ro("real", &APyCFloat::get_real, R"pbdoc(
+            Real part.
+
+            Returns
+            -------
+            :class:`APyFixed`
+            )pbdoc")
+        .def_prop_ro("imag", &APyCFloat::get_imag, R"pbdoc(
+            Imaginary part.
+
+            Returns
+            -------
+            :class:`APyFixed`
+            )pbdoc")
 
         /*
          * Conversion methods
          */
         .def_static(
-            "from_float",
+            "from_complex",
             &APyCFloat::from_number,
             nb::arg("value"),
             nb::arg("exp_bits"),
             nb::arg("man_bits"),
             nb::arg("bias") = nb::none(),
             R"pbdoc(
-            Create an :class:`APyCFloat` object from an :class:`int` or :class:`float`.
+            Create an :class:`APyCFloat` object from an :class:`int`, :class:`float`, or
+            :class:`complex`.
 
-            The quantization mode used is :class:`QuantizationMode.TIES_EVEN`.
+            The initialize floating-point value is the one closest to `value`. Ties are
+            rounded using :class:`QuantizationMode.TIES_EVEN`.
 
             Parameters
             ----------
-            value : :class:`int`, :class:`float`
-                Floating-point value to initialize from.
+            value : :class:`complex`, :class:`float`, :class:`int`
+                Value to initialize from.
             exp_bits : :class:`int`
                 Number of exponent bits.
             man_bits : :class:`int`
@@ -186,11 +327,12 @@ void bind_cfloat(nb::module_& m)
             Examples
             --------
 
-            >>> from apytypes import APyCFloat
-
-            `a`, initialized from floating-point values.
-
-            >>> a = APyCFloat.from_float(1.35, exp_bits=10, man_bits=15)
+            >>> import apytypes as apy
+            >>> a = apy.APyCFloat.from_complex(1.375, exp_bits=10, man_bits=15)
+            >>> a
+            APyCFloat(sign=(0, 0), exp=(511, 0), man=(12288, 0), exp_bits=10, man_bits=15)
+            >>> str(a)
+            '(1.375+0j)'
 
             Returns
             -------
@@ -198,10 +340,54 @@ void bind_cfloat(nb::module_& m)
 
             See also
             --------
-            from_bits
+            from_complex
             )pbdoc"
         )
-        // .def("__float__", &APyCFloat::operator double)
+        .def_static(
+            "from_float",
+            &APyCFloat::from_number,
+            nb::arg("value"),
+            nb::arg("exp_bits"),
+            nb::arg("man_bits"),
+            nb::arg("bias") = nb::none(),
+            R"pbdoc(
+            Create an :class:`APyCFloat` object from an :class:`int`, :class:`float`, or
+            :class:`complex`.
+
+            The initialize floating-point value is the one closest to `value`. Ties are
+            rounded using :class:`QuantizationMode.TIES_EVEN`.
+
+            Parameters
+            ----------
+            value : int, float, complex
+                Value to initialize from.
+            exp_bits : int
+                Number of exponent bits.
+            man_bits : int
+                Number of mantissa bits.
+            bias : int, optional
+                Exponent bias. If not provided, *bias* is ``2**exp_bits - 1``.
+
+            Examples
+            --------
+
+            >>> import apytypes as apy
+            >>> a = apy.APyCFloat.from_float(1.25, exp_bits=10, man_bits=15)
+            >>> a
+            APyCFloat(sign=(0, 0), exp=(511, 0), man=(8192, 0), exp_bits=10, man_bits=15)
+            >>> str(a)
+            '(1.25+0j)'
+
+            Returns
+            -------
+            :class:`APyCFloat`
+
+            See also
+            --------
+            from_complex
+            )pbdoc"
+        )
+        .def("__complex__", &APyCFloat::to_complex)
         // .def_static(
         //     "from_bits",
         //     &APyCFloat::from_bits,
@@ -227,7 +413,6 @@ void bind_cfloat(nb::module_& m)
         //     --------
 
         //     >>> from apytypes import APyCFloat
-
         //     `a`, initialized to -1.5 from a bit pattern.
 
         //     >>> a = APyCFloat.from_bits(0b1_01111_10, exp_bits=5, man_bits=2)
@@ -249,7 +434,6 @@ void bind_cfloat(nb::module_& m)
         //     --------
 
         //     >>> from apytypes import APyCFloat
-
         //     `a`, initialized to -1.5 from a bit pattern.
 
         //     >>> a = APyCFloat.from_bits(0b1_01111_10, exp_bits=5, man_bits=2)
@@ -266,206 +450,108 @@ void bind_cfloat(nb::module_& m)
         //     --------
         //     from_bits
         //     )pbdoc")
-        // .def("__str__", &APyCFloat::str)
-        // .def("__repr__", &APyCFloat::repr)
+        .def("__str__", &APyCFloat::to_string, nb::arg("base") = 10)
+        .def("__repr__", &APyCFloat::repr)
         // .def("_repr_latex_", &APyCFloat::latex)
-        // .def(
-        //     "cast",
-        //     &APyCFloat::cast,
-        //     nb::arg("exp_bits") = nb::none(),
-        //     nb::arg("man_bits") = nb::none(),
-        //     nb::arg("bias") = nb::none(),
-        //     nb::arg("quantization") = nb::none(),
-        //     R"pbdoc(
-        //     Change format of the floating-point number.
+        .def(
+            "cast",
+            &APyCFloat::cast,
+            nb::arg("exp_bits") = nb::none(),
+            nb::arg("man_bits") = nb::none(),
+            nb::arg("bias") = nb::none(),
+            nb::arg("quantization") = nb::none(),
+            R"pbdoc(
+            Change format of the complex-valued floating-point number.
 
-        //     This is the primary method for performing quantization when dealing with
-        //     APyTypes floating-point numbers.
+            This is the primary method for performing quantization when dealing with
+            APyTypes floating-point numbers.
 
-        //     Parameters
-        //     ----------
-        //     exp_bits : :class:`int`, optional
-        //         Number of exponent bits in the result.
-        //     man_bits : :class:`int`, optional
-        //         Number of mantissa bits in the result.
-        //     bias : :class:`int`, optional
-        //         Exponent bias. If not provided, *bias* is ``2**exp_bits - 1``.
-        //     quantization : :class:`QuantizationMode`, optional.
-        //         Quantization mode to use in this cast. If None, use the global
-        //         quantization mode.
+            Parameters
+            ----------
+            exp_bits : :class:`int`, optional
+                Number of exponent bits in the result.
+            man_bits : :class:`int`, optional
+                Number of mantissa bits in the result.
+            bias : :class:`int`, optional
+                Exponent bias. If not provided, *bias* is ``2**exp_bits - 1``.
+            quantization : :class:`QuantizationMode`, optional.
+                Quantization mode to use in this cast. If None, use the global
+                quantization mode.
 
-        //     Returns
-        //     -------
-        //     :class:`APyCFloat`
+            Returns
+            -------
+            :class:`APyCFloat`
 
-        //     )pbdoc"
-        // )
+            )pbdoc"
+        )
 
-        // /*
-        //  * Non-computational properties
-        //  */
-        // .def_prop_ro("is_zero", &APyCFloat::is_zero, R"pbdoc(
-        //     True if and only if value is zero.
+        /*
+         * Non-computational properties
+         */
+        .def_prop_ro("is_zero", &APyCFloat::is_zero, R"pbdoc(
+            True if, and only if, both the real and imaginary parts are zero.
 
-        //     Returns
-        //     -------
-        //     :class:`bool`
-        //     )pbdoc")
-        // .def_prop_ro("is_normal", &APyCFloat::is_normal, R"pbdoc(
-        //     True if and only if value is normal (not zero, subnormal, infinite, or
-        //     NaN).
+            Returns
+            -------
+            :class:`bool`
+            )pbdoc")
+        .def(
+            "is_identical",
+            &APyCFloat::is_identical,
+            nb::arg("other"),
+            nb::arg("ignore_zero_sign") = false,
+            R"pbdoc(
+            Test if two :py:class:`APyCFloat` objects are identical.
 
-        //     Returns
-        //     -------
-        //     :class:`bool`
-        //     )pbdoc")
-        // .def_prop_ro("is_subnormal", &APyCFloat::is_subnormal, R"pbdoc(
-        //     True if and only if value is subnormal.
+            Two :py:class:`APyCFloat` objects are considered identical if, and only if,
+            they have the same sign, exponent, mantissa, and format.
 
-        //     Returns
-        //     -------
-        //     :class:`bool`
-        //     )pbdoc")
-        // .def_prop_ro("is_finite", &APyCFloat::is_finite, R"pbdoc(
-        //     True if and only if value is zero, subnormal, or normal.
+            Parameters
+            ----------
+            other : :class:`APyCFloat`
+                The floating-point object to test identicality against.
 
-        //     Returns
-        //     -------
-        //     :class:`bool`
-        //     )pbdoc")
-        // .def_prop_ro("is_nan", &APyCFloat::is_nan, R"pbdoc(
-        //     True if and only if value is NaN.
+            ignore_zero_sign : :class:`bool`, default: :code:`False`
+                If :code:`True`, plus and minus zero are considered identical. If
+                :code:`False`, plus and minus zero are considered different.
 
-        //     Returns
-        //     -------
-        //     :class:`bool`
-        //     )pbdoc")
-        // .def_prop_ro("is_inf", &APyCFloat::is_inf, R"pbdoc(
-        //     True if and only if value is infinite.
+            Returns
+            -------
+            :class:`bool`
+            )pbdoc"
+        )
 
-        //     Returns
-        //     -------
-        //     :class:`bool`
-        //     )pbdoc")
-        // .def("is_identical", &APyCFloat::is_identical, nb::arg("other"), R"pbdoc(
-        //     Test if two :py:class:`APyCFloat` objects are identical.
+        /*
+         * Properties
+         */
+        .def_prop_ro("man_bits", &APyCFloat::get_man_bits, R"pbdoc(
+            Number of mantissa bits.
 
-        //     Two :py:class:`APyCFloat` objects are considered identical if, and only
-        //     if,  they have the same sign, exponent, mantissa, and format.
+            Returns
+            -------
+            :class:`int`
+            )pbdoc")
+        .def_prop_ro("exp_bits", &APyCFloat::get_exp_bits, R"pbdoc(
+            Number of exponent bits.
 
-        //     Returns
-        //     -------
-        //     :class:`bool`
-        //     )pbdoc")
+            Returns
+            -------
+            :class:`int`
+            )pbdoc")
+        .def_prop_ro("bits", &APyCFloat::get_bits, R"pbdoc(
+            Total number of bits.
 
-        // /*
-        //  * Properties
-        //  */
-        // .def_prop_ro("sign", &APyCFloat::get_sign, R"pbdoc(
-        //     Sign bit.
+            Returns
+            -------
+            :class:`int`
+            )pbdoc")
+        .def_prop_ro("bias", &APyCFloat::get_bias, R"pbdoc(
+            Exponent bias.
 
-        //     See also
-        //     --------
-        //     true_sign
-
-        //     Returns
-        //     -------
-        //     :class:`bool`
-        //     )pbdoc")
-        // .def_prop_ro(
-        //     "true_sign",
-        //     [](const APyCFloat& rhs) { return rhs.get_sign() ? -1 : 1; },
-        //     R"pbdoc(
-        //     Sign value.
-
-        //     See also
-        //     --------
-        //     sign
-
-        //     Returns
-        //     -------
-        //     :class:`int`
-        //     )pbdoc"
-        // )
-        // .def_prop_ro("man", &APyCFloat::get_man, R"pbdoc(
-        //     Mantissa bits.
-
-        //     These are without a possible hidden one.
-
-        //     See also
-        //     --------
-        //     true_man
-
-        //     Returns
-        //     -------
-        //     :class:`int`
-        //     )pbdoc")
-        // .def_prop_ro("true_man", &APyCFloat::true_man, R"pbdoc(
-        //     Mantissa value.
-
-        //     These are with a possible hidden one.
-
-        //     See also
-        //     --------
-        //     man
-
-        //     Returns
-        //     -------
-        //     :class:`int`
-        //     )pbdoc")
-        // .def_prop_ro("exp", &APyCFloat::get_exp, R"pbdoc(
-        //     Exponent bits with bias.
-
-        //     See also
-        //     --------
-        //     true_exp
-
-        //     Returns
-        //     -------
-        //     :class:`int`
-        //     )pbdoc")
-        // .def_prop_ro("true_exp", &APyCFloat::true_exp, R"pbdoc(
-        //     Exponent value.
-
-        //     The bias value is subtracted and exponent adjusted in case of
-        //     a subnormal number.
-
-        //     See also
-        //     --------
-        //     exp
-
-        //     Returns
-        //     -------
-        //     :class:`int`
-        //     )pbdoc")
-        // .def_prop_ro("bias", &APyCFloat::get_bias, R"pbdoc(
-        //     Exponent bias.
-
-        //     Returns
-        //     -------
-        //     :class:`int`
-        //     )pbdoc")
-        // .def_prop_ro("man_bits", &APyCFloat::get_man_bits, R"pbdoc(
-        //     Number of mantissa bits.
-
-        //     Returns
-        //     -------
-        //     :class:`int`
-        //     )pbdoc")
-        // .def_prop_ro("exp_bits", &APyCFloat::get_exp_bits, R"pbdoc(
-        //     Number of exponent bits.
-
-        //     Returns
-        //     -------
-        //     :class:`int`
-        //     )pbdoc")
-        // .def_prop_ro("bits", &APyCFloat::get_bits, R"pbdoc(
-        //     Total number of bits.
-
-        //     Returns
-        //     -------
-        //     :class:`int`
-        //     )pbdoc")
+            Returns
+            -------
+            :class:`int`
+            )pbdoc")
 
         // /*
         //  * Convenience methods
@@ -550,32 +636,5 @@ void bind_cfloat(nb::module_& m)
         //         see :func:`get_float_quantization_mode`, is used.
         //     )pbdoc"
         // )
-        // .def("next_up", &APyCFloat::next_up, R"pbdoc(
-        //     Get the smallest floating-point number in the same format that compares
-        //     greater.
-
-        //     See also
-        //     --------
-        //     next_down
-
-        //     Returns
-        //     -------
-        //     :class:`APyCFloat`
-
-        //     )pbdoc")
-        // .def("next_down", &APyCFloat::next_down, R"pbdoc(
-        //     Get the largest floating-point number in the same format that compares
-        //     less.
-
-        //     See also
-        //     --------
-        //     next_up
-
-        //     Returns
-        //     -------
-        //     :class:`APyCFloat`
-
-        //     )pbdoc")
-
         ;
 }

--- a/src/apyfixed.cc
+++ b/src/apyfixed.cc
@@ -857,8 +857,7 @@ APyFixed APyFixed::from_number(
     } else if (nb::isinstance<nb::float_>(py_obj)) {
         const auto d = static_cast<double>(nb::cast<nb::float_>(py_obj));
         return APyFixed::from_double(d, int_bits, frac_bits, bits);
-    } else if (nb::isinstance<APyFixed>(py_obj
-               )) { // One should really use `cast` instead
+    } else if (nb::isinstance<APyFixed>(py_obj)) {
         const auto d = static_cast<APyFixed>(nb::cast<APyFixed>(py_obj));
         return d.cast(
             int_bits, frac_bits, QuantizationMode::RND_INF, OverflowMode::WRAP, bits

--- a/src/apyfixed.h
+++ b/src/apyfixed.h
@@ -409,6 +409,9 @@ public:
     friend class APyCFixed;
     friend class APyFixedArray;
     friend class APyCFixedArray;
+    friend class APyFloat;
+    friend class APyCFloat;
+
     template <typename T, typename ARRAY_TYPE> friend class APyArray;
 
 }; // end: class APyFixed

--- a/src/apyfloatarray_wrapper.cc
+++ b/src/apyfloatarray_wrapper.cc
@@ -387,7 +387,7 @@ void bind_float_array(nb::module_& m)
 
             Array `lhs` (2 x 3 matrix), initialized from floating-point values.
 
-            >>> lhs = APyFloatArray.from_float(
+            >>> lhs = apy.APyFloatArray.from_float(
             ...     [
             ...         [1.0, 2.0, 3.0],
             ...         [4.0, 5.0, 6.0],

--- a/src/apytypes_common.cc
+++ b/src/apytypes_common.cc
@@ -193,8 +193,8 @@ APyFloatAccumulatorContext::APyFloatAccumulatorContext(
         );
     }
 
-    check_exponent_format(exp_bits.value());
-    check_mantissa_format(man_bits.value());
+    check_exponent_format(exp_bits.value(), "APyFloatAccumulatorContext");
+    check_mantissa_format(man_bits.value(), "APyFloatAccumulatorContext");
 
     new_mode.exp_bits = exp_bits.value();
     new_mode.man_bits = man_bits.value();

--- a/src/apytypes_fwd.h
+++ b/src/apytypes_fwd.h
@@ -123,6 +123,10 @@ struct APyFloatSpec {
         return std::make_tuple(exp_bits, man_bits, bias)
             == std::make_tuple(other.exp_bits, other.man_bits, other.bias);
     }
+    bool operator!=(const APyFloatSpec& other) const noexcept
+    {
+        return !(*this == other);
+    }
 };
 
 #endif

--- a/src/apytypes_mp.h
+++ b/src/apytypes_mp.h
@@ -50,7 +50,7 @@ typedef std::int64_t apy_limb_signed_t;
 /*
  * Sizes of APy limbs (underlying words)
  */
-//! Number of bits in a char, as defined by Posix
+//! Number of bits in a char, as defined by POSIX
 #define POSIX_CHAR_BITS 8
 //! Number of bytes in a limb
 constexpr std::size_t APY_LIMB_SIZE_BYTES = sizeof(apy_limb_t);

--- a/src/apytypes_util.h
+++ b/src/apytypes_util.h
@@ -1044,7 +1044,7 @@ template <class RANDOM_ACCESS_ITERATOR_IN>
 }
 
 //! Take the two's complement absolute value of a limb vector and place onto `res_out`.
-//! Return `true` if the argument is negative
+//! Return `true` if the argument is negative, and `false` otherwise.
 template <class RANDOM_ACCESS_ITERATOR_IN, class RANDOM_ACCESS_ITERATOR_OUT>
 [[maybe_unused]] static APY_INLINE bool limb_vector_abs(
     RANDOM_ACCESS_ITERATOR_IN cbegin_it,


### PR DESCRIPTION
# PR Summary
This PR adds the scalar complex-valued floating-point type `APyCFloat`.

# PR Checklist

- N/A "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] new and changed code is tested
- [x] relevant changes added to [CHANGELOG.md](https://github.com/apytypes/apytypes/blob/main/CHANGELOG.md)
- [x] new functionality is documented
