### PR TITLE
src: support more Numpy types during construction

### DIFF
--- a/lib/test/apycfixed/test_constructors.py
+++ b/lib/test/apycfixed/test_constructors.py
@@ -26,3 +26,34 @@ def test_raises():
 def test_constructor():
     assert APyCFixed((0x14,), int_bits=4, frac_bits=4) == 1.25
     assert APyCFixed((0x00, 0x14), int_bits=4, frac_bits=4) == 0.0 + 1.25j
+
+
+def test_from_float():
+    np = pytest.importorskip("numpy")
+    types = [
+        np.float16,
+        np.float32,
+        np.float64,
+        np.int8,
+        np.int16,
+        np.int32,
+        np.int64,
+        np.uint8,
+        np.uint16,
+        np.uint32,
+        np.uint64,
+    ]
+    for t in types:
+        a = APyCFixed.from_float(t(125), int_bits=30, frac_bits=30)
+        assert a.is_identical(APyCFixed.from_complex(125, int_bits=30, frac_bits=30))
+
+
+def test_from_complex():
+    np = pytest.importorskip("numpy")
+    types = [
+        np.complex64,
+        np.complex128,
+    ]
+    for t in types:
+        a = APyCFixed.from_float(t(923.75), int_bits=30, frac_bits=30)
+        assert a.is_identical(APyCFixed.from_complex(923.75, int_bits=30, frac_bits=30))

--- a/lib/test/apycfloat/test_constructors.py
+++ b/lib/test/apycfloat/test_constructors.py
@@ -92,3 +92,32 @@ def test_from_complex():
     assert APyCFloat.from_complex(
         APyCFixed.from_complex(-4, int_bits=10, frac_bits=8), exp_bits=10, man_bits=8
     ).is_identical(APyCFloat((True, 0), (2**9 + 1, 0), (0, 0), exp_bits=10, man_bits=8))
+
+    np = pytest.importorskip("numpy")
+    types = [
+        np.complex64,
+        np.complex128,
+    ]
+    for t in types:
+        a = APyCFloat.from_float(t(923.75), exp_bits=11, man_bits=52)
+        assert a.is_identical(APyCFloat.from_complex(923.75, exp_bits=11, man_bits=52))
+
+
+def test_from_float():
+    np = pytest.importorskip("numpy")
+    types = [
+        np.float16,
+        np.float32,
+        np.float64,
+        np.int8,
+        np.int16,
+        np.int32,
+        np.int64,
+        np.uint8,
+        np.uint16,
+        np.uint32,
+        np.uint64,
+    ]
+    for t in types:
+        a = APyCFloat.from_float(t(125), exp_bits=11, man_bits=52)
+        assert a.is_identical(APyCFloat.from_complex(125, exp_bits=11, man_bits=52))

--- a/src/apyfixedarray.cc
+++ b/src/apyfixedarray.cc
@@ -1363,16 +1363,15 @@ APyFixedArray APyFixedArray::from_numbers(
 
     // Extract all Python doubles and integers
     auto py_objs = python_sequence_walk<nb::float_, nb::int_, APyFixed, APyFloat>(
-        number_seq, "APyFixedArray.from_complex"
+        number_seq, "APyFixedArray.from_float"
     );
 
     // Iterate over objects and set in fixed-point array
     for (std::size_t i = 0; i < result._nitems; i++) {
         if (nb::isinstance<nb::float_>(py_objs[i])) {
             // Python double object
-            double d = static_cast<double>(nb::cast<nb::float_>(py_objs[i]));
             fixed_point_from_double(
-                d,
+                static_cast<double>(nb::cast<nb::float_>(py_objs[i])),
                 std::begin(result._data) + (i + 0) * result._itemsize,
                 std::begin(result._data) + (i + 1) * result._itemsize,
                 result._bits,


### PR DESCRIPTION
# PR Summary

Support some more Numpy types when constructing APyTypes types.

Closes #706

## PR Checklist

- [x] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] new and changed code is tested
- [N/A] relevant changes added to [CHANGELOG.md](https://github.com/apytypes/apytypes/blob/main/CHANGELOG.md)
- [N/A] new functionality is documented
