### PR TITLE
src: Iterable in favor of Sequence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   an `APyFixedArray` with a single element.
 - `APyFloatQuantizationContext` now accepts the seed parameter for all quantization
   modes, although it is only used for the stochastic ones.
+- Initialize tensors with [Iterable](https://docs.python.org/3/library/collections.abc.html#collections.abc.Iterable)
+  instead of [Sequence](https://docs.python.org/3/library/collections.abc.html#collections.abc.Sequence).
 
 ### Removed
 

--- a/lib/apytypes/_apytypes.pyi
+++ b/lib/apytypes/_apytypes.pyi
@@ -1,6 +1,6 @@
 import enum
 import types
-from collections.abc import Sequence
+from collections.abc import Iterable
 from typing import Annotated, Any, overload
 
 from numpy.typing import ArrayLike
@@ -588,7 +588,7 @@ class APyCFixedArray:
 
     def __init__(
         self,
-        bit_pattern_sequence: Sequence[Any],
+        bit_pattern_sequence: Iterable[Any],
         int_bits: int | None = None,
         frac_bits: int | None = None,
         bits: int | None = None,
@@ -1332,15 +1332,13 @@ class APyCFixedArray:
 
     @staticmethod
     def from_complex(
-        complex_sequence: Sequence[Any],
+        complex_sequence: Iterable[Any],
         int_bits: int | None = None,
         frac_bits: int | None = None,
         bits: int | None = None,
     ) -> APyCFixedArray:
         """
-        Create an :class:`APyCFixedArray` object from a sequence of :class:`int`,
-        :class:`float`, :class:`complex`, :class:`APyFixed`, :class:`APyFloat`, or
-        :class:`APyCFixed`.
+        Create an :class:`APyCFixedArray` from iterable sequence of numbers.
 
         The input is quantized using :class:`QuantizationMode.RND_INF` and overflow
         is handled using the :class:`OverflowMode.WRAP` mode. Exactly two of the
@@ -1350,7 +1348,7 @@ class APyCFixedArray:
 
         Parameters
         ----------
-        complex_sequence : sequence of :class:`complex`, :class:`float`, :class:`int`, :class:`APyCFixed`, :class:`APyFixed`, or :class:`APyFloat`.
+        complex_sequence : :class:`~collections.abc.Iterable` of numbers
             Values to initialize from. The tensor shape will be taken from the
             sequence shape.
         int_bits : :class:`int`, optional
@@ -1389,22 +1387,20 @@ class APyCFixedArray:
 
     @staticmethod
     def from_float(
-        number_seq: Sequence[Any],
+        number_seq: Iterable[Any],
         int_bits: int | None = None,
         frac_bits: int | None = None,
         bits: int | None = None,
     ) -> APyCFixedArray:
         """
-        Create an :class:`APyCFixedArray` object from a sequence of :class:`int`,
-        :class:`float`, :class:`complex`, :class:`APyFixed`, :class:`APyFloat`, or
-        :class:`APyCFixed`.
+        Create an :class:`APyCFixedArray` from iterable sequence of numbers.
 
         This is an alias for :func:`~apytypes.APyCFixedArray.from_complex`, look
         there for more documentation.
 
         Parameters
         ----------
-        number_seq : sequence of numbers
+        number_seq : :class:`~collections.abc.Iterable` of numbers
             Values to initialize from. The tensor shape will be taken from the
             sequence shape.
         int_bits : :class:`int`, optional
@@ -1642,32 +1638,7 @@ class APyCFloat:
         exp_bits: int,
         man_bits: int,
         bias: int | None = None,
-    ) -> None:
-        """
-        Create an :class:`APyCFloat` object and initialize its real part.
-
-        The imaginary part is zero initialized.
-
-        Parameters
-        ----------
-        sign : :class:`bool` or :class:`int`
-            Sign of real part. `True`/non-zero equals negative.
-        exp : :class:`int`
-            Exponent of real part as stored, i.e., actual value + bias.
-        man : :class:`int`
-            Mantissa of the float as stored, i.e., without a hidden one.
-        exp_bits : :class:`int`
-            Number of exponent bits.
-        man_bits : :class:`int`
-            Number of mantissa bits.
-        bias : :class:`int`, optional
-            Exponent bias. If not provided, *bias* is ``2**exp_bits - 1``.
-
-        Returns
-        -------
-        :class:`APyCFloat`
-        """
-
+    ) -> None: ...
     @overload
     def __init__(
         self,
@@ -2025,9 +1996,9 @@ class APyCFloatArray:
 
     def __init__(
         self,
-        sign_seq: Sequence[Any],
-        exp_seq: Sequence[Any],
-        man_seq: Sequence[Any],
+        sign_seq: Iterable[Any],
+        exp_seq: Iterable[Any],
+        man_seq: Iterable[Any],
         exp_bits: int,
         man_bits: int,
         bias: int | None = None,
@@ -2195,21 +2166,19 @@ class APyCFloatArray:
 
     @staticmethod
     def from_complex(
-        complex_sequence: Sequence[Any],
+        complex_sequence: Iterable[Any],
         exp_bits: int,
         man_bits: int,
         bias: int | None = None,
     ) -> APyCFloatArray:
         """
-        Create an :class:`APyCFloatArray` object from a sequence of :class:`int`,
-        :class:`float`, :class:`complex`, :class:`APyFixed`, :class:`APyFloat`, or
-        :class:`APyCFixed`.
+        Create an :class:`APyCFloatArray` from iterable sequence of numbers.
 
         Using NumPy arrays as input is in general faster than using e.g. lists.
 
         Parameters
         ----------
-        complex_sequence : sequence of :class:`complex`, :class:`float`, :class:`int`, :class:`APyCFloat`, :class:`APyCFixed`, :class:`APyFixed`, or :class:`APyFloat`.
+        complex_sequence : :class:`~collections.abc.Iterable` of numbers.
             Values to initialize from. The tensor shape will be taken from the
             sequence shape.
         exp_bits : :class:`int`
@@ -2274,22 +2243,20 @@ class APyCFloatArray:
 
     @staticmethod
     def from_float(
-        complex_sequence: Sequence[Any],
+        complex_sequence: Iterable[Any],
         exp_bits: int,
         man_bits: int,
         bias: int | None = None,
     ) -> APyCFloatArray:
         """
-        Create an :class:`APyCFloatArray` object from a sequence of :class:`int`,
-        :class:`float`, :class:`complex`, :class:`APyFixed`, :class:`APyFloat`, or
-        :class:`APyCFixed`.
+        Create an :class:`APyCFloatArray` from iterable sequence of numbers.
 
         This is an alias for :func:`~apytypes.APyCFloatArray.from_complex`, look
         there for more documentation.
 
         Parameters
         ----------
-        complex_sequence : sequence of :class:`complex`, :class:`float`, :class:`int`, :class:`APyCFloat`, :class:`APyCFixed`, :class:`APyFixed`, or :class:`APyFloat`.
+        complex_sequence : :class:`~collections.abc.Iterable` of numbers.
             Values to initialize from. The tensor shape will be taken from the
             sequence shape.
         exp_bits : :class:`int`
@@ -3564,7 +3531,7 @@ class APyFixed:
 class APyFixedArray:
     def __init__(
         self,
-        bit_pattern_sequence: Sequence[Any],
+        bit_pattern_sequence: Iterable[Any],
         int_bits: int | None = None,
         frac_bits: int | None = None,
         bits: int | None = None,
@@ -4406,14 +4373,13 @@ class APyFixedArray:
 
     @staticmethod
     def from_float(
-        number_seq: Sequence[Any],
+        number_seq: Iterable[Any],
         int_bits: int | None = None,
         frac_bits: int | None = None,
         bits: int | None = None,
     ) -> APyFixedArray:
         """
-        Create an :class:`APyFixedArray` object from a sequence of :class:`int`,
-        :class:`float`, :class:`APyFixed`, or :class:`APyFloat`.
+        Create an :class:`APyFixedArray` from iterable sequence of numbers.
 
         The input is quantized using :class:`QuantizationMode.RND_INF` and overflow
         is handled using the :class:`OverflowMode.WRAP` mode. Exactly two of the
@@ -4423,7 +4389,7 @@ class APyFixedArray:
 
         Parameters
         ----------
-        number_seq : sequence of numbers
+        number_seq : :class:`~collections.abc.Iterable` of numbers.
             Values to initialize from. The tensor shape will be taken from the
             sequence shape.
         int_bits : :class:`int`, optional
@@ -5437,9 +5403,9 @@ class APyFloatArray:
 
     def __init__(
         self,
-        signs: Sequence[Any],
-        exps: Sequence[Any],
-        mans: Sequence[Any],
+        signs: Iterable[Any],
+        exps: Iterable[Any],
+        mans: Iterable[Any],
         exp_bits: int,
         man_bits: int,
         bias: int | None = None,
@@ -5449,12 +5415,12 @@ class APyFloatArray:
 
         Parameters
         ----------
-        signs : sequence of bools or ints
+        signs : :class:`~collections.abc.Iterable` of :class:`bool`s or :class:`int`s
             The sign of the float. False/0 means positive. True/non-zero means
             negative.
-        exps : sequence of ints
+        exps : :class:`~collections.abc.Iterable` of :class:`int`s
             Exponents of the floats as stored, i.e., actual value + bias.
-        mans : sequence of ints
+        mans : :class:`~collections.abc.Iterable` of :class:`int`s
             Mantissas of the floats as stored, i.e., without a hidden one.
         exp_bits : :class:`int`
             Number of exponent bits.
@@ -5731,17 +5697,17 @@ class APyFloatArray:
 
     @staticmethod
     def from_float(
-        number_sequence: Sequence[Any],
+        number_sequence: Iterable[Any],
         exp_bits: int,
         man_bits: int,
         bias: int | None = None,
     ) -> APyFloatArray:
         """
-        Create an :class:`APyFloatArray` from a possibly nested sequence of numbers.
+        Create an :class:`APyFloatArray` from iterable sequence of numbers.
 
         Parameters
         ----------
-        number_sequence : sequence of numbers
+        number_sequence : :class:`~collections.abc.Iterable` of numbers
             Floating point values to initialize from. The tensor shape will be taken
             from the sequence shape.
         exp_bits : :class:`int`
@@ -5870,7 +5836,7 @@ class APyFloatArray:
 
     @staticmethod
     def from_bits(
-        bits: Sequence, exp_bits: int, man_bits: int, bias: int | None = None
+        bits: Iterable, exp_bits: int, man_bits: int, bias: int | None = None
     ) -> APyFloatArray:
         """
         Create an :class:`APyFloatArray` object from bit-representations.

--- a/lib/apytypes/_utils.py
+++ b/lib/apytypes/_utils.py
@@ -1,6 +1,6 @@
 import math
 import warnings
-from collections.abc import Callable, Iterable, Sequence
+from collections.abc import Callable, Iterable
 from functools import partial
 from typing import Any, Literal, overload
 
@@ -51,7 +51,7 @@ def fx(
 
 @overload
 def fx(
-    value: Sequence[Any],
+    value: Iterable[Any],
     int_bits: int | None = None,
     frac_bits: int | None = None,
     bits: int | None = None,
@@ -62,7 +62,7 @@ def fx(
 
 @overload
 def fx(
-    value: Sequence[Any],
+    value: Iterable[Any],
     int_bits: int | None = None,
     frac_bits: int | None = None,
     bits: int | None = None,
@@ -72,7 +72,7 @@ def fx(
 
 
 def fx(
-    value: int | float | complex | Sequence[Any],
+    value: int | float | complex | Iterable[Any],
     int_bits: int | None = None,
     frac_bits: int | None = None,
     bits: int | None = None,
@@ -170,7 +170,7 @@ def fp(
 
 @overload
 def fp(
-    value: Sequence[Any],
+    value: Iterable[Any],
     exp_bits: int,
     man_bits: int,
     bias: int | None = None,
@@ -181,7 +181,7 @@ def fp(
 
 @overload
 def fp(
-    value: Sequence[Any],
+    value: Iterable[Any],
     exp_bits: int,
     man_bits: int,
     bias: int | None = None,
@@ -191,7 +191,7 @@ def fp(
 
 
 def fp(
-    value: int | float | complex | Sequence[Any],
+    value: int | float | complex | Iterable[Any],
     exp_bits: int,
     man_bits: int,
     bias: int | None = None,

--- a/lib/test/apyfloatarray/test_methods.py
+++ b/lib/test/apyfloatarray/test_methods.py
@@ -127,7 +127,7 @@ def test_array_from_float_raises(float_array: type[APyCFloatArray]):
     with pytest.raises(
         ValueError,
         match=r"APyC?FloatArray.from_(float)|(complex): "
-        + r"unexpected type when traversing Sequence: <class 'str'>",
+        + r"unexpected type when traversing iterable sequence: <class 'str'>",
     ):
         _ = float_array.from_float(["0"], 5, 10)
 

--- a/src/apycfixedarray.cc
+++ b/src/apycfixedarray.cc
@@ -42,13 +42,13 @@ namespace nb = nanobind;
  * ********************************************************************************** */
 
 APyCFixedArray::APyCFixedArray(
-    const nb::typed<nb::sequence, nb::any>& seq,
+    const nb::typed<nb::iterable, nb::any>& seq,
     std::optional<int> int_bits,
     std::optional<int> frac_bits,
     std::optional<int> bits
 )
     : APyCFixedArray(
-          python_sequence_extract_shape</* IS_COMPLEX_COLLAPSE = */ true>(
+          python_iterable_extract_shape</* IS_COMPLEX_COLLAPSE = */ true>(
               seq, "APyCFixedArray.__init__"
           ),
           int_bits,
@@ -64,7 +64,7 @@ APyCFixedArray::APyCFixedArray(
     }
 
     // 1D vector of Python int objects (`nb::int_` objects)
-    auto python_objs = python_sequence_walk<nb::int_>(seq, "APyCFixedArray.__init__");
+    auto python_objs = python_iterable_walk<nb::int_>(seq, "APyCFixedArray.__init__");
 
     // If the walked sequence of Python integers is
     assert(python_objs.size() == _nitems || python_objs.size() == 2 * _nitems);
@@ -1228,7 +1228,7 @@ APyCFixedArray APyCFixedArray::identity(
 }
 
 APyCFixedArray APyCFixedArray::from_complex(
-    const nb::typed<nb::sequence, nb::any>& cplx_seq,
+    const nb::typed<nb::iterable, nb::any>& cplx_seq,
     std::optional<int> int_bits,
     std::optional<int> frac_bits,
     std::optional<int> bits
@@ -1241,14 +1241,14 @@ APyCFixedArray APyCFixedArray::from_complex(
     }
 
     APyCFixedArray result(
-        python_sequence_extract_shape(cplx_seq, "APyCFixedArray.from_complex"),
+        python_iterable_extract_shape(cplx_seq, "APyCFixedArray.from_complex"),
         int_bits,
         frac_bits,
         bits
     );
 
     // Extract all Python doubles and integers
-    auto py_obj = python_sequence_walk<
+    auto py_obj = python_iterable_walk<
         nb::float_,
         nb::int_,
         APyFixed,
@@ -1340,7 +1340,7 @@ APyCFixedArray APyCFixedArray::from_complex(
 }
 
 APyCFixedArray APyCFixedArray::from_numbers(
-    const nb::typed<nb::sequence, nb::any>& number_seq,
+    const nb::typed<nb::iterable, nb::any>& number_seq,
     std::optional<int> int_bits,
     std::optional<int> frac_bits,
     std::optional<int> bits

--- a/src/apycfixedarray.h
+++ b/src/apycfixedarray.h
@@ -93,7 +93,7 @@ public:
     APyCFixedArray() = delete;
 
     explicit APyCFixedArray(
-        const nb::typed<nb::sequence, nb::any>& bit_pattern_sequence,
+        const nb::typed<nb::iterable, nb::any>& bit_pattern_sequence,
         std::optional<int> int_bits = std::nullopt,
         std::optional<int> frac_bits = std::nullopt,
         std::optional<int> bits = std::nullopt
@@ -252,7 +252,7 @@ public:
     //! Create an `APyCFixedArray` tensor object initialized with values from a sequence
     //! of `complex`
     static APyCFixedArray from_complex(
-        const nb::typed<nb::sequence, nb::any>& cplx_seq,
+        const nb::typed<nb::iterable, nb::any>& cplx_seq,
         std::optional<int> int_bits = std::nullopt,
         std::optional<int> frac_bits = std::nullopt,
         std::optional<int> bits = std::nullopt
@@ -261,7 +261,7 @@ public:
     //! Create an `APyCFixedArray` tensor object initialized with values from a sequence
     //! of numbers
     static APyCFixedArray from_numbers(
-        const nb::typed<nb::sequence, nb::any>& number_seq,
+        const nb::typed<nb::iterable, nb::any>& number_seq,
         std::optional<int> int_bits = std::nullopt,
         std::optional<int> frac_bits = std::nullopt,
         std::optional<int> bits = std::nullopt

--- a/src/apycfixedarray_wrapper.cc
+++ b/src/apycfixedarray_wrapper.cc
@@ -73,7 +73,7 @@ void bind_cfixed_array(nb::module_& m)
          */
         .def(
             nb::init<
-                const nb::typed<nb::sequence, nb::any>&,
+                const nb::typed<nb::iterable, nb::any>&,
                 std::optional<int>,
                 std::optional<int>,
                 std::optional<int>>(),
@@ -901,9 +901,7 @@ void bind_cfixed_array(nb::module_& m)
             nb::arg("frac_bits") = nb::none(),
             nb::arg("bits") = nb::none(),
             R"pbdoc(
-            Create an :class:`APyCFixedArray` object from a sequence of :class:`int`,
-            :class:`float`, :class:`complex`, :class:`APyFixed`, :class:`APyFloat`, or
-            :class:`APyCFixed`.
+            Create an :class:`APyCFixedArray` from iterable sequence of numbers.
 
             The input is quantized using :class:`QuantizationMode.RND_INF` and overflow
             is handled using the :class:`OverflowMode.WRAP` mode. Exactly two of the
@@ -913,7 +911,7 @@ void bind_cfixed_array(nb::module_& m)
 
             Parameters
             ----------
-            complex_sequence : sequence of :class:`complex`, :class:`float`, :class:`int`, :class:`APyCFixed`, :class:`APyFixed`, or :class:`APyFloat`.
+            complex_sequence : :class:`~collections.abc.Iterable` of numbers
                 Values to initialize from. The tensor shape will be taken from the
                 sequence shape.
             int_bits : :class:`int`, optional
@@ -961,16 +959,14 @@ void bind_cfixed_array(nb::module_& m)
             nb::arg("frac_bits") = nb::none(),
             nb::arg("bits") = nb::none(),
             R"pbdoc(
-            Create an :class:`APyCFixedArray` object from a sequence of :class:`int`,
-            :class:`float`, :class:`complex`, :class:`APyFixed`, :class:`APyFloat`, or
-            :class:`APyCFixed`.
+            Create an :class:`APyCFixedArray` from iterable sequence of numbers.
 
             This is an alias for :func:`~apytypes.APyCFixedArray.from_complex`, look
             there for more documentation.
 
             Parameters
             ----------
-            number_seq : sequence of numbers
+            number_seq : :class:`~collections.abc.Iterable` of numbers
                 Values to initialize from. The tensor shape will be taken from the
                 sequence shape.
             int_bits : :class:`int`, optional

--- a/src/apycfloat_wrapper.cc
+++ b/src/apycfloat_wrapper.cc
@@ -106,31 +106,7 @@ void bind_cfloat(nb::module_& m)
             nb::arg("man"),
             nb::arg("exp_bits"),
             nb::arg("man_bits"),
-            nb::arg("bias") = nb::none(),
-            R"pbdoc(
-            Create an :class:`APyCFloat` object and initialize its real part.
-
-            The imaginary part is zero initialized.
-
-            Parameters
-            ----------
-            sign : :class:`bool` or :class:`int`
-                Sign of real part. `True`/non-zero equals negative.
-            exp : :class:`int`
-                Exponent of real part as stored, i.e., actual value + bias.
-            man : :class:`int`
-                Mantissa of the float as stored, i.e., without a hidden one.
-            exp_bits : :class:`int`
-                Number of exponent bits.
-            man_bits : :class:`int`
-                Number of mantissa bits.
-            bias : :class:`int`, optional
-                Exponent bias. If not provided, *bias* is ``2**exp_bits - 1``.
-
-            Returns
-            -------
-            :class:`APyCFloat`
-            )pbdoc"
+            nb::arg("bias") = nb::none()
         )
 
         .def(

--- a/src/apycfloatarray.cc
+++ b/src/apycfloatarray.cc
@@ -36,15 +36,15 @@ APyCFloatArray::APyCFloatArray(
  * ********************************************************************************** */
 
 APyCFloatArray::APyCFloatArray(
-    const nb::typed<nb::sequence, nb::any>& sign_seq,
-    const nb::typed<nb::sequence, nb::any>& exp_seq,
-    const nb::typed<nb::sequence, nb::any>& man_seq,
+    const nb::typed<nb::iterable, nb::any>& sign_seq,
+    const nb::typed<nb::iterable, nb::any>& exp_seq,
+    const nb::typed<nb::iterable, nb::any>& man_seq,
     int exp_bits,
     int man_bits,
     std::optional<exp_t> bias
 )
     : APyArray(
-          python_sequence_extract_shape<true>(sign_seq, "APyCFloatArray.__init__"),
+          python_iterable_extract_shape<true>(sign_seq, "APyCFloatArray.__init__"),
           /* itemsize= */ 2
       )
     , exp_bits { check_exponent_format(exp_bits, "APyCFloatArray.__init__") }
@@ -54,8 +54,8 @@ APyCFloatArray::APyCFloatArray(
     constexpr std::string_view NAME = "APyCFloatArray.__init__";
 
     const auto& signs_shape = _shape;
-    const auto exps_shape = python_sequence_extract_shape<true>(exp_seq, NAME);
-    const auto mans_shape = python_sequence_extract_shape<true>(man_seq, NAME);
+    const auto exps_shape = python_iterable_extract_shape<true>(exp_seq, NAME);
+    const auto mans_shape = python_iterable_extract_shape<true>(man_seq, NAME);
     if (!((signs_shape == exps_shape) && (signs_shape == mans_shape))) {
         throw std::domain_error(
             fmt::format(
@@ -68,9 +68,9 @@ APyCFloatArray::APyCFloatArray(
         );
     }
 
-    auto signs = python_sequence_walk<nb::int_, nb::bool_>(sign_seq, NAME);
-    auto exps = python_sequence_walk<nb::int_>(exp_seq, NAME);
-    auto mans = python_sequence_walk<nb::int_>(man_seq, NAME);
+    auto signs = python_iterable_walk<nb::int_, nb::bool_>(sign_seq, NAME);
+    auto exps = python_iterable_walk<nb::int_>(exp_seq, NAME);
+    auto mans = python_iterable_walk<nb::int_>(man_seq, NAME);
 
     // If the walked sequence of Python integers is
     assert(signs.size() == exps.size() && signs.size() == mans.size());
@@ -145,7 +145,7 @@ APyCFloatArray APyCFloatArray::identity(
 //! Create an `APyCFloatArray` tensor object initialized with values from a sequence
 //! of complex-like numbers
 APyCFloatArray APyCFloatArray::from_numbers(
-    const nb::typed<nb::sequence, nb::any>& number_seq,
+    const nb::typed<nb::iterable, nb::any>& number_seq,
     int exp_bits,
     int man_bits,
     std::optional<exp_t> bias
@@ -161,13 +161,13 @@ APyCFloatArray APyCFloatArray::from_numbers(
     }
 
     APyCFloatArray result(
-        python_sequence_extract_shape(number_seq, "APyCFloatArray.from_complex"),
+        python_iterable_extract_shape(number_seq, "APyCFloatArray.from_complex"),
         exp_bits,
         man_bits,
         bias
     );
 
-    const auto py_objs = python_sequence_walk<
+    const auto py_objs = python_iterable_walk<
         std::complex<double>,
         nb::float_,
         nb::int_,

--- a/src/apycfloatarray.h
+++ b/src/apycfloatarray.h
@@ -36,9 +36,9 @@ public:
     APyCFloatArray() = delete;
 
     explicit APyCFloatArray(
-        const nb::typed<nb::sequence, nb::any>& sign_seq,
-        const nb::typed<nb::sequence, nb::any>& exp_seq,
-        const nb::typed<nb::sequence, nb::any>& man_seq,
+        const nb::typed<nb::iterable, nb::any>& sign_seq,
+        const nb::typed<nb::iterable, nb::any>& exp_seq,
+        const nb::typed<nb::iterable, nb::any>& man_seq,
         int exp_bits,
         int man_bits,
         std::optional<exp_t> bias = std::nullopt
@@ -246,7 +246,7 @@ public:
     //! Create an `APyCFloatArray` tensor object initialized with values from a sequence
     //! of `complex`
     static APyCFloatArray from_complex(
-        const nb::typed<nb::sequence, nb::any>& cplx_seq,
+        const nb::typed<nb::iterable, nb::any>& cplx_seq,
         int exp_bits,
         int man_bits,
         std::optional<exp_t> bias = std::nullopt
@@ -255,7 +255,7 @@ public:
     //! Create an `APyCFloatArray` tensor object initialized with values from a sequence
     //! of complex-like numbers
     static APyCFloatArray from_numbers(
-        const nb::typed<nb::sequence, nb::any>& number_seq,
+        const nb::typed<nb::iterable, nb::any>& number_seq,
         int exp_bits,
         int man_bits,
         std::optional<exp_t> bias = std::nullopt

--- a/src/apycfloatarray_wrapper.cc
+++ b/src/apycfloatarray_wrapper.cc
@@ -64,9 +64,9 @@ void bind_cfloat_array(nb::module_& m)
          */
         .def(
             nb::init<
-                const nb::typed<nb::sequence, nb::any>&,
-                const nb::typed<nb::sequence, nb::any>&,
-                const nb::typed<nb::sequence, nb::any>&,
+                const nb::typed<nb::iterable, nb::any>&,
+                const nb::typed<nb::iterable, nb::any>&,
+                const nb::typed<nb::iterable, nb::any>&,
                 int,
                 int,
                 std::optional<exp_t>>(),
@@ -237,15 +237,13 @@ void bind_cfloat_array(nb::module_& m)
             nb::arg("man_bits"),
             nb::arg("bias") = nb::none(),
             R"pbdoc(
-            Create an :class:`APyCFloatArray` object from a sequence of :class:`int`,
-            :class:`float`, :class:`complex`, :class:`APyFixed`, :class:`APyFloat`, or
-            :class:`APyCFixed`.
+            Create an :class:`APyCFloatArray` from iterable sequence of numbers.
 
             Using NumPy arrays as input is in general faster than using e.g. lists.
 
             Parameters
             ----------
-            complex_sequence : sequence of :class:`complex`, :class:`float`, :class:`int`, :class:`APyCFloat`, :class:`APyCFixed`, :class:`APyFixed`, or :class:`APyFloat`.
+            complex_sequence : :class:`~collections.abc.Iterable` of numbers.
                 Values to initialize from. The tensor shape will be taken from the
                 sequence shape.
             exp_bits : :class:`int`
@@ -318,16 +316,14 @@ void bind_cfloat_array(nb::module_& m)
             nb::arg("man_bits"),
             nb::arg("bias") = nb::none(),
             R"pbdoc(
-            Create an :class:`APyCFloatArray` object from a sequence of :class:`int`,
-            :class:`float`, :class:`complex`, :class:`APyFixed`, :class:`APyFloat`, or
-            :class:`APyCFixed`.
+            Create an :class:`APyCFloatArray` from iterable sequence of numbers.
 
             This is an alias for :func:`~apytypes.APyCFloatArray.from_complex`, look
             there for more documentation.
 
             Parameters
             ----------
-            complex_sequence : sequence of :class:`complex`, :class:`float`, :class:`int`, :class:`APyCFloat`, :class:`APyCFixed`, :class:`APyFixed`, or :class:`APyFloat`.
+            complex_sequence : :class:`~collections.abc.Iterable` of numbers.
                 Values to initialize from. The tensor shape will be taken from the
                 sequence shape.
             exp_bits : :class:`int`

--- a/src/apyfixedarray.cc
+++ b/src/apyfixedarray.cc
@@ -11,7 +11,6 @@
 #include "apytypes_simd.h"
 #include "apytypes_util.h"
 #include "array_utils.h"
-#include "broadcast.h"
 #include "python_util.h"
 
 // Python object access through Nanobind
@@ -40,13 +39,13 @@ namespace nb = nanobind;
  * ********************************************************************************** */
 
 APyFixedArray::APyFixedArray(
-    const nb::typed<nb::sequence, nb::any>& bit_pattern_sequence,
+    const nb::typed<nb::iterable, nb::any>& bit_pattern_sequence,
     std::optional<int> int_bits,
     std::optional<int> frac_bits,
     std::optional<int> bits
 )
     : APyFixedArray(
-          python_sequence_extract_shape(bit_pattern_sequence, "APyFixedArray.__init__"),
+          python_iterable_extract_shape(bit_pattern_sequence, "APyFixedArray.__init__"),
           int_bits,
           frac_bits,
           bits
@@ -60,7 +59,7 @@ APyFixedArray::APyFixedArray(
     }
 
     // 1D vector of Python int object (`nb::int_` objects)
-    auto python_ints = python_sequence_walk<nb::int_>(
+    auto python_ints = python_iterable_walk<nb::int_>(
         bit_pattern_sequence, "APyFixedArray.__init__"
     );
 
@@ -1300,7 +1299,7 @@ APyFixedArray APyFixedArray::cast(
  * ********************************************************************************** */
 
 APyFixedArray APyFixedArray::from_numbers(
-    const nb::typed<nb::sequence, nb::any>& number_seq,
+    const nb::typed<nb::iterable, nb::any>& number_seq,
     std::optional<int> int_bits,
     std::optional<int> frac_bits,
     std::optional<int> bits
@@ -1313,14 +1312,14 @@ APyFixedArray APyFixedArray::from_numbers(
     }
 
     APyFixedArray result(
-        python_sequence_extract_shape(number_seq, "APyFixedArray.from_float"),
+        python_iterable_extract_shape(number_seq, "APyFixedArray.from_float"),
         int_bits,
         frac_bits,
         bits
     );
 
     // Extract all Python doubles and integers
-    auto py_objs = python_sequence_walk<nb::float_, nb::int_, APyFixed, APyFloat>(
+    auto py_objs = python_iterable_walk<nb::float_, nb::int_, APyFixed, APyFloat>(
         number_seq, "APyFixedArray.from_float"
     );
 

--- a/src/apyfixedarray.h
+++ b/src/apyfixedarray.h
@@ -102,7 +102,7 @@ public:
     APyFixedArray() = delete;
 
     explicit APyFixedArray(
-        const nb::typed<nb::sequence, nb::any>& bit_pattern_sequence,
+        const nb::typed<nb::iterable, nb::any>& bit_pattern_sequence,
         std::optional<int> int_bits = std::nullopt,
         std::optional<int> frac_bits = std::nullopt,
         std::optional<int> bits = std::nullopt
@@ -265,7 +265,7 @@ public:
     //! Create an `APyFixedArray` tensor object initialized with values from a sequence
     //! of Python objects
     static APyFixedArray from_numbers(
-        const nb::typed<nb::sequence, nb::any>& number_seq,
+        const nb::typed<nb::iterable, nb::any>& number_seq,
         std::optional<int> int_bits = std::nullopt,
         std::optional<int> frac_bits = std::nullopt,
         std::optional<int> bits = std::nullopt

--- a/src/apyfixedarray_wrapper.cc
+++ b/src/apyfixedarray_wrapper.cc
@@ -59,7 +59,7 @@ void bind_fixed_array(nb::module_& m)
          */
         .def(
             nb::init<
-                const nb::typed<nb::sequence, nb::any>&,
+                const nb::typed<nb::iterable, nb::any>&,
                 std::optional<int>,
                 std::optional<int>,
                 std::optional<int>>(),
@@ -978,8 +978,7 @@ void bind_fixed_array(nb::module_& m)
             nb::arg("frac_bits") = nb::none(),
             nb::arg("bits") = nb::none(),
             R"pbdoc(
-            Create an :class:`APyFixedArray` object from a sequence of :class:`int`,
-            :class:`float`, :class:`APyFixed`, or :class:`APyFloat`.
+            Create an :class:`APyFixedArray` from iterable sequence of numbers.
 
             The input is quantized using :class:`QuantizationMode.RND_INF` and overflow
             is handled using the :class:`OverflowMode.WRAP` mode. Exactly two of the
@@ -989,7 +988,7 @@ void bind_fixed_array(nb::module_& m)
 
             Parameters
             ----------
-            number_seq : sequence of numbers
+            number_seq : :class:`~collections.abc.Iterable` of numbers.
                 Values to initialize from. The tensor shape will be taken from the
                 sequence shape.
             int_bits : :class:`int`, optional

--- a/src/apyfloatarray.cc
+++ b/src/apyfloatarray.cc
@@ -31,9 +31,9 @@ namespace nb = nanobind;
 
 void APyFloatArray::create_in_place(
     APyFloatArray* apyfloatarray,
-    const nb::typed<nb::sequence, nb::any>& sign_seq,
-    const nb::typed<nb::sequence, nb::any>& exp_seq,
-    const nb::typed<nb::sequence, nb::any>& man_seq,
+    const nb::typed<nb::iterable, nb::any>& sign_seq,
+    const nb::typed<nb::iterable, nb::any>& exp_seq,
+    const nb::typed<nb::iterable, nb::any>& man_seq,
     int exp_bits,
     int man_bits,
     std::optional<exp_t> bias
@@ -47,22 +47,22 @@ void APyFloatArray::create_in_place(
 }
 
 APyFloatArray::APyFloatArray(
-    const nb::sequence& sign_seq,
-    const nb::sequence& exp_seq,
-    const nb::sequence& man_seq,
+    const nb::iterable& sign_seq,
+    const nb::iterable& exp_seq,
+    const nb::iterable& man_seq,
     std::uint8_t exp_bits,
     std::uint8_t man_bits,
     std::optional<exp_t> bias
 )
-    : APyArray(python_sequence_extract_shape(sign_seq, "APyFloatArray.__init__"))
+    : APyArray(python_iterable_extract_shape(sign_seq, "APyFloatArray.__init__"))
     , exp_bits(exp_bits)
     , man_bits(man_bits)
 {
     constexpr std::string_view caller_name = "APyFloatArray.__init__";
 
     const auto& signs_shape = _shape;
-    const auto exps_shape = python_sequence_extract_shape(exp_seq, caller_name);
-    const auto mans_shape = python_sequence_extract_shape(man_seq, caller_name);
+    const auto exps_shape = python_iterable_extract_shape(exp_seq, caller_name);
+    const auto mans_shape = python_iterable_extract_shape(man_seq, caller_name);
     if (!((signs_shape == exps_shape) && (signs_shape == mans_shape))) {
         throw std::domain_error(
             fmt::format(
@@ -74,9 +74,9 @@ APyFloatArray::APyFloatArray(
         );
     }
 
-    auto signs = python_sequence_walk<nb::int_, nb::bool_>(sign_seq, caller_name);
-    auto exps = python_sequence_walk<nb::int_>(exp_seq, caller_name);
-    auto mans = python_sequence_walk<nb::int_>(man_seq, caller_name);
+    auto signs = python_iterable_walk<nb::int_, nb::bool_>(sign_seq, caller_name);
+    auto exps = python_iterable_walk<nb::int_>(exp_seq, caller_name);
+    auto mans = python_iterable_walk<nb::int_>(man_seq, caller_name);
 
     this->bias = bias.value_or(APyFloat::ieee_bias(exp_bits));
     for (std::size_t i = 0; i < signs.size(); ++i) {
@@ -1079,7 +1079,7 @@ bool APyFloatArray::is_identical(const nb::object& other, bool ignore_zero_sign)
 }
 
 APyFloatArray APyFloatArray::from_numbers(
-    const nb::typed<nb::sequence, nb::any>& number_seq,
+    const nb::typed<nb::iterable, nb::any>& number_seq,
     int exp_bits,
     int man_bits,
     std::optional<exp_t> bias
@@ -1095,13 +1095,13 @@ APyFloatArray APyFloatArray::from_numbers(
     check_mantissa_format(man_bits, "APyFloatArray.from_float");
 
     APyFloatArray result(
-        python_sequence_extract_shape(number_seq, "APyFloatArray.from_float"),
+        python_iterable_extract_shape(number_seq, "APyFloatArray.from_float"),
         exp_bits,
         man_bits,
         bias
     );
 
-    const auto py_objs = python_sequence_walk<nb::float_, nb::int_, APyFixed, APyFloat>(
+    const auto py_objs = python_iterable_walk<nb::float_, nb::int_, APyFixed, APyFloat>(
         number_seq, "APyFloatArray.from_float"
     );
 
@@ -1200,7 +1200,7 @@ void APyFloatArray::_set_values_from_ndarray(const nb::ndarray<nb::c_contig>& nd
 }
 
 APyFloatArray APyFloatArray::from_bits(
-    const nb::sequence& python_bit_patterns,
+    const nb::iterable& python_bit_patterns,
     int exp_bits,
     int man_bits,
     std::optional<exp_t> bias
@@ -1224,13 +1224,13 @@ APyFloatArray APyFloatArray::from_bits(
     }
 
     APyFloatArray result(
-        python_sequence_extract_shape(python_bit_patterns, "APyFloatArray.from_bits"),
+        python_iterable_extract_shape(python_bit_patterns, "APyFloatArray.from_bits"),
         exp_bits,
         man_bits,
         bias
     );
 
-    const auto py_obj = python_sequence_walk<nb::float_, nb::int_>(
+    const auto py_obj = python_iterable_walk<nb::float_, nb::int_>(
         python_bit_patterns, "APyFloatArray.from_bits"
     );
 

--- a/src/apyfloatarray.h
+++ b/src/apyfloatarray.h
@@ -27,9 +27,9 @@ public:
     //! Constructor taking a sequence of signs, biased exponents, and mantissas.
     //! If no bias is given, an IEEE-like bias will be used.
     explicit APyFloatArray(
-        const nanobind::sequence& sign_seq,
-        const nanobind::sequence& exp_seq,
-        const nanobind::sequence& man_seq,
+        const nanobind::iterable& sign_seq,
+        const nanobind::iterable& exp_seq,
+        const nanobind::iterable& man_seq,
         std::uint8_t exp_bits,
         std::uint8_t man_bits,
         std::optional<exp_t> bias = std::nullopt
@@ -164,9 +164,9 @@ public:
     //! Factory function for Python interface
     static void create_in_place(
         APyFloatArray* apyfloatarray,
-        const nb::typed<nb::sequence, nb::any>& sign_seq,
-        const nb::typed<nb::sequence, nb::any>& exp_seq,
-        const nb::typed<nb::sequence, nb::any>& man_seq,
+        const nb::typed<nb::iterable, nb::any>& sign_seq,
+        const nb::typed<nb::iterable, nb::any>& exp_seq,
+        const nb::typed<nb::iterable, nb::any>& man_seq,
         int exp_bits,
         int man_bits,
         std::optional<exp_t> bias = std::nullopt
@@ -175,7 +175,7 @@ public:
     //! Create an `APyFloatArray` tensor object initialized with values from a sequence
     //! of numbers
     static APyFloatArray from_numbers(
-        const nb::typed<nb::sequence, nb::any>& number_seq,
+        const nb::typed<nb::iterable, nb::any>& number_seq,
         int exp_bits,
         int man_bits,
         std::optional<exp_t> bias = std::nullopt
@@ -191,7 +191,7 @@ public:
 
     //! Create an `APyFloatArray` tensor object initialized from bit-representation
     static APyFloatArray from_bits(
-        const nb::sequence& python_bit_patterns,
+        const nb::iterable& python_bit_patterns,
         int exp_bits,
         int man_bits,
         std::optional<exp_t> bias = std::nullopt

--- a/src/apyfloatarray_wrapper.cc
+++ b/src/apyfloatarray_wrapper.cc
@@ -70,12 +70,12 @@ void bind_float_array(nb::module_& m)
 
             Parameters
             ----------
-            signs : sequence of bools or ints
+            signs : :class:`~collections.abc.Iterable` of :class:`bool`s or :class:`int`s
                 The sign of the float. False/0 means positive. True/non-zero means
                 negative.
-            exps : sequence of ints
+            exps : :class:`~collections.abc.Iterable` of :class:`int`s
                 Exponents of the floats as stored, i.e., actual value + bias.
-            mans : sequence of ints
+            mans : :class:`~collections.abc.Iterable` of :class:`int`s
                 Mantissas of the floats as stored, i.e., without a hidden one.
             exp_bits : :class:`int`
                 Number of exponent bits.
@@ -345,11 +345,11 @@ void bind_float_array(nb::module_& m)
             nb::arg("man_bits"),
             nb::arg("bias") = nb::none(),
             R"pbdoc(
-            Create an :class:`APyFloatArray` from a possibly nested sequence of numbers.
+            Create an :class:`APyFloatArray` from iterable sequence of numbers.
 
             Parameters
             ----------
-            number_sequence : sequence of numbers
+            number_sequence : :class:`~collections.abc.Iterable` of numbers
                 Floating point values to initialize from. The tensor shape will be taken
                 from the sequence shape.
             exp_bits : :class:`int`


### PR DESCRIPTION
This PR changes the [Sequence](https://docs.python.org/3/library/collections.abc.html#collections.abc.Sequence) semantics of APyTypes' initializers to [Iterable](https://docs.python.org/3/library/collections.abc.html#collections.abc.Iterable). This is because the Numpy arrays are considered Iterable, but not of Sequence type.


## PR Checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

- [x] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] new and changed code is tested
- [x] relevant changes added to [CHANGELOG.md](https://github.com/apytypes/apytypes/blob/main/CHANGELOG.md)
- [x] new functionality is documented
