### PR TITLE
build: add option `b_ndebug=if-release`

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1,8 +1,15 @@
 project(
     'apytypes',
     'cpp', 'c',
-    default_options : ['cpp_std=c++17', 'c_std=c17', 'b_lto=true'],
-    version : run_command(find_program('python3'), '-m', 'setuptools_scm', check: true).stdout().strip(),
+    default_options : [
+      'cpp_std=c++17',
+      'c_std=c17',
+      'b_lto=true',
+      'b_ndebug=if-release',
+    ],
+    version : run_command(
+      find_program('python3'), '-m', 'setuptools_scm', check: true
+    ).stdout().strip(),
     meson_version : '>=1.1',
 )
 


### PR DESCRIPTION
# PR Summary

Closes #709 

```
  apytypes 0.4.0.dev25+gc99152b7.d20250609

    Subprojects
      fmt         : YES
      highway     : YES
      nanobind    : YES
      robin-map   : YES (from nanobind)

    User defined options
      Native files: /tmp/apytypes/.mesonpy-za2_7xts/meson-python-native-file.ini
--->  b_ndebug    : if-release
      b_vscrt     : md
      buildtype   : release
```

## PR Checklist

- [X] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [N/A] new and changed code is tested
- [N/A] relevant changes added to [CHANGELOG.md](https://github.com/apytypes/apytypes/blob/main/CHANGELOG.md)
- [N/A] new functionality is documented
