### PR TITLE
Implement `fma` and `fmac` for `APyFloat`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `inf` and `nan` functions to create floating-point objects initialized
   to infinity or NaN.
+- `fma` and `fmac`, i.e. fused multiply-add and fused multiply-accumulate for `APyFloat`
 
 ### Fixed
 

--- a/lib/apytypes/_apytypes.pyi
+++ b/lib/apytypes/_apytypes.pyi
@@ -3127,6 +3127,53 @@ class APyFloat:
     def __pow__(self, arg: APyFloat, /) -> APyFloat: ...
     @overload
     def __pow__(self, arg: int, /) -> APyFloat: ...
+    @staticmethod
+    def fma(x: APyFloat, y: APyFloat, z: APyFloat) -> APyFloat:
+        """
+        Fused multiply-add, i.e. calculate (x * y) + z using only one quantization step.
+
+        versionadded:: 0.4
+
+        Parameters
+        ----------
+        x : :class:`APyFloat`
+            Floating-point x.
+        y : :class:`APyFloat`
+            Floating-point y.
+        z : :class:`APyFloat`
+            Floating-point z.
+
+        Returns
+        -------
+        :class:`APyFloat`
+
+        See also
+        --------
+        fmac
+        """
+
+    def fmac(self, x: APyFloat, y: APyFloat) -> APyFloat:
+        """
+        Fused multiply-accumulate, i.e. add x * y to the current value using only one quantization step.
+
+        versionadded:: 0.4
+
+        Parameters
+        ----------
+        x : :class:`APyFloat`
+            Floating-point x.
+        y : :class:`APyFloat`
+            Floating-point y.
+
+        Returns
+        -------
+        :class:`APyFloat`
+
+        See also
+        --------
+        fma
+        """
+
     def __and__(self, arg: APyFloat, /) -> APyFloat: ...
     def __or__(self, arg: APyFloat, /) -> APyFloat: ...
     def __xor__(self, arg: APyFloat, /) -> APyFloat: ...

--- a/src/apyfloat.h
+++ b/src/apyfloat.h
@@ -159,7 +159,8 @@ public:
         APyFixed value,
         int exp_bits,
         int man_bits,
-        std::optional<exp_t> bias = std::nullopt
+        std::optional<exp_t> bias = std::nullopt,
+        std::optional<QuantizationMode> quantization = std::nullopt
     );
     //! Cast to `double`
     double to_double() const;
@@ -309,6 +310,10 @@ public:
     static APyFloat pow(const APyFloat& x, const APyFloat& y);
     //! Power function with integer exponent
     static APyFloat pown(const APyFloat& x, int n);
+    //! Fused-multiply add
+    static APyFloat fma(const APyFloat& x, const APyFloat& y, const APyFloat& z);
+    //! Fused-multiply accumulate
+    APyFloat& fmac(const APyFloat& x, const APyFloat& y);
 
     /* ****************************************************************************** *
      * *                         Binary comparison operators                        * *

--- a/src/apyfloat_util.h
+++ b/src/apyfloat_util.h
@@ -78,6 +78,8 @@ calc_bias(int new_exp_bits, int exp_bits1, exp_t bias1, int exp_bits2, exp_t bia
     return ((s1 + s2) >> 1) - 1;
 }
 
+//! Calculate new bias. Assumes new_exp_bits is larger than the exp_bits of spec1 and
+//! spec2.
 [[maybe_unused]] static APY_INLINE exp_t
 calc_bias(int new_exp_bits, const APyFloatSpec& spec1, const APyFloatSpec& spec2)
 {

--- a/src/apyfloat_wrapper.cc
+++ b/src/apyfloat_wrapper.cc
@@ -130,6 +130,62 @@ void bind_float(nb::module_& m)
         .def("__pow__", &APyFloat::pow)
         .def("__pow__", &APyFloat::pown)
 
+        .def_static(
+            "fma",
+            &APyFloat::fma,
+            nb::arg("x"),
+            nb::arg("y"),
+            nb::arg("z"),
+            R"pbdoc(
+            Fused multiply-add, i.e. calculate (x * y) + z using only one quantization step.
+
+            versionadded:: 0.4
+
+            Parameters
+            ----------
+            x : :class:`APyFloat`
+                Floating-point x.
+            y : :class:`APyFloat`
+                Floating-point y.
+            z : :class:`APyFloat`
+                Floating-point z.
+
+            Returns
+            -------
+            :class:`APyFloat`
+
+            See also
+            --------
+            fmac
+            )pbdoc"
+        )
+        .def(
+            "fmac",
+            &APyFloat::fmac,
+            nb::arg("x"),
+            nb::arg("y"),
+            R"pbdoc(
+            Fused multiply-accumulate, i.e. add x * y to the current value using only one quantization step.
+
+            versionadded:: 0.4
+
+            Parameters
+            ----------
+            x : :class:`APyFloat`
+                Floating-point x.
+            y : :class:`APyFloat`
+                Floating-point y.
+
+            Returns
+            -------
+            :class:`APyFloat`
+
+            See also
+            --------
+            fma
+            )pbdoc"
+        )
+
         .def("__and__", BIN_OP<std::bit_and<>, APyFloat, APyFloat>)
         .def("__or__", BIN_OP<std::bit_or<>, APyFloat, APyFloat>)
         .def("__xor__", BIN_OP<std::bit_xor<>, APyFloat, APyFloat>)

--- a/src/apyfloatarray.cc
+++ b/src/apyfloatarray.cc
@@ -490,7 +490,10 @@ APyFloatArray APyFloatArray::arange(
 
     for (std::size_t i = 0; i < apy_vals.size(); i++) {
         result._data[i]
-            = APyFloat::from_fixed(apy_vals[i], exp_bits, man_bits, bias).get_data();
+            = APyFloat::from_fixed(
+                  apy_vals[i], exp_bits, man_bits, bias, QuantizationMode::RND_CONV
+            )
+                  .get_data();
     }
 
     return result;
@@ -1050,7 +1053,10 @@ APyFloatArray APyFloatArray::from_numbers(
         } else if (nb::isinstance<APyFixed>(py_obj[i])) {
             const auto d = static_cast<APyFixed>(nb::cast<APyFixed>(py_obj[i]));
             result._data[i]
-                = APyFloat::from_fixed(d, exp_bits, man_bits, bias).get_data();
+                = APyFloat::from_fixed(
+                      d, exp_bits, man_bits, bias, QuantizationMode::RND_CONV
+                )
+                      .get_data();
         } else if (nb::isinstance<APyFloat>(py_obj[i])) {
             const auto d = static_cast<APyFloat>(nb::cast<APyFloat>(py_obj[i]));
             result._data[i]


### PR DESCRIPTION
<!--
Thank you so much for your PR!
-->

# PR Summary
<!-- Please provide at least 1-2 sentences describing the pull request in detail
(Why is this change required?  What problem does it solve?) and link to relevant
issues and PRs.
-->
Implement fused multiply-add (`fma`) and fused multiply-accumulate (`fmac`) in `APyFloat`. Closes #98.

The plan in this PR is to implement the slow path first, as it is the easiest, and then add the fast path.
To help ensure correctness, the script for Berkeley TestFloat will be extended to include test case generation for `fma`.

# PR Checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

- [x] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [ ] new and changed code is tested
- [x] relevant changes added to [CHANGELOG.md](https://github.com/apytypes/apytypes/blob/main/CHANGELOG.md)
- [ ] new functionality is documented
