### PR TITLE
src: add fast paths for medium-length fixed-point inner products

### DIFF
--- a/src/apytypes_intrinsics.h
+++ b/src/apytypes_intrinsics.h
@@ -53,7 +53,10 @@ long_unsigned_mult(apy_limb_t src0, apy_limb_t src1)
     return { high_limb, apy_limb_t(res) };
 #elif (COMPILER_LIMB_SIZE == 64)
 #if defined(__GNUC__)
-    // GNU C-compatible compiler (including Clang and MacOS Xcode)
+    /*
+     * GNU C-compatible compiler, including Clang, MacOS Xcode, and Intel C++ compiler
+     * (ICC).
+     */
     unsigned __int128 res = (unsigned __int128)src0 * (unsigned __int128)src1;
     apy_limb_t high_limb = apy_limb_t(res >> 64);
     return { high_limb, apy_limb_t(res) };
@@ -91,7 +94,10 @@ long_signed_mult(apy_limb_t src0, apy_limb_t src1)
     return { high_limb, apy_limb_t(res) };
 #elif (COMPILER_LIMB_SIZE == 64)
 #if defined(__GNUC__)
-    // GNU C-compatible compiler (including Clang and MacOS Xcode)
+    /*
+     * GNU C-compatible compiler, including Clang, MacOS Xcode, and Intel C++ compiler
+     * (ICC).
+     */
     __int128 res
         = (__int128)apy_limb_signed_t(src0) * (__int128)apy_limb_signed_t(src1);
     apy_limb_signed_t high_limb = apy_limb_signed_t(res >> 64);
@@ -224,7 +230,10 @@ template <typename INT_TYPE>
         "leading_zeros(INT_TYPE n): int type must be 32-bit or 64-bit"
     );
 #if defined(__GNUC__)
-    // GNU C-compatible compiler (including Clang and MacOS Xcode)
+    /*
+     * GNU C-compatible compiler, including Clang, MacOS Xcode, and Intel C++ compiler
+     * (ICC).
+     */
     if constexpr (sizeof(INT_TYPE) == 8) {
         return n == 0 ? 0 : __builtin_ctzll(n);
     } else {
@@ -262,7 +271,10 @@ template <typename INT_TYPE>
         "leading_zeros(INT_TYPE n): int type must be 32-bit or 64-bit"
     );
 #if defined(__GNUC__)
-    // GNU C-compatible compiler (including Clang and MacOS Xcode)
+    /*
+     * GNU C-compatible compiler, including Clang, MacOS Xcode, and Intel C++ compiler
+     * (ICC).
+     */
     if constexpr (sizeof(INT_TYPE) == 8) {
         return n == 0 ? 64 : __builtin_clzll(n);
     } else {

--- a/src/ieee754.h
+++ b/src/ieee754.h
@@ -27,8 +27,10 @@
     // big-endian architectures.
     return true;
 #elif defined(__GNUC__) && defined(__BYTE_ORDER__)
-    // GNU C-compatible compiler (including Clang and MacOS Xcode) with macro
-    // __BYTE_ORDER__ specified
+    /*
+     * GNU C-compatible compiler, including Clang, MacOS Xcode, and Intel C++ compiler
+     * (ICC). Macro __BYTE_ORDER__ is specified
+     */
     return __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__;
 #else
     // Failure: could not reliably detect the byte-order of the target architecture.


### PR DESCRIPTION
# PR Summary

This restores the fast path for medium-length fixed-point inner products (`__matmul__` and `convolve`). It should be noticeable in the benchmarks.

## PR Checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

- N/A "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] new and changed code is tested
- N/A relevant changes added to [CHANGELOG.md](https://github.com/apytypes/apytypes/blob/main/CHANGELOG.md)
- N/A new functionality is documented
