### PR TITLE
Example: Floating-point ODE solver

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Updated [nanobind](https://github.com/wjakob/nanobind) from v2.4.0 to v2.8.0.
 - `APyFixedArray` inner products now returns `APyFixed`, instead of returning
   an `APyFixedArray` with a single element.
+- `APyFloatQuantizationContext` now accepts the seed parameter for all quantization
+  modes, although it is only used for the stochastic ones.
 
 ### Removed
 

--- a/examples/ode_solver.py
+++ b/examples/ode_solver.py
@@ -1,0 +1,65 @@
+"""
+Floating-point ODE solver
+=========================
+
+This illustrates the effect of solving an ODE with forward Euler
+using different floating-point formats and different quantization schemes.
+
+The ODE in question is
+
+.. math::
+
+   u'(t) = v(t), \quad u(0) = 1,
+
+   v'(t) = -u(t), \quad v(0) = 0,
+
+and the solution is the unit circle in the (u, v) plane.
+
+(Example was inspired from M. Croci, M. Fasi, N. J Higham, T. Mary, M. Mikaitis. "Stochastic Rounding: Implementation, Error Analysis, and Applications", in *Royal Society Open Science*, 2022.)
+"""
+
+import math
+
+import matplotlib.pyplot as plt
+
+import apytypes as apy
+
+
+def solve_ode(exp_bits, man_bits, bias, iterations=2**14):
+    h = 2 * math.pi / iterations
+    ode = apy.fp([[0, h], [-h, 0]], exp_bits, man_bits, bias)
+    current_value = apy.fp([1, 0], exp_bits, man_bits, bias)
+    results = apy.zeros(
+        (iterations + 1, 2), exp_bits=exp_bits, man_bits=man_bits, bias=bias
+    )
+
+    results[0, :] = current_value
+    for i in range(iterations):
+        current_value += ode @ current_value
+        results[i + 1, :] = current_value
+    return results
+
+
+fig, ax = plt.subplots()
+
+# Floating-point configurations: (exp_bits, man_bits, bias, quantization)
+# Note: when the bias is set to None, it defaults to an IEEE-like bias
+fp_formats = [
+    (8, 23, None, "TIES_EVEN"),
+    (5, 10, None, "TIES_EVEN"),
+    (5, 10, None, "TO_ZERO"),
+    (5, 10, None, "STOCH_WEIGHTED"),
+    (5, 10, None, "STOCH_EQUAL"),
+    (4, 6, 11, "STOCH_WEIGHTED"),
+]
+
+for exp_bits, man_bits, bias, mode in fp_formats:
+    with apy.APyFloatQuantizationContext(
+        eval(f"apy.QuantizationMode.{mode}"), quantization_seed=12
+    ):
+        results = solve_ode(exp_bits, man_bits, bias)
+    ax.plot(results[:, 0], results[:, 1], label=f"E{exp_bits}M{man_bits} ({mode})")
+
+ax.set_aspect("equal")
+fig.legend(ncols=2, loc="upper center")
+plt.show()

--- a/lib/test/test_contextmanagers.py
+++ b/lib/test/test_contextmanagers.py
@@ -335,8 +335,8 @@ class TestQuantizationContext:
         assert get_float_quantization_mode() == QuantizationMode.TO_POS
         assert get_float_quantization_seed() == 123
 
-    def test_raised_exception(self):
-        """Make sure an exception is raised if a seed is given for APyFloatQuantizationContext with a non-stochastic quantization mode."""
-        with pytest.raises(ValueError, match="Seed"):
-            with APyFloatQuantizationContext(QuantizationMode.TO_POS, 123):
-                pass
+    def test_no_exception(self):
+        """Make sure no exception is raised if a seed is given for APyFloatQuantizationContext with a non-stochastic quantization mode."""
+        with APyFloatQuantizationContext(QuantizationMode.TO_POS, 123):
+            assert get_float_quantization_mode() == QuantizationMode.TO_POS
+            assert get_float_quantization_seed() == 123

--- a/src/apytypes_common.cc
+++ b/src/apytypes_common.cc
@@ -35,12 +35,6 @@ APyFloatQuantizationContext::APyFloatQuantizationContext(
     , new_seed(new_seed.value_or(get_float_quantization_seed()))
     , prev_seed(get_float_quantization_seed())
 {
-    if (new_seed.has_value() && new_mode != QuantizationMode::STOCH_WEIGHTED
-        && new_mode != QuantizationMode::STOCH_EQUAL) {
-        throw nb::value_error(
-            "Seed for quantization was given for a non-stochastic quantization mode."
-        );
-    }
 }
 
 void APyFloatQuantizationContext::enter_context()


### PR DESCRIPTION
<!--
Thank you so much for your PR!
-->

# PR Summary
<!-- Please provide at least 1-2 sentences describing the pull request in detail
(Why is this change required?  What problem does it solve?) and link to relevant
issues and PRs.
-->
Added new floating-point example, studying word-length effects in an ODE solver. The example is inspired from [this](https://royalsocietypublishing.org/doi/10.1098/rsos.211631) article. 

The code is similar to the example for vector rotation, but it's a fun example for floating-point people.

I also modified `APyFloatQuantizationContext` to allow the seed parameter for all quantization modes (not only stochastic ones). This simplified iterating over the same function using different modes while using a specific seed.

## PR Checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

- [N/A] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] new and changed code is tested
- [x] relevant changes added to [CHANGELOG.md](https://github.com/apytypes/apytypes/blob/main/CHANGELOG.md)
- [x] new functionality is documented
