### PR TITLE
src: specialize `fixed_point_from_double()` for single limbs

### DIFF
--- a/.github/workflows/tests-debug-memcheck.yml
+++ b/.github/workflows/tests-debug-memcheck.yml
@@ -22,6 +22,8 @@ jobs:
   build:
     strategy:
       fail-fast: false
+      matrix:
+        limb-size: ["32", "64"]
     runs-on: "ubuntu-24.04"
 
     steps:
@@ -42,8 +44,9 @@ jobs:
     - name: Install APyTypes (debug mode)
       run: |
         git fetch --tags
-        python -m pip install -e . -v --no-build-isolation  \
-          -Csetup-args=-Dbuildtype=debug                    \
+        python -m pip install -e . -v --no-build-isolation   \
+          -Csetup-args='-Dbuildtype=debug'                   \
+          -Csetup-args='-Dlimb_size=${{ matrix.limb-size }}' \
           -Cbuild-dir=build-dbg
     - name: Run the test suite in Valgrind memcheck
       run: |

--- a/lib/test/apyfixed/test_constructors.py
+++ b/lib/test/apyfixed/test_constructors.py
@@ -11,17 +11,17 @@ def test_construction_raises():
     """
     # Zero-bit fixed-point numbers can not be created
     with pytest.raises(ValueError, match="Fixed-point bit specification needs a"):
-        APyFixed(0, bits=0, int_bits=0)
+        _ = APyFixed(0, bits=0, int_bits=0)
 
     # Exactly two of three bit-specifiers needs to be set when creating `APyFixed`
     with pytest.raises(ValueError, match="Fixed-point bit specification needs exactly"):
-        APyFixed(0, bits=1, int_bits=0, frac_bits=0)
+        _ = APyFixed(0, bits=1, int_bits=0, frac_bits=0)
     with pytest.raises(ValueError, match="Fixed-point bit specification needs exactly"):
-        APyFixed(0, frac_bits=1)
+        _ = APyFixed(0, frac_bits=1)
     with pytest.raises(ValueError, match="Fixed-point bit specification needs exactly"):
-        APyFixed(0, int_bits=1)
+        _ = APyFixed(0, int_bits=1)
     with pytest.raises(ValueError, match="Fixed-point bit specification needs exactly"):
-        APyFixed(0, bits=1)
+        _ = APyFixed(0, bits=1)
 
 
 def test_constructor():
@@ -134,21 +134,19 @@ def test_string_construction():
     )
 
     with pytest.raises(ValueError, match="Not a valid decimal numeric string"):
-        APyFixed.from_str("Foo", 4, 4)
+        _ = APyFixed.from_str("Foo", 4, 4)
 
 
-def test_incorrect_double_construction():
+@pytest.mark.parametrize("bits", [4, 8, 100, 2000])
+def test_incorrect_double_construction(bits: int):
     with pytest.raises(ValueError, match="Cannot convert nan to fixed-point"):
-        APyFixed.from_float(float("NaN"), 4, 4)
-
+        _ = APyFixed.from_float(float("NaN"), bits=bits, frac_bits=4)
     with pytest.raises(ValueError, match="Cannot convert inf to fixed-point"):
-        APyFixed.from_float(float("inf"), 4, 4)
-
+        _ = APyFixed.from_float(float("inf"), bits=bits, frac_bits=4)
     with pytest.raises(ValueError, match="Cannot convert nan to fixed-point"):
-        APyFixed.from_float(APyFloat(0, 15, 3, 4, 3), 4, 4)
-
+        _ = APyFixed.from_float(APyFloat(0, 15, 3, 4, 3), bits=bits, frac_bits=4)
     with pytest.raises(ValueError, match="Cannot convert inf to fixed-point"):
-        APyFixed.from_float(APyFloat(0, 15, 0, 4, 3), 4, 4)
+        _ = APyFixed.from_float(APyFloat(0, 15, 0, 4, 3), bits=bits, frac_bits=4)
 
 
 def test_issue_487():

--- a/src/apycfixed.cc
+++ b/src/apycfixed.cc
@@ -738,9 +738,21 @@ APyCFixed APyCFixed::from_double(
 )
 {
     APyCFixed result(int_bits, frac_bits, bits);
-    fixed_point_from_double(
-        value, result.real_begin(), result.real_end(), result._bits, result._int_bits
-    );
+    if (result._data.size() == 2) {
+        unsigned shift = 64 - (result._bits & (64 - 1));
+        int frac_bits = result.frac_bits();
+        result._data[0] = fixed_point_from_double_single_limb(value, frac_bits, shift);
+    } else {
+        assert(result._data.size() >= 4);
+        assert(result._data.size() % 2 == 0);
+        fixed_point_from_double(
+            value,
+            result.real_begin(),
+            result.real_end(),
+            result._bits,
+            result._int_bits
+        );
+    }
     return result;
 }
 
@@ -784,12 +796,21 @@ APyCFixed APyCFixed::from_complex(
     APyCFixed result(int_bits, frac_bits, bits);
     double real = value.real();
     double imag = value.imag();
-    fixed_point_from_double(
-        real, result.real_begin(), result.real_end(), result._bits, result._int_bits
-    );
-    fixed_point_from_double(
-        imag, result.imag_begin(), result.imag_end(), result._bits, result._int_bits
-    );
+    if (result._data.size() == 2) {
+        unsigned shift = 64 - (result._bits & (64 - 1));
+        int frac_bits = result.frac_bits();
+        result._data[0] = fixed_point_from_double_single_limb(real, frac_bits, shift);
+        result._data[1] = fixed_point_from_double_single_limb(imag, frac_bits, shift);
+    } else {
+        assert(result._data.size() >= 4);
+        assert(result._data.size() % 2 == 0);
+        fixed_point_from_double(
+            real, result.real_begin(), result.real_end(), result._bits, result._int_bits
+        );
+        fixed_point_from_double(
+            imag, result.imag_begin(), result.imag_end(), result._bits, result._int_bits
+        );
+    }
     return result;
 }
 

--- a/src/apycfixed.h
+++ b/src/apycfixed.h
@@ -149,7 +149,7 @@ public:
     //! Copy scalar
     APyCFixed python_copy() const { return *this; }
     //! Deepcopy scalar (same as copy here)
-    APyCFixed python_deepcopy(nb::dict& _) const { return *this; }
+    APyCFixed python_deepcopy(nb::dict&) const { return *this; }
 
     /* ****************************************************************************** *
      *                         Binary arithmetic operators                            *

--- a/src/apycfixedarray.h
+++ b/src/apycfixedarray.h
@@ -126,7 +126,7 @@ public:
     //! Copy array
     APyCFixedArray python_copy() const { return *this; }
     //! Deepcopy array (same as copy here)
-    APyCFixedArray python_deepcopy(const nb::dict& _) const { return *this; }
+    APyCFixedArray python_deepcopy(const nb::dict&) const { return *this; }
 
     /* ****************************************************************************** *
      * *                     Arithmetic member functions                            * *

--- a/src/apyfixed.cc
+++ b/src/apyfixed.cc
@@ -880,13 +880,21 @@ APyFixed APyFixed::from_double(
 )
 {
     APyFixed result(int_bits, frac_bits, bits);
-    fixed_point_from_double(
-        value,
-        std::begin(result._data),
-        std::end(result._data),
-        result._bits,
-        result._int_bits
-    );
+    if (result._data.size() == 1) {
+        unsigned shift_amount = 64 - (result._bits & (64 - 1));
+        result._data[0] = fixed_point_from_double_single_limb(
+            value, result.frac_bits(), shift_amount
+        );
+    } else {
+        assert(result._data.size() > 1);
+        fixed_point_from_double(
+            value,
+            std::begin(result._data),
+            std::end(result._data),
+            result._bits,
+            result._int_bits
+        );
+    }
     return result;
 }
 

--- a/src/apyfixed.h
+++ b/src/apyfixed.h
@@ -147,7 +147,7 @@ public:
     //! Copy scalar
     APyFixed python_copy() const { return *this; }
     //! Deepcopy scalar
-    APyFixed python_deepcopy(nb::dict& _) const { return *this; }
+    APyFixed python_deepcopy(nb::dict&) const { return *this; }
 
     /* ****************************************************************************** *
      *                         Binary arithmetic operators                            *

--- a/src/apyfixedarray.h
+++ b/src/apyfixedarray.h
@@ -135,7 +135,7 @@ public:
     //! Copy array
     APyFixedArray python_copy() const { return *this; }
     //! Deepcopy array (same as copy here)
-    APyFixedArray python_deepcopy(const nb::dict& _) const { return *this; }
+    APyFixedArray python_deepcopy(const nb::dict&) const { return *this; }
 
     /* ****************************************************************************** *
      * *                       Binary arithmetic operators                          * *

--- a/src/apyfloat.h
+++ b/src/apyfloat.h
@@ -232,7 +232,7 @@ public:
     //! Copy scalar
     APyFloat python_copy() const { return *this; }
     //! Deepcopy scalar (same as copy here)
-    APyFloat python_deepcopy(nb::dict& _) const { return *this; }
+    APyFloat python_deepcopy(nb::dict&) const { return *this; }
 
     /* ****************************************************************************** *
      * *                             Arithmetic operators                           * *

--- a/src/apyfloatarray.cc
+++ b/src/apyfloatarray.cc
@@ -857,13 +857,13 @@ APyFloatArray::nanmin(const std::optional<PyShapeParam_t>& py_axis) const
 
 std::string APyFloatArray::repr() const
 {
-    const auto sign_formatter = [](auto cbegin_it, auto _) -> std::string {
+    const auto sign_formatter = [](auto cbegin_it, auto) -> std::string {
         return fmt::format("{}", int(cbegin_it->sign));
     };
-    const auto exp_formatter = [](auto cbegin_it, auto _) -> std::string {
+    const auto exp_formatter = [](auto cbegin_it, auto) -> std::string {
         return fmt::format("{}", cbegin_it->exp);
     };
-    const auto man_formatter = [](auto cbegin_it, auto _) -> std::string {
+    const auto man_formatter = [](auto cbegin_it, auto) -> std::string {
         return fmt::format("{}", cbegin_it->man);
     };
 
@@ -1366,7 +1366,7 @@ APyFloatArray APyFloatArray::checked_2d_matmul(const APyFloatArray& rhs) const
 
 std::string APyFloatArray::to_string_dec() const
 {
-    const auto formatter = [spec = spec()](auto cbegin_it, auto _) -> std::string {
+    const auto formatter = [spec = spec()](auto cbegin_it, auto) -> std::string {
         // NOTE: Python, unlike C++, unconditionally encodes the string of a
         // floating-point NaN without a minus sign.
         if (is_nan(*cbegin_it, spec)) {

--- a/src/apyfloatarray.h
+++ b/src/apyfloatarray.h
@@ -262,7 +262,7 @@ public:
     APyFloatArray python_copy() const { return *this; }
 
     //! Deepcopy array
-    APyFloatArray python_deepcopy(const nb::dict& _) const { return *this; }
+    APyFloatArray python_deepcopy(const nb::dict&) const { return *this; }
 
     //! Perform a linear convolution with `other` using `mode`
     APyFloatArray convolve(const APyFloatArray& other, const std::string& mode) const;

--- a/src/apytypes_scratch_vector.h
+++ b/src/apytypes_scratch_vector.h
@@ -11,11 +11,11 @@
 #ifndef _APYTYPES_SCRATCH_VECTOR_H
 #define _APYTYPES_SCRATCH_VECTOR_H
 
-#include <cassert>
 #include <fmt/format.h>
 
 #include <algorithm>        // std::copy, std::copy_n
 #include <array>            // std::array
+#include <cassert>          // assert
 #include <cstddef>          // std::size_t, std::ptrdiff_t
 #include <initializer_list> // std::initializer_list
 #include <iterator>         // std::begin, std::end, std::make_reverse_iterator
@@ -236,8 +236,16 @@ public:
     size_type capacity() const noexcept { return _capacity; }
     reference back() { return *std::prev(end()); }
     const_reference back() const { return *std::prev(cend()); }
-    reference operator[](size_type pos) { return _ptr[pos]; }
-    const_reference operator[](size_type pos) const { return _ptr[pos]; }
+    reference operator[](size_type pos)
+    {
+        assert(pos < _size);
+        return _ptr[pos];
+    }
+    const_reference operator[](size_type pos) const
+    {
+        assert(pos < _size);
+        return _ptr[pos];
+    }
 
     reference at(size_type pos)
     {

--- a/src/ieee754.h
+++ b/src/ieee754.h
@@ -9,7 +9,7 @@
 #define _CXX_IEEE754_FIDDLE
 
 #include "apytypes_util.h"
-#include <cstdint> // uint64_t
+#include <cstdint> // std::uint64_t
 #include <cstring> // std::memcpy
 #include <limits>  // std::numeric_limits
 
@@ -40,18 +40,18 @@
 #endif
 }
 
-[[maybe_unused]] static APY_INLINE uint64_t type_pun_double_to_uint64_t(double d)
+[[maybe_unused]] static APY_INLINE std::uint64_t type_pun_double_to_uint64_t(double d)
 {
     // These functions are only compatible with IEEE-754 double-precision `double`s
     static_assert(std::numeric_limits<double>::is_iec559);
 
     // The *only* C++17 way to legaly and portably type-pun in C++: with `std::memcpy`
-    uint64_t double_pun;
+    std::uint64_t double_pun;
     std::memcpy(&double_pun, &d, sizeof(double_pun));
     return double_pun;
 }
 
-[[maybe_unused]] static APY_INLINE double type_pun_uint64_t_to_double(uint64_t num)
+[[maybe_unused]] static APY_INLINE double type_pun_uint64_t_to_double(std::uint64_t num)
 {
     // These functions are only compatible with IEEE-754 double-precision `double`s
     static_assert(std::numeric_limits<double>::is_iec559);
@@ -64,9 +64,9 @@
 
 [[maybe_unused]] static APY_INLINE bool sign_of_double(double d)
 {
-    uint64_t double_pun = type_pun_double_to_uint64_t(d);
+    std::uint64_t double_pun = type_pun_double_to_uint64_t(d);
     if constexpr (target_is_little_endian()) {
-        return bool(double_pun & (uint64_t(1) << 63));
+        return bool(double_pun & (std::uint64_t(1) << 63));
     } else { // std::endiand::native == std::endian::big
         throw NotImplementedException();
     }
@@ -76,7 +76,7 @@
 //! Return value range: [0, 2048)
 [[maybe_unused]] static APY_INLINE int exp_of_double(double d)
 {
-    uint64_t double_pun = type_pun_double_to_uint64_t(d);
+    std::uint64_t double_pun = type_pun_double_to_uint64_t(d);
     if constexpr (target_is_little_endian()) {
         return static_cast<int>((double_pun << 1) >> 53);
     } else { // std::endiand::native == std::endian::big
@@ -86,9 +86,9 @@
 
 //! Return significand/mantissa of a `double` (without the hidden one) in a `uint64_t`.
 //! Range of returned value: [0, 4503599627370496)
-[[maybe_unused]] static APY_INLINE uint64_t man_of_double(double d)
+[[maybe_unused]] static APY_INLINE std::uint64_t man_of_double(double d)
 {
-    uint64_t double_pun = type_pun_double_to_uint64_t(d);
+    std::uint64_t double_pun = type_pun_double_to_uint64_t(d);
     if constexpr (target_is_little_endian()) {
         return double_pun & 0x000FFFFFFFFFFFFF;
     } else { // std::endiand::native == std::endian::big
@@ -99,10 +99,10 @@
 //! [Un]set the sign of a `double` type from a `bool`
 [[maybe_unused]] static APY_INLINE void set_sign_of_double(double& d, bool sign)
 {
-    uint64_t double_pun = type_pun_double_to_uint64_t(d);
+    std::uint64_t double_pun = type_pun_double_to_uint64_t(d);
     if constexpr (target_is_little_endian()) {
         double_pun &= 0x7FFFFFFFFFFFFFFF;
-        double_pun |= (uint64_t(sign) << 63);
+        double_pun |= (std::uint64_t(sign) << 63);
     } else {
         throw NotImplementedException();
     }
@@ -113,10 +113,10 @@
 //! Domain of argument `exp`: [0, 2048)
 [[maybe_unused]] static APY_INLINE void set_exp_of_double(double& d, int exp)
 {
-    uint64_t double_pun = type_pun_double_to_uint64_t(d);
+    std::uint64_t double_pun = type_pun_double_to_uint64_t(d);
     if constexpr (target_is_little_endian()) {
         double_pun &= 0x800FFFFFFFFFFFFF;
-        double_pun |= 0x7FF0000000000000 & (uint64_t(exp) << 52);
+        double_pun |= 0x7FF0000000000000 & (std::uint64_t(exp) << 52);
     } else {
         throw NotImplementedException();
     }
@@ -125,9 +125,9 @@
 
 //! Set the mantissa part of a `double` from `uint64_t`.
 //! Domain of argument `uint64_t`: [0, 4503599627370496)
-[[maybe_unused]] static APY_INLINE void set_man_of_double(double& d, uint64_t man)
+[[maybe_unused]] static APY_INLINE void set_man_of_double(double& d, std::uint64_t man)
 {
-    uint64_t double_pun = type_pun_double_to_uint64_t(d);
+    std::uint64_t double_pun = type_pun_double_to_uint64_t(d);
     if constexpr (target_is_little_endian()) {
         double_pun &= 0xFFF0000000000000;
         double_pun |= 0x000FFFFFFFFFFFFF & man;


### PR DESCRIPTION
# PR Summary
Bring back the performance when constructing fixed points from floating points.

Closes #712

## PR Checklist

- [X] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] new and changed code is tested
- [N/A] relevant changes added to [CHANGELOG.md](https://github.com/apytypes/apytypes/blob/main/CHANGELOG.md)
- [N/A] new functionality is documented
