### PR TITLE
src: remove `to_double()` casts from apyfloat_util.h

### DIFF
--- a/src/apyfixed.h
+++ b/src/apyfixed.h
@@ -295,7 +295,7 @@ public:
 
     //! Return the least significant 64-bits from the underlying limb-vector
     //! (convenience function used in `APyFloat`)
-    std::uint64_t get_lsbs() const { return uint64_t_from_limb_vector(_data, 0); }
+    std::uint64_t get_lsbs() const { return limb_vector_to_uint64(_data, 0); }
 
     APyFixed ipow(unsigned int n) const;
 

--- a/src/apyfixed.h
+++ b/src/apyfixed.h
@@ -86,6 +86,9 @@ public:
     //! Retrieve the bit specification
     APY_INLINE APyFixedSpec spec() const noexcept { return { _bits, _int_bits }; }
 
+    //! Peak at the underlying data vector
+    const ScratchVector<apy_limb_t>& read_data() const { return _data; }
+
     /* ****************************************************************************** *
      *                            Python constructors                                 *
      * ****************************************************************************** */

--- a/src/apyfloat.cc
+++ b/src/apyfloat.cc
@@ -380,7 +380,7 @@ APyFloat::one(std::uint8_t exp_bits, std::uint8_t man_bits, std::optional<exp_t>
 APyFloat& APyFloat::update_from_bits(nb::int_ python_long_int_bit_pattern)
 {
     auto data_vec = python_long_to_limb_vec(python_long_int_bit_pattern);
-    std::uint64_t low = uint64_t_from_limb_vector(data_vec, 0);
+    std::uint64_t low = limb_vector_to_uint64(data_vec, 0);
 
     man = low & man_mask();
 

--- a/src/apyfloat_util.h
+++ b/src/apyfloat_util.h
@@ -964,7 +964,7 @@ APyFloatData floating_point_from_fixed_point(
     } else {
         // We know the mantissa is in [1, 2), so remove the leading one
         limb_vector_set_bit(std::begin(fx_man), std::end(fx_man), man_bits + c, 0);
-        return { sign, exp_t(tmp_exp), uint64_t_from_limb_vector(fx_man, 0) };
+        return { sign, exp_t(tmp_exp), limb_vector_to_uint64(fx_man, 0) };
     }
 }
 
@@ -1763,15 +1763,7 @@ template <
         }
     }
 
-#if (COMPILER_LIMB_SIZE == 64)
-    z = { res_sign, exp_t(new_exp), apy_res.read_data()[0] };
-#elif (COMPILER_LIMB_SIZE == 32)
-    man_t man = apy_res.read_data()[0] + (man_t(apy_res.read_data()[1]) << 32);
-    z = { res_sign, exp_t(new_exp), man };
-#else
-#error "C Macro `COMPILER_LIMB_SIZE` not specified. Must be set during compilation."
-#endif
-
+    z = { res_sign, exp_t(new_exp), limb_vector_to_uint64(apy_res.read_data(), 0) };
     return;
 }
 
@@ -1828,14 +1820,8 @@ static void APY_INLINE _division_core(
         }
     }
 
-#if (COMPILER_LIMB_SIZE == 64)
-    z = { sign, exp_t(new_exp), apy_man_res.read_data()[0] };
-#elif (COMPILER_LIMB_SIZE == 32)
-    man_t man = apy_res_man.read_data()[0] + (man_t(apy_res_man.read_data()[1]) << 32);
-    z = { sign, exp_t(new_exp), man };
-#else
-#error "C Macro `COMPILER_LIMB_SIZE` not specified. Must be set during compilation."
-#endif
+    z = { sign, exp_t(new_exp), limb_vector_to_uint64(apy_man_res.read_data(), 0) };
+    return;
 }
 
 [[maybe_unused]]

--- a/src/apyfloat_util.h
+++ b/src/apyfloat_util.h
@@ -1762,8 +1762,16 @@ template <
             new_exp = 1;
         }
     }
-    apy_res <<= dst_spec.man_bits;
-    z = { res_sign, exp_t(new_exp), man_t(apy_res.to_double()) };
+
+#if (COMPILER_LIMB_SIZE == 64)
+    z = { res_sign, exp_t(new_exp), apy_res.read_data()[0] };
+#elif (COMPILER_LIMB_SIZE == 32)
+    man_t man = apy_res.read_data()[0] + (man_t(apy_res.read_data()[1]) << 32);
+    z = { res_sign, exp_t(new_exp), man };
+#else
+#error "C Macro `COMPILER_LIMB_SIZE` not specified. Must be set during compilation."
+#endif
+
     return;
 }
 
@@ -1819,8 +1827,15 @@ static void APY_INLINE _division_core(
             new_exp = 1;
         }
     }
-    apy_man_res <<= z_spec.man_bits;
-    z = { sign, exp_t(new_exp), man_t(apy_man_res.to_double()) };
+
+#if (COMPILER_LIMB_SIZE == 64)
+    z = { sign, exp_t(new_exp), apy_man_res.read_data()[0] };
+#elif (COMPILER_LIMB_SIZE == 32)
+    man_t man = apy_res_man.read_data()[0] + (man_t(apy_res_man.read_data()[1]) << 32);
+    z = { sign, exp_t(new_exp), man };
+#else
+#error "C Macro `COMPILER_LIMB_SIZE` not specified. Must be set during compilation."
+#endif
 }
 
 [[maybe_unused]]

--- a/src/apytypes_util.h
+++ b/src/apytypes_util.h
@@ -957,12 +957,12 @@ template <typename RANDOM_ACCESS_ITERATOR_IN, typename RANDOM_ACCESS_ITERATOR_OU
 //! zeroed if out-of-bounds.
 template <typename VECTOR_TYPE>
 [[maybe_unused, nodiscard]] static APY_INLINE std::uint64_t
-uint64_t_from_limb_vector(const VECTOR_TYPE& limb_vec, std::size_t n)
+limb_vector_to_uint64(const VECTOR_TYPE& limb_vec, std::size_t n)
 {
     static_assert(APY_LIMB_SIZE_BITS == 32 || APY_LIMB_SIZE_BITS == 64);
     if constexpr (APY_LIMB_SIZE_BITS == 64) {
         // No bound-checking for 64-bit limbs
-        return limb_vec[n];
+        return std::uint64_t(limb_vec[n]);
     } else { /* APY_LIMB_SIZE_BITS == 32 */
         if (n + 1 < limb_vec.size()) {
             return std::uint64_t(limb_vec[n]) | (std::uint64_t(limb_vec[n + 1]) << 32);


### PR DESCRIPTION
# PR Summary
This PR should speed up the general (long) floating-point multiplication routine somewhat. I wrote a Mandelbrot set renderer, and this change had a small but noticeable impact on it.

## PR Checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

- N/A "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [ ] new and changed code is tested
- N/A relevant changes added to [CHANGELOG.md](https://github.com/apytypes/apytypes/blob/main/CHANGELOG.md)
- N/A new functionality is documented
