### PR TITLE
Fix overflow in fixed-point to float conversion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Incorrect accumulation in `APyFixedArray.cumsum()` and
   `APyCFixedArray.cumsum()` when result has more limbs than source.
 - Crash in `sum`, `cumsum`, `prod`, and `cumprod` for empty arrays.
+- Fixed-point to floating-point conversion properly rounds to `+-inf`.
 
 ### Changed
 

--- a/lib/test/apyfixed/test_methods.py
+++ b/lib/test/apyfixed/test_methods.py
@@ -76,6 +76,28 @@ def test_to_float():
     # 1/4 of the greatest negative subnormal number, rounds towards zero
     assert float(APyFixed(-1, int_bits=0, frac_bits=1076)) == 0.0
 
+    ##
+    # Infinities
+    #
+    assert float(APyFixed(2**1030, int_bits=1100, frac_bits=5)) == float("inf")
+    assert float(APyFixed(2**1035, int_bits=1031, frac_bits=5)) == float("-inf")
+
+    from sys import float_info
+
+    fxp_float_max = APyFixed.from_float(+float_info.max, int_bits=2000, frac_bits=0)
+    fxp_float_min = APyFixed.from_float(-float_info.max, int_bits=2000, frac_bits=0)
+    assert float(fxp_float_max) == +float_info.max
+    assert float(fxp_float_min) == -float_info.max
+
+    # Rounds away from zero
+    assert float(fxp_float_max + 2 ** (1023 - 53) + 1) == float("inf")
+    assert float(fxp_float_max + 2 ** (1023 - 53) + 0) == float("inf")
+    assert float(fxp_float_max + 2 ** (1023 - 53) - 1) == float_info.max
+
+    assert float(fxp_float_min - 2 ** (1023 - 53) + 1) == -float_info.max
+    assert float(fxp_float_min - 2 ** (1023 - 53) + 0) == float("-inf")
+    assert float(fxp_float_min - 2 ** (1023 - 53) - 1) == float("-inf")
+
 
 def test_from_float():
     ##

--- a/src/apyfixed_util.h
+++ b/src/apyfixed_util.h
@@ -1490,7 +1490,14 @@ fixed_point_to_double(RANDOM_ACCESS_IT begin_it, RANDOM_ACCESS_IT end_it, int fr
             int right_shift_n = -left_shift_n;
             int rnd_pow2 = right_shift_n - 1;
             limb_vector_add_pow2(std::begin(man_vec), std::end(man_vec), rnd_pow2);
-            limb_vector_lsr(std::begin(man_vec), std::end(man_vec), right_shift_n);
+
+            int pow2 = right_shift_n + 53;
+            if (limb_vector_gte_pow2(std::begin(man_vec), std::end(man_vec), pow2)) {
+                exp++;
+                limb_vector_lsr(std::begin(man_vec), std::end(man_vec), rnd_pow2);
+            } else {
+                limb_vector_lsr(std::begin(man_vec), std::end(man_vec), right_shift_n);
+            }
         }
         man = man_vec[0];
 
@@ -1524,11 +1531,24 @@ fixed_point_to_double(RANDOM_ACCESS_IT begin_it, RANDOM_ACCESS_IT end_it, int fr
             int right_shift_n = -left_shift_n;
             int rnd_pow2 = right_shift_n - 1;
             limb_vector_add_pow2(std::begin(man_vec), std::end(man_vec), rnd_pow2);
-            limb_vector_lsr(std::begin(man_vec), std::end(man_vec), right_shift_n);
+
+            int pow2 = right_shift_n + 53;
+            if (limb_vector_gte_pow2(std::begin(man_vec), std::end(man_vec), pow2)) {
+                exp++;
+                limb_vector_lsr(std::begin(man_vec), std::end(man_vec), rnd_pow2);
+            } else {
+                limb_vector_lsr(std::begin(man_vec), std::end(man_vec), right_shift_n);
+            }
         }
 
         man = uint64_t(man_vec[0]);
         man |= uint64_t(man_vec[1]) << 32;
+    }
+
+    // Check for overflow to infinity
+    if (exp >= 2047) {
+        exp = 2047;
+        man = 0;
     }
 
     // Return the result


### PR DESCRIPTION
<!--
Thank you so much for your PR!
-->

# PR Summary
<!-- Please provide at least 1-2 sentences describing the pull request in detail
(Why is this change required?  What problem does it solve?) and link to relevant
issues and PRs.
-->
This PR fixes overflow to infinity when casting `APyFixed*` to float, and thus closes #511.

*This PR is not ready as there is a failing test case. The test intends to check that a fixed-point number can round to infinity. Either there is a case missing when rounding the mantissa (as the exponent does not seem to be updated), or the test case is wrong. Can you take a look @miklhh?*

# PR Checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

- [x] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] new and changed code is tested
- [x] relevant changes added to [CHANGELOG.md](https://github.com/apytypes/apytypes/blob/main/CHANGELOG.md)
- [N/A] new functionality is documented
