### PR TITLE
Fix bug in APyFloat add/sub

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Bug in `APyFloat` addition/substraction when the exponent difference was larger
+- than 64, introduced in v0.3.0.
+
 ### Changed
 
 ### Removed

--- a/lib/test/apyfloat/test_arithmetic.py
+++ b/lib/test/apyfloat/test_arithmetic.py
@@ -324,6 +324,31 @@ def test_sub_diff_exp(lhs, rhs):
 
 
 @pytest.mark.float_sub
+@pytest.mark.parametrize("t", [0, 2])
+def test_sub_large_exponent_diff(t):
+    # 't' is used to test the case where the word lengths don't match
+
+    # Exponent difference larger than 64
+    b = 127
+    lhs = APyFloat(sign=0, exp=2, man=6193994, exp_bits=8, man_bits=23)
+    rhs = APyFloat(sign=1, exp=142 + t, man=65471, exp_bits=8, man_bits=23, bias=b + t)
+    ref = APyFloat(
+        sign=1, exp=142 + t // 2, man=65471, exp_bits=8, man_bits=23, bias=b + t // 2
+    )
+    res = lhs + rhs
+    assert res.is_identical(ref)
+
+    # Exponent difference equal to 64
+    lhs = APyFloat(sign=1, exp=191, man=983040, exp_bits=8, man_bits=23)
+    rhs = APyFloat(sign=1, exp=127 + t, man=57343, exp_bits=8, man_bits=23, bias=b + t)
+    ref = APyFloat(
+        sign=1, exp=191 + t // 2, man=983040, exp_bits=8, man_bits=23, bias=b + t // 2
+    )
+    res = lhs + rhs
+    assert res.is_identical(ref)
+
+
+@pytest.mark.float_sub
 def test_sub_diff_sign():
     # Subtract two numbers that have different sign
     # 12 - -4

--- a/src/apyfloat_util.h
+++ b/src/apyfloat_util.h
@@ -663,6 +663,8 @@ template <
     const unsigned exp_delta = new_exp - y.exp - (y.exp == 0);
     if (exp_delta <= 3) {
         my_aligned = my >> exp_delta;
+    } else if (exp_delta >= _MAN_T_SIZE_BITS) {
+        my_aligned = (my != 0);
     } else {
         bool round_bit = ((my << (_MAN_T_SIZE_BITS - exp_delta)) != 0);
         my_aligned = (my >> exp_delta) | round_bit;
@@ -786,6 +788,8 @@ template <
     const unsigned exp_delta = true_exp(x_wide, x_spec) - true_exp(y_wide, y_spec);
     if (exp_delta <= 3) {
         my_aligned = my >> exp_delta;
+    } else if (exp_delta >= _MAN_T_SIZE_BITS) {
+        my_aligned = (my != 0);
     } else {
         bool round_bit = ((my << (_MAN_T_SIZE_BITS - exp_delta)) != 0);
         my_aligned = (my >> exp_delta) | round_bit;


### PR DESCRIPTION
<!--
Thank you so much for your PR!
-->

# PR Summary
<!-- Please provide at least 1-2 sentences describing the pull request in detail
(Why is this change required?  What problem does it solve?) and link to relevant
issues and PRs.
-->
Fix bug in floating-point addition/subtraction that occurred when the exponent difference was larger or equal to 64.

It was found by running the Berkeley TestFloat script. From using `git bisect`, it was introduced in ae53f0b but didn't trigger any test cases. New test cases have therefore been added. 

# PR Checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

- [N/A] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] new and changed code is tested
- [x] relevant changes added to [CHANGELOG.md](https://github.com/apytypes/apytypes/blob/main/CHANGELOG.md)
- [N/A] new functionality is documented
