### PR TITLE
src: fix negative quantization bits fp_mul bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Wrong name in fixed-point division exception message (`__div__` -> `__truediv__`)
 - Inconsistency in formatting of complex-valued numbers (e.g., `(1.0+2.5j)` for
   scalars and `[1.0+2.5j]` for arrays)
+- Bug in floating-point matrix multiplications when inside accumulator contexts
+  using quantization modes `TRN_INF` and `TRN_AWAY`.
 
 ### Changed
 

--- a/src/apyfloat_util.h
+++ b/src/apyfloat_util.h
@@ -231,7 +231,7 @@ template <QuantizationMode QNTZ, bool SUPPORT_NEGATIVE_BITS_TO_QUANTIZE = false>
 )
 {
     if constexpr (SUPPORT_NEGATIVE_BITS_TO_QUANTIZE) {
-        if (bits_to_quantize < 0) {
+        if (bits_to_quantize <= 0) {
             man <<= -bits_to_quantize;
             return; // early exit
         }
@@ -1902,7 +1902,7 @@ public:
         ONE_BEFORE = 1ULL << (NEW_MAN_BITS - 2);
         TWO_RES = 1ULL << dst_spec.man_bits;
         STICKY = (1ULL << (MAN_DELTA - 1)) - 1;
-        qntz_func = get_qntz_func(qntz, MAN_DELTA < 0);
+        qntz_func = get_qntz_func(qntz, MAN_DELTA <= 0);
         BIAS_TERM = dst_spec.bias - std::int64_t(src1_spec.bias)
             - std::int64_t(src2_spec.bias);
     }


### PR DESCRIPTION
# PR Summary
Closes #742

Fixes an off-by-one bug where the quantization should not take place in short floating-point multiplications.

## PR Checklist

- [x] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] new and changed code is tested
- [x] relevant changes added to [CHANGELOG.md](https://github.com/apytypes/apytypes/blob/main/CHANGELOG.md)
- N/A new functionality is documented
