### PR TITLE
Add convenience methods 'inf' and 'nan' for APyFloat

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `inf` and `nan` functions to create floating-point objects initialized
+  to infinity or NaN.
+
 ### Fixed
 
 ### Changed

--- a/docs/api/apyfloat.rst
+++ b/docs/api/apyfloat.rst
@@ -33,6 +33,13 @@
    Convenience methods
    -------------------
 
+   Creation
+   ^^^^^^^^
+
+   .. automethod:: inf
+
+   .. automethod:: nan
+
    Casting
    ^^^^^^^
 

--- a/lib/apytypes/_apytypes.pyi
+++ b/lib/apytypes/_apytypes.pyi
@@ -3582,6 +3582,74 @@ class APyFloat:
         :class:`APyFloat`
         """
 
+    @staticmethod
+    def inf(exp_bits: int, man_bits: int, bias: int | None = None) -> APyFloat:
+        """
+        Create an :class:`APyFloat` object that is initialized to positive infinity.
+
+        versionadded:: 0.4
+
+        Parameters
+        ----------
+        exp_bits : :class:`int`
+            Number of exponent bits.
+        man_bits : :class:`int`
+            Number of mantissa bits.
+        bias : :class:`int`, optional
+            Exponent bias. If not provided, *bias* is ``2**exp_bits - 1``.
+
+        Examples
+        --------
+
+        >>> import apytypes as apy
+
+        `a`, initialized to positive infinity.
+
+        >>> a = apy.APyFloat.inf(exp_bits=10, man_bits=15)
+
+        Returns
+        -------
+        :class:`APyFloat`
+
+        See also
+        --------
+        nan
+        """
+
+    @staticmethod
+    def nan(exp_bits: int, man_bits: int, bias: int | None = None) -> APyFloat:
+        """
+        Create an :class:`APyFloat` object that is initialized to NaN.
+
+        versionadded:: 0.4
+
+        Parameters
+        ----------
+        exp_bits : :class:`int`
+            Number of exponent bits.
+        man_bits : :class:`int`
+            Number of mantissa bits.
+        bias : :class:`int`, optional
+            Exponent bias. If not provided, *bias* is ``2**exp_bits - 1``.
+
+        Examples
+        --------
+
+        >>> import apytypes as apy
+
+        `a`, initialized to NaN.
+
+        >>> a = apy.APyFloat.nan(exp_bits=10, man_bits=15)
+
+        Returns
+        -------
+        :class:`APyFloat`
+
+        See also
+        --------
+        inf
+        """
+
 class APyFloatAccumulatorContext(ContextManager):
     """
     Context for using custom accumulators when performing inner products and matrix multiplications.

--- a/lib/test/apyfloat/test_methods.py
+++ b/lib/test/apyfloat/test_methods.py
@@ -506,3 +506,40 @@ def test_python_deepcopy():
     assert a is b
     c = copy.deepcopy(a)
     assert a is not c
+
+
+@pytest.mark.parametrize("func", ["inf", "nan"])
+def test_inf_nan_creation(func):
+    #
+    # Test raises
+
+    # Too many exponent bits
+    with pytest.raises(
+        ValueError,
+        match="Exponent bits must be a non-negative integer less or equal to .. but 300 was given",
+    ):
+        eval(f"APyFloat.{func}(300, 5)")
+    with pytest.raises(
+        ValueError,
+        match="Exponent bits must be a non-negative integer less or equal to .. but -300 was given",
+    ):
+        eval(f"APyFloat.{func}(-300, 5)")
+    # Too many mantissa bits
+    with pytest.raises(
+        ValueError,
+        match="Mantissa bits must be a non-negative integer less or equal to .. but 300 was given",
+    ):
+        eval(f"APyFloat.{func}(5, 300)")
+    with pytest.raises(
+        ValueError,
+        match="Mantissa bits must be a non-negative integer less or equal to .. but -300 was given",
+    ):
+        eval(f"APyFloat.{func}(5, -300)")
+
+    #
+    # Test actual operation
+    x = eval(f"APyFloat.{func}(5, 7, 8)")
+    assert x.is_identical(APyFloat.from_float(float(func), 5, 7, 8))
+
+    x = eval(f"APyFloat.{func}(4, 3)")
+    assert x.is_identical(APyFloat.from_float(float(func), 4, 3, 7))

