### PR TITLE
Avoid casting Python ints to floats in APyFixedArray.from_*

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   has multiple of 64 bits.
 - Incorrect fixed-point rounding in `APyFixedArray.from_array` on Windows.
 - Incorrect LaTeX-representation of negative fixed-point scalars.
+- Incorrect casting of large integers in `APyFixedArray.from_*`.
 
 ### Changed
 

--- a/lib/test/apyfixed/test_methods.py
+++ b/lib/test/apyfixed/test_methods.py
@@ -275,7 +275,7 @@ def test_from_float_with_non_floats():
     )
 
     # Test long integer (256 bits)
-    int_val = 0xFF_FF_FF_FF_FF_FF_FF_FF_FF_FF_FF_FF_FF_FF_FF_FF_FF_FF_FF_FF_FF_FF_FF_FF_FF_FF_FF_FF_FF_FF_FF_FF
+    int_val = 2**257 - 1
     assert APyFixed.from_float(int_val, 257, 0).is_identical(
         APyFixed(int_val, int_bits=257, frac_bits=0)
     )

--- a/lib/test/apyfixedarray/test_constructors.py
+++ b/lib/test/apyfixedarray/test_constructors.py
@@ -59,6 +59,17 @@ def test_array_floating_point_construction(fixed_array):
     b = fixed_array.from_float([100, -200, -300, -400], bits=4, frac_bits=0)
     assert a.is_identical(b)
 
+    # Python long integer (256 bits)
+    int_val = 2**257 - 1
+    assert fixed_array.from_float([int_val], bits=257, int_bits=257).is_identical(
+        fixed_array([int_val], bits=257, int_bits=257)
+    )
+
+    int_val = 2**64 - 1
+    assert fixed_array.from_float([int_val], bits=65, int_bits=65).is_identical(
+        fixed_array([int_val], bits=65, int_bits=65)
+    )
+
     ##
     # From APyFloat
     #
@@ -138,6 +149,12 @@ def test_numpy_creation(fixed_array, dt):
         anp = np.array([[1, 2, 3, 4]], dtype=dt)
     a = fixed_array.from_float(anp, 5, 4)
     assert np.all(a.to_numpy() == anp.astype(np.double))
+
+    if dt == "uint64":
+        anp = np.asarray([2**64 - 1], dtype=dt)
+        assert fixed_array.from_array(anp, bits=65, int_bits=65).is_identical(
+            fixed_array([2**64 - 1], bits=65, int_bits=65)
+        )
 
 
 @pytest.mark.parametrize("fixed_array", [APyFixedArray, APyCFixedArray])

--- a/src/apyfixed.cc
+++ b/src/apyfixed.cc
@@ -896,25 +896,14 @@ APyFixed APyFixed::from_integer(
     std::optional<int> bits
 )
 {
-    // Extract things bit widths
-    const int res_bits = bits_from_optional(bits, int_bits, frac_bits);
-    const int res_int_bits = int_bits.has_value() ? *int_bits : *bits - *frac_bits;
-
-    APyFixed result(res_bits, res_int_bits);
-    result._data = python_long_to_limb_vec(value, result._data.size());
-
-    // Adjust the number
-    if (result.frac_bits() > 0) {
-        limb_vector_lsl(result._data.begin(), result._data.end(), result.frac_bits());
-    } else { /* result.frac_bits() <= 0 */
-        limb_vector_asr(result._data.begin(), result._data.end(), -result.frac_bits());
-    }
-
-    // Two's-complements overflow bits outside of the range
-    _overflow_twos_complement(
-        result._data.begin(), result._data.end(), res_bits, res_int_bits
+    APyFixed result(int_bits, frac_bits, bits);
+    fixed_point_from_py_integer(
+        value,
+        std::begin(result._data),
+        std::end(result._data),
+        result._bits,
+        result._int_bits
     );
-
     return result;
 }
 

--- a/src/apyfloat_util.h
+++ b/src/apyfloat_util.h
@@ -73,8 +73,8 @@ apyfloat_to_bits(const APyFloatData& d, std::uint8_t exp_bits, std::uint8_t man_
 [[maybe_unused]] static APY_INLINE exp_t
 calc_bias(int new_exp_bits, int exp_bits1, exp_t bias1, int exp_bits2, exp_t bias2)
 {
-    auto s1 = (bias1 + 1) << (new_exp_bits - exp_bits1);
-    auto s2 = (bias2 + 1) << (new_exp_bits - exp_bits2);
+    const auto s1 = (bias1 + 1) << (new_exp_bits - exp_bits1);
+    const auto s2 = (bias2 + 1) << (new_exp_bits - exp_bits2);
     return ((s1 + s2) >> 1) - 1;
 }
 


### PR DESCRIPTION
<!--
Thank you so much for your PR!
-->

Python integers are currently casted to floats as an intermediate step in `from_float` and `from_array`, thus causing issues for large integers. This PR solves that.

MRE:
```Python
import numpy as np
from apytypes import APyFixed, APyFixedArray

num =  2**64 - 1 # 18446744073709551615

APyFixedArray([num], bits=65, int_bits=65) # APyFixedArray([18446744073709551615], shape=(1,), bits=65, int_bits=65)
APyFixedArray.from_float([num], bits=65, int_bits=65) # APyFixedArray([9223372036854775808], shape=(1,), bits=65, int_bits=65)
nparr = np.asarray(num, dtype=np.uint64)
APyFixedArray.from_array(nparr, bits=65, int_bits=65) # APyFixedArray([9223372036854775808], shape=(1,), bits=65, int_bits=65)
```

TODOs:
- [x] `from_float`
- [x] `from_array`
- [x] Complex versions

# PR Checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

- [N/A] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] new and changed code is tested
- [x] relevant changes added to [CHANGELOG.md](https://github.com/apytypes/apytypes/blob/main/CHANGELOG.md)
- [N/A] new functionality is documented
