### PR TITLE
src: make unsafe fixed-point casting explicit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Array `__repr__` methods.
   - Array `__str__` methods.
 - Improved type hints for APyArray methods.
+- Bug in `APyFixedArray.from_float` when converting from `APyFixed` (issue #683).
 
 ### Changed
 

--- a/lib/test/apyfixedarray/test_methods.py
+++ b/lib/test/apyfixedarray/test_methods.py
@@ -1259,3 +1259,27 @@ def test_array_is_not_identical_to_scalar(
     assert not fixed_array.from_float([-2.5], 10, 10).is_identical(
         fixed_scalar.from_float(-2.5, 10, 10)
     )
+
+
+@pytest.mark.parametrize(
+    ("fixed_array", "fixed_scalar"),
+    [
+        (APyFixedArray, APyFixed),
+        (APyCFixedArray, APyCFixed),
+    ],
+)
+def test_issue_683(fixed_array: type[APyCFixedArray], fixed_scalar: type[APyCFixed]):
+    a = fixed_scalar.from_float(3, int_bits=15, frac_bits=60)
+    b = fixed_scalar.from_float(3, int_bits=15, frac_bits=62)
+    c = b.cast(int_bits=7, frac_bits=30)
+    d = b.cast(int_bits=7, frac_bits=31)
+
+    arr0 = fixed_array.from_float([a], int_bits=7, frac_bits=30)
+    arr1 = fixed_array.from_float([b], int_bits=7, frac_bits=31)
+    arr2 = fixed_array.from_float([c], int_bits=7, frac_bits=30)
+    arr3 = fixed_array.from_float([d], int_bits=7, frac_bits=31)
+
+    assert arr0[0].is_identical(fixed_scalar.from_float(3, int_bits=7, frac_bits=30))
+    assert arr1[0].is_identical(fixed_scalar.from_float(3, int_bits=7, frac_bits=31))
+    assert arr2[0].is_identical(fixed_scalar.from_float(3, int_bits=7, frac_bits=30))
+    assert arr3[0].is_identical(fixed_scalar.from_float(3, int_bits=7, frac_bits=31))

--- a/src/apycfixed.cc
+++ b/src/apycfixed.cc
@@ -616,7 +616,7 @@ APyCFixed APyCFixed::cast(
     APyCFixed result(std::max(new_bits, _bits), new_int_bits);
 
     // Real part
-    _cast(
+    fixed_point_cast_unsafe(
         real_begin(),
         real_end(),
         result.real_begin(),
@@ -630,7 +630,7 @@ APyCFixed APyCFixed::cast(
     );
 
     // Imaginary part
-    _cast(
+    fixed_point_cast_unsafe(
         imag_begin(),
         imag_end(),
         std::begin(result._data) + bits_to_limbs(new_bits),
@@ -677,7 +677,7 @@ APyCFixed APyCFixed::from_number(
     } else if (nb::isinstance<APyFixed>(py_obj)) {
         APyCFixed result(int_bits, frac_bits, bits);
         const auto d = static_cast<APyFixed>(nb::cast<APyFixed>(py_obj));
-        _cast(
+        fixed_point_cast_unsafe(
             std::begin(d._data),
             std::end(d._data),
             result.real_begin(),
@@ -693,7 +693,7 @@ APyCFixed APyCFixed::from_number(
     } else if (nb::isinstance<APyFloat>(py_obj)) {
         APyCFixed result(int_bits, frac_bits, bits);
         const auto d = static_cast<APyFloat>(nb::cast<APyFloat>(py_obj)).to_fixed();
-        _cast(
+        fixed_point_cast_unsafe(
             std::begin(d._data),
             std::end(d._data),
             result.real_begin(),

--- a/src/apycfixedarray.cc
+++ b/src/apycfixedarray.cc
@@ -1050,9 +1050,9 @@ APyCFixedArray APyCFixedArray::cast(
     std::size_t pad_limbs = bits_to_limbs(std::max(new_bits, _bits)) - result_limbs;
     APyCFixedArray::vector_type result_data(_nitems * 2 * result_limbs + pad_limbs);
 
-    // Do the casting
+    // Do the casting: `fixed_point_cast_unsafe` is safe to use because of `pad_limbs`
     for (std::size_t i = 0; i < 2 * _nitems; i++) {
-        _cast(
+        fixed_point_cast_unsafe(
             std::begin(_data) + (i + 0) * _itemsize / 2,
             std::begin(_data) + (i + 1) * _itemsize / 2,
             std::begin(result_data) + (i + 0) * result_limbs,
@@ -1325,7 +1325,7 @@ APyCFixedArray APyCFixedArray::from_complex(
             );
         } else if (nb::isinstance<APyFixed>(py_obj[i])) {
             const auto d = static_cast<APyFixed>(nb::cast<APyFixed>(py_obj[i]));
-            _cast(
+            fixed_point_cast(
                 std::begin(d._data),
                 std::end(d._data),
                 std::begin(result._data) + i * result._itemsize,
@@ -1340,7 +1340,7 @@ APyCFixedArray APyCFixedArray::from_complex(
         } else if (nb::isinstance<APyFloat>(py_obj[i])) {
             const auto d
                 = static_cast<APyFloat>(nb::cast<APyFloat>(py_obj[i])).to_fixed();
-            _cast(
+            fixed_point_cast(
                 std::begin(d._data),
                 std::end(d._data),
                 std::begin(result._data) + i * result._itemsize,
@@ -1354,7 +1354,7 @@ APyCFixedArray APyCFixedArray::from_complex(
             );
         } else if (nb::isinstance<APyCFixed>(py_obj[i])) {
             const auto d = static_cast<APyCFixed>(nb::cast<APyCFixed>(py_obj[i]));
-            _cast(
+            fixed_point_cast(
                 d.real_begin(),
                 d.real_end(),
                 result.real_begin() + i * result._itemsize,
@@ -1366,7 +1366,7 @@ APyCFixedArray APyCFixedArray::from_complex(
                 QuantizationMode::RND_INF,
                 OverflowMode::WRAP
             );
-            _cast(
+            fixed_point_cast(
                 d.imag_begin(),
                 d.imag_end(),
                 result.imag_begin() + i * result._itemsize,

--- a/src/apyfixed.cc
+++ b/src/apyfixed.cc
@@ -1007,7 +1007,7 @@ APyFixed APyFixed::cast(
 
     // Result that temporarily can hold all the necessary bits
     APyFixed result(std::max(new_bits, _bits), new_int_bits);
-    _cast(
+    fixed_point_cast_unsafe(
         std::begin(_data),
         std::end(_data),
         std::begin(result._data),


### PR DESCRIPTION
# PR Summary
This PR makes the unsafe (fast-path) fixed-point casting function explicit by renaming it `fixed_point_cast_unsafe`. This PR also introduces a safe fixed-point casting function `fixed_point_cast` that can be used safely at any time.

Closes #683.

## PR Checklist

- [X] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] new and changed code is tested
- [X] relevant changes added to [CHANGELOG.md](https://github.com/apytypes/apytypes/blob/main/CHANGELOG.md)
- [N/A] new functionality is documented