--- a/src/apyfloat.cc
+++ b/src/apyfloat.cc
@@ -1405,3 +1405,19 @@ APyFloat APyFloat::next_down() const
     }
     return APyFloat(0, exp, new_man, exp_bits, man_bits, bias);
 }
+
+APyFloat APyFloat::inf(int exp_bits, int man_bits, std::optional<exp_t> bias)
+{
+    check_exponent_format(exp_bits);
+    check_mantissa_format(man_bits);
+    const exp_t exp = (1 << exp_bits) - 1;
+    return APyFloat(0, exp, 0, exp_bits, man_bits, bias);
+}
+
+APyFloat APyFloat::nan(int exp_bits, int man_bits, std::optional<exp_t> bias)
+{
+    check_exponent_format(exp_bits);
+    check_mantissa_format(man_bits);
+    const exp_t exp = (1 << exp_bits) - 1;
+    return APyFloat(0, exp, 1, exp_bits, man_bits, bias);
+}

--- a/src/apyfloat.h
+++ b/src/apyfloat.h
@@ -475,6 +475,12 @@ public:
     APyFloat next_up() const;
     //! Get the largest floating-point number in the same format that compares less.
     APyFloat next_down() const;
+    //! Create an APyFloat object that is initialized to positive infinity.
+    static APyFloat
+    inf(int exp_bits, int man_bits, std::optional<exp_t> bias = std::nullopt);
+    //! Create an APyFloat object that is initialized to NaN.
+    static APyFloat
+    nan(int exp_bits, int man_bits, std::optional<exp_t> bias = std::nullopt);
 
     /* ****************************************************************************** *
      * *                              Helper functions                              * *

--- a/src/apyfloat_wrapper.cc
+++ b/src/apyfloat_wrapper.cc
@@ -593,5 +593,83 @@ void bind_float(nb::module_& m)
             -------
             :class:`APyFloat`
 
-            )pbdoc");
+            )pbdoc")
+        .def_static(
+            "inf",
+            &APyFloat::inf,
+            nb::arg("exp_bits"),
+            nb::arg("man_bits"),
+            nb::arg("bias") = nb::none(),
+            R"pbdoc(
+            Create an :class:`APyFloat` object that is initialized to positive infinity.
+
+            versionadded:: 0.4
+
+            Parameters
+            ----------
+            exp_bits : :class:`int`
+                Number of exponent bits.
+            man_bits : :class:`int`
+                Number of mantissa bits.
+            bias : :class:`int`, optional
+                Exponent bias. If not provided, *bias* is ``2**exp_bits - 1``.
+
+            Examples
+            --------
+
+            >>> import apytypes as apy
+
+            `a`, initialized to positive infinity.
+
+            >>> a = apy.APyFloat.inf(exp_bits=10, man_bits=15)
+
+            Returns
+            -------
+            :class:`APyFloat`
+
+            See also
+            --------
+            nan
+
+            )pbdoc"
+        )
+        .def_static(
+            "nan",
+            &APyFloat::nan,
+            nb::arg("exp_bits"),
+            nb::arg("man_bits"),
+            nb::arg("bias") = nb::none(),
+            R"pbdoc(
+            Create an :class:`APyFloat` object that is initialized to NaN.
+
+            versionadded:: 0.4
+
+            Parameters
+            ----------
+            exp_bits : :class:`int`
+                Number of exponent bits.
+            man_bits : :class:`int`
+                Number of mantissa bits.
+            bias : :class:`int`, optional
+                Exponent bias. If not provided, *bias* is ``2**exp_bits - 1``.
+
+            Examples
+            --------
+
+            >>> import apytypes as apy
+
+            `a`, initialized to NaN.
+
+            >>> a = apy.APyFloat.nan(exp_bits=10, man_bits=15)
+
+            Returns
+            -------
+            :class:`APyFloat`
+
+            See also
+            --------
+            inf
+
+            )pbdoc"
+        );
 }


### PR DESCRIPTION
<!--
Thank you so much for your PR!
-->

# PR Summary
<!-- Please provide at least 1-2 sentences describing the pull request in detail
(Why is this change required?  What problem does it solve?) and link to relevant
issues and PRs.
-->

This PR adds the convenience methods `inf` and `nan` to `APyFloat`, making it simple to create infinity and NaN of a given format. 

# PR Checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

- [N/A] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] new and changed code is tested
- [x] relevant changes added to [CHANGELOG.md](https://github.com/apytypes/apytypes/blob/main/CHANGELOG.md)
- [x] new functionality is documented
