### PR TITLE
src: remove `APyFixed` from `float_mul_general()`

### DIFF
--- a/examples/ode_solver.py
+++ b/examples/ode_solver.py
@@ -54,9 +54,7 @@ fp_formats = [
 ]
 
 for exp_bits, man_bits, bias, mode in fp_formats:
-    with apy.APyFloatQuantizationContext(
-        eval(f"apy.QuantizationMode.{mode}"), quantization_seed=12
-    ):
+    with apy.APyFloatQuantizationContext(eval(f"apy.QuantizationMode.{mode}"), seed=12):
         results = solve_ode(exp_bits, man_bits, bias)
     ax.plot(results[:, 0], results[:, 1], label=f"E{exp_bits}M{man_bits} ({mode})")
 

--- a/lib/apytypes/__init__.py
+++ b/lib/apytypes/__init__.py
@@ -16,8 +16,10 @@ from apytypes._apytypes import (
     OverflowMode,
     QuantizationMode,
     _get_simd_version_str,
+    get_fixed_quantization_seed,
     get_float_quantization_mode,
     get_float_quantization_seed,
+    set_fixed_quantization_seed,
     set_float_quantization_mode,
     set_float_quantization_seed,
 )
@@ -72,6 +74,7 @@ __all__ = [
     "full_like",
     "fullrange",
     "fx",
+    "get_fixed_quantization_seed",
     "get_float_quantization_mode",
     "get_float_quantization_seed",
     "identity",
@@ -80,6 +83,7 @@ __all__ = [
     "ones_like",
     "ravel",
     "reshape",
+    "set_fixed_quantization_seed",
     "set_float_quantization_mode",
     "set_float_quantization_seed",
     "shape",
@@ -144,19 +148,20 @@ format is calculated as the "average" of the inputs' biases:
 .. math::
     \texttt{bias}_3 = \frac{\left ( \left (\texttt{bias}_1 + 1 \right ) / 2^{\texttt{exp_bits}_1} + \left (\texttt{bias}_2 + 1 \right ) / 2^{\texttt{exp_bits}_2} \right ) \times 2^{\texttt{exp_bits}_3}}{2} - 1,
 
-where :math:`\texttt{exp_bits}_1` and :math:`\texttt{exp_bits}_2` are the bit widths of the operands, :math:`\texttt{bias}_1` and :math:`\texttt{bias}_2` are the
-input biases, and :math:`\texttt{exp_bits}_3` is the target bit width.
-Note that this formula still results in an IEEE-like bias when the inputs use IEEE-like biases.
+where :math:`\texttt{exp_bits}_1` and :math:`\texttt{exp_bits}_2` are the bit widths of
+the operands, :math:`\texttt{bias}_1` and :math:`\texttt{bias}_2` are the input biases,
+and :math:`\texttt{exp_bits}_3` is the target bit width. Note that this formula still
+results in an IEEE-like bias when the inputs use IEEE-like biases.
 """
 
 APyFloatArray.__doc__ = r"""
 Class for multidimensional arrays with configurable floating-point formats.
 
 :class:`APyFloatArray` is a class for multidimensional arrays with configurable
-floating-point formats. The interface is much like the one of NumPy,
-and direct plotting is supported by most functions in Matplotlib.
-:class:`APyFloatArray` should always be preferred, if possible, when working with
-arrays as it allows for better performance, and integration with other features of APyTypes.
+floating-point formats. The interface is much like the one of NumPy, and direct plotting
+is supported by most functions in Matplotlib. :class:`APyFloatArray` should always be
+preferred, if possible, when working with arrays as it allows for better performance,
+and integration with other features of APyTypes.
 
 For information about the workings of floating-point numbers, see its scalar
 equivalent :class:`APyFloat`.
@@ -165,11 +170,12 @@ equivalent :class:`APyFloat`.
 APyFloatQuantizationContext.__doc__ = r"""
 Context for changing the quantization mode used for floating-point operations.
 
-If not specified explicitly, floating-point operations will use the quantization mode that is set globally,
-which is :class:`QuantizationMode.TIES_EVEN` by default. The mode however can be changed using the static method
-:func:`apytypes.set_float_quantization_mode`, or, preferably, by using a so-called quantization context.
-With a quantization context one can change the quantization mode used by all operations within a specific section
-in the code.
+If not specified explicitly, floating-point operations will use the quantization mode
+that is set globally, which is :class:`QuantizationMode.TIES_EVEN` by default. The mode
+however can be changed using the static method
+:func:`apytypes.set_float_quantization_mode`, or, preferably, by using a so-called
+quantization context. With a quantization context one can change the quantization mode
+used by all operations within a specific section in the code.
 
 Examples
 --------
@@ -195,7 +201,7 @@ Stochastic rounding with an optional seed
 
 >>> m = QuantizationMode.STOCH_WEIGHTED
 >>> s = 0x1234
->>> with APyFloatQuantizationContext(quantization=m, quantization_seed=s):
+>>> with APyFloatQuantizationContext(quantization=m, seed=s):
 ...     a + b
 APyFloat(sign=0, exp=16, man=683, exp_bits=5, man_bits=10)
 
@@ -204,11 +210,12 @@ Nesting the contexts is also possible.
 """
 
 APyFloatAccumulatorContext.__doc__ = r"""
-Context for using custom accumulators when performing inner products and matrix multiplications.
+Context for using custom accumulators when performing inner products and matrix
+multiplications.
 
-Inner products and matrix multiplications will by default perform the summation in the resulting format
-of the operands, but with :class:`APyFloatAccumulatorContext` a custom accumulator can be simulated
-as seen in the example below.
+Inner products and matrix multiplications will by default perform the summation in the
+resulting format of the operands, but with :class:`APyFloatAccumulatorContext` a custom
+accumulator can be simulated as seen in the example below.
 
 Examples
 --------
@@ -234,8 +241,8 @@ Matrix multiplication using stochastic quantization and a wider accumulator
 ...     d = A @ b.T
 
 
-If no quantization mode is specified to the accumulator context it will fallback to the mode set globally,
-see :class:`APyFloatQuantizationContext`.
+If no quantization mode is specified to the accumulator context it will fallback to the
+mode set globally, see :class:`APyFloatQuantizationContext`.
 """
 
 APyFixed.__doc__ = r"""

--- a/lib/apytypes/_apytypes.pyi
+++ b/lib/apytypes/_apytypes.pyi
@@ -132,33 +132,40 @@ def get_float_quantization_mode() -> QuantizationMode:
 
 def set_float_quantization_seed(seed: int) -> None:
     """
-    Set current quantization seed.
-
-    The quantization seed is used for stochastic quantization.
+    Reset the floating-point default stochastic quantization engine.
 
     Parameters
     ----------
     seed : :class:`int`
-        The quantization seed to use.
+        The quantization seed passed to the default engine.
+    """
 
-    See Also
-    --------
-    get_float_quantization_seed
+def set_fixed_quantization_seed(seed: int) -> None:
+    """
+    Reset the fixed-point default stochastic quantization engine.
+
+    Parameters
+    ----------
+    seed : :class:`int`
+        The quantization seed passed to the default engine.
     """
 
 def get_float_quantization_seed() -> int:
     """
-    Set current quantization seed.
-
-    The quantization seed is used for stochastic quantization.
+    Retrieve the currently used floating-point quantization seed.
 
     Returns
     -------
     :class:`int`
+    """
 
-    See Also
-    --------
-    set_float_quantization_seed
+def get_fixed_quantization_seed() -> int:
+    """
+    Retrieve the currently used fixed-point quantization seed.
+
+    Returns
+    -------
+    :class:`int`
     """
 
 class APyCFixed:
@@ -4695,9 +4702,10 @@ class APyFloat:
     .. math::
         \texttt{bias}_3 = \frac{\left ( \left (\texttt{bias}_1 + 1 \right ) / 2^{\texttt{exp_bits}_1} + \left (\texttt{bias}_2 + 1 \right ) / 2^{\texttt{exp_bits}_2} \right ) \times 2^{\texttt{exp_bits}_3}}{2} - 1,
 
-    where :math:`\texttt{exp_bits}_1` and :math:`\texttt{exp_bits}_2` are the bit widths of the operands, :math:`\texttt{bias}_1` and :math:`\texttt{bias}_2` are the
-    input biases, and :math:`\texttt{exp_bits}_3` is the target bit width.
-    Note that this formula still results in an IEEE-like bias when the inputs use IEEE-like biases.
+    where :math:`\texttt{exp_bits}_1` and :math:`\texttt{exp_bits}_2` are the bit widths of
+    the operands, :math:`\texttt{bias}_1` and :math:`\texttt{bias}_2` are the input biases,
+    and :math:`\texttt{exp_bits}_3` is the target bit width. Note that this formula still
+    results in an IEEE-like bias when the inputs use IEEE-like biases.
     """
 
     def __init__(
@@ -5392,10 +5400,10 @@ class APyFloatArray:
     Class for multidimensional arrays with configurable floating-point formats.
 
     :class:`APyFloatArray` is a class for multidimensional arrays with configurable
-    floating-point formats. The interface is much like the one of NumPy,
-    and direct plotting is supported by most functions in Matplotlib.
-    :class:`APyFloatArray` should always be preferred, if possible, when working with
-    arrays as it allows for better performance, and integration with other features of APyTypes.
+    floating-point formats. The interface is much like the one of NumPy, and direct plotting
+    is supported by most functions in Matplotlib. :class:`APyFloatArray` should always be
+    preferred, if possible, when working with arrays as it allows for better performance,
+    and integration with other features of APyTypes.
 
     For information about the workings of floating-point numbers, see its scalar
     equivalent :class:`APyFloat`.
@@ -6779,11 +6787,12 @@ class APyFloatQuantizationContext(ContextManager):
     """
     Context for changing the quantization mode used for floating-point operations.
 
-    If not specified explicitly, floating-point operations will use the quantization mode that is set globally,
-    which is :class:`QuantizationMode.TIES_EVEN` by default. The mode however can be changed using the static method
-    :func:`apytypes.set_float_quantization_mode`, or, preferably, by using a so-called quantization context.
-    With a quantization context one can change the quantization mode used by all operations within a specific section
-    in the code.
+    If not specified explicitly, floating-point operations will use the quantization mode
+    that is set globally, which is :class:`QuantizationMode.TIES_EVEN` by default. The mode
+    however can be changed using the static method
+    :func:`apytypes.set_float_quantization_mode`, or, preferably, by using a so-called
+    quantization context. With a quantization context one can change the quantization mode
+    used by all operations within a specific section in the code.
 
     Examples
     --------
@@ -6809,7 +6818,7 @@ class APyFloatQuantizationContext(ContextManager):
 
     >>> m = QuantizationMode.STOCH_WEIGHTED
     >>> s = 0x1234
-    >>> with APyFloatQuantizationContext(quantization=m, quantization_seed=s):
+    >>> with APyFloatQuantizationContext(quantization=m, seed=s):
     ...     a + b
     APyFloat(sign=0, exp=16, man=683, exp_bits=5, man_bits=10)
 
@@ -6818,7 +6827,7 @@ class APyFloatQuantizationContext(ContextManager):
     """
 
     def __init__(
-        self, quantization: QuantizationMode, quantization_seed: int | None = None
+        self, quantization: QuantizationMode, seed: int | None = None
     ) -> None: ...
     def __enter__(self) -> None: ...
     def __exit__(
@@ -6847,11 +6856,12 @@ class APyFixedAccumulatorContext(ContextManager):
 
 class APyFloatAccumulatorContext(ContextManager):
     """
-    Context for using custom accumulators when performing inner products and matrix multiplications.
+    Context for using custom accumulators when performing inner products and matrix
+    multiplications.
 
-    Inner products and matrix multiplications will by default perform the summation in the resulting format
-    of the operands, but with :class:`APyFloatAccumulatorContext` a custom accumulator can be simulated
-    as seen in the example below.
+    Inner products and matrix multiplications will by default perform the summation in the
+    resulting format of the operands, but with :class:`APyFloatAccumulatorContext` a custom
+    accumulator can be simulated as seen in the example below.
 
     Examples
     --------
@@ -6877,8 +6887,8 @@ class APyFloatAccumulatorContext(ContextManager):
     ...     d = A @ b.T
 
 
-    If no quantization mode is specified to the accumulator context it will fallback to the mode set globally,
-    see :class:`APyFloatQuantizationContext`.
+    If no quantization mode is specified to the accumulator context it will fallback to the
+    mode set globally, see :class:`APyFloatQuantizationContext`.
     """
 
     def __init__(

--- a/lib/test/apyfixed/test_quantization.py
+++ b/lib/test/apyfixed/test_quantization.py
@@ -6,7 +6,7 @@ from apytypes import APyCFixed, APyFixed, QuantizationMode
 @pytest.mark.parametrize(
     ("fixed_type", "im"), [(APyFixed, 1), (APyCFixed, 1), (APyCFixed, 1j)]
 )
-def test_trn(fixed_type, im):
+def test_trn(fixed_type: type[APyCFixed], im: complex):
     mode = QuantizationMode.TRN
     assert fixed_type.from_float(-0.75 * im, 1, 2).cast(1, 4, mode) == -0.75 * im
     assert fixed_type.from_float(-0.75 * im, 1, 2).cast(2, 1, mode) == -1.0 * im
@@ -36,7 +36,7 @@ def test_trn(fixed_type, im):
 @pytest.mark.parametrize(
     ("fixed_type", "im"), [(APyFixed, 1), (APyCFixed, 1), (APyCFixed, 1j)]
 )
-def test_trn_inf(fixed_type, im):
+def test_trn_inf(fixed_type: type[APyCFixed], im: complex):
     mode = QuantizationMode.TRN_INF
     assert fixed_type.from_float(-0.75 * im, 1, 2).cast(1, 4, mode) == -0.75 * im
     assert fixed_type.from_float(-0.75 * im, 1, 2).cast(1, 1, mode) == -0.5 * im
@@ -68,7 +68,7 @@ def test_trn_inf(fixed_type, im):
 @pytest.mark.parametrize(
     ("fixed_type", "im"), [(APyFixed, 1), (APyCFixed, 1), (APyCFixed, 1j)]
 )
-def test_trn_away(fixed_type, im):
+def test_trn_away(fixed_type: type[APyCFixed], im: complex):
     mode = QuantizationMode.TRN_AWAY
     assert fixed_type.from_float(-0.75 * im, 1, 2).cast(1, 4, mode) == -0.75 * im
     assert fixed_type.from_float(-0.75 * im, 1, 2).cast(1, 1, mode) == -1.0 * im
@@ -100,7 +100,7 @@ def test_trn_away(fixed_type, im):
 @pytest.mark.parametrize(
     ("fixed_type", "im"), [(APyFixed, 1), (APyCFixed, 1), (APyCFixed, 1j)]
 )
-def test_trn_zero(fixed_type, im):
+def test_trn_zero(fixed_type: type[APyCFixed], im: complex):
     mode = QuantizationMode.TRN_ZERO
     assert fixed_type.from_float(-0.75 * im, 1, 2).cast(1, 4, mode) == -0.75 * im
     assert fixed_type.from_float(-0.75 * im, 1, 2).cast(1, 1, mode) == -0.5 * im
@@ -132,7 +132,7 @@ def test_trn_zero(fixed_type, im):
 @pytest.mark.parametrize(
     ("fixed_type", "im"), [(APyFixed, 1), (APyCFixed, 1), (APyCFixed, 1j)]
 )
-def test_trn_mag(fixed_type, im):
+def test_trn_mag(fixed_type: type[APyCFixed], im: complex):
     mode = QuantizationMode.TRN_MAG
     assert fixed_type.from_float(-0.75 * im, 1, 2).cast(1, 4, mode) == -0.75 * im
     assert fixed_type.from_float(-0.75 * im, 1, 2).cast(1, 1, mode) == -0.5 * im
@@ -162,7 +162,7 @@ def test_trn_mag(fixed_type, im):
 @pytest.mark.parametrize(
     ("fixed_type", "im"), [(APyFixed, 1), (APyCFixed, 1), (APyCFixed, 1j)]
 )
-def test_rnd(fixed_type, im):
+def test_rnd(fixed_type: type[APyCFixed], im: complex):
     mode = QuantizationMode.RND
     assert fixed_type.from_float(-0.75 * im, 1, 2).cast(1, 4, mode) == -0.75 * im
     assert fixed_type.from_float(-0.75 * im, 1, 2).cast(1, 1, mode) == -0.5 * im
@@ -194,7 +194,7 @@ def test_rnd(fixed_type, im):
 @pytest.mark.parametrize(
     ("fixed_type", "im"), [(APyFixed, 1), (APyCFixed, 1), (APyCFixed, 1j)]
 )
-def test_rnd_zero(fixed_type, im):
+def test_rnd_zero(fixed_type: type[APyCFixed], im: complex):
     mode = QuantizationMode.RND_ZERO
     assert fixed_type.from_float(-0.75 * im, 1, 2).cast(1, 4, mode) == -0.75 * im
     assert fixed_type.from_float(-0.75 * im, 1, 2).cast(1, 1, mode) == -0.5 * im
@@ -226,7 +226,7 @@ def test_rnd_zero(fixed_type, im):
 @pytest.mark.parametrize(
     ("fixed_type", "im"), [(APyFixed, 1), (APyCFixed, 1), (APyCFixed, 1j)]
 )
-def test_rnd_inf(fixed_type, im):
+def test_rnd_inf(fixed_type: type[APyCFixed], im: complex):
     mode = QuantizationMode.RND_INF
     assert fixed_type.from_float(-0.75 * im, 1, 2).cast(1, 4, mode) == -0.75 * im
     assert fixed_type.from_float(-0.75 * im, 1, 2).cast(1, 1, mode) == -1.0 * im
@@ -265,7 +265,7 @@ def test_rnd_inf(fixed_type, im):
 @pytest.mark.parametrize(
     ("fixed_type", "im"), [(APyFixed, 1), (APyCFixed, 1), (APyCFixed, 1j)]
 )
-def test_rnd_min_inf(fixed_type, im):
+def test_rnd_min_inf(fixed_type: type[APyCFixed], im: complex):
     mode = QuantizationMode.RND_MIN_INF
     assert fixed_type.from_float(-0.75 * im, 1, 2).cast(1, 4, mode) == -0.75 * im
     assert fixed_type.from_float(-0.75 * im, 1, 2).cast(1, 1, mode) == -1.0 * im
@@ -304,7 +304,7 @@ def test_rnd_min_inf(fixed_type, im):
 @pytest.mark.parametrize(
     ("fixed_type", "im"), [(APyFixed, 1), (APyCFixed, 1), (APyCFixed, 1j)]
 )
-def test_rnd_conv(fixed_type, im):
+def test_rnd_conv(fixed_type: type[APyCFixed], im: complex):
     mode = QuantizationMode.RND_CONV
     assert fixed_type.from_float(-0.75 * im, 1, 2).cast(1, 4, mode) == -0.75 * im
     assert fixed_type.from_float(-0.25 * im, 3, 2).cast(3, 0, mode) == 0.0 * im
@@ -340,7 +340,7 @@ def test_rnd_conv(fixed_type, im):
 @pytest.mark.parametrize(
     ("fixed_type", "im"), [(APyFixed, 1), (APyCFixed, 1), (APyCFixed, 1j)]
 )
-def test_rnd_conv_odd(fixed_type, im):
+def test_rnd_conv_odd(fixed_type: type[APyCFixed], im: complex):
     mode = QuantizationMode.RND_CONV_ODD
     assert fixed_type.from_float(-0.75 * im, 1, 2).cast(1, 4, mode) == -0.75 * im
     assert fixed_type.from_float(-0.25 * im, 3, 2).cast(3, 0, mode) == 0.0 * im
@@ -453,7 +453,7 @@ def test_jam():
 @pytest.mark.parametrize(
     ("fixed_type", "im"), [(APyFixed, 1), (APyCFixed, 1), (APyCFixed, 1j)]
 )
-def test_jam_unbiased(fixed_type, im):
+def test_jam_unbiased(fixed_type: type[APyCFixed], im: complex):
     mode = QuantizationMode.JAM_UNBIASED
     assert fixed_type.from_float(-0.75 * im, 1, 2).cast(1, 4, mode) == -0.75 * im
     assert fixed_type.from_float(-2.25 * im, 3, 2).cast(3, 0, mode) == -3.0 * im
@@ -493,18 +493,64 @@ def test_jam_unbiased(fixed_type, im):
     assert fixed_type.from_float(0.0 * im, -1, 6).cast(5, 0, mode) == 0.0 * im
 
 
-@pytest.mark.parametrize(
-    ("fixed_type", "im"), [(APyFixed, 1), (APyCFixed, 1), (APyCFixed, 1j)]
-)
-def test_stochastic_weighted(fixed_type, im):
-    pass
+def test_stochastic_equal():
+    #
+    # The probability of rounding `N` independent trials of
+    # `QuantizationMode.STOCH_EQUAL` up, follows a R.V. X, s.t.: X ~ Bin(N, 0.5).
+    # Set `p` and `N` such that Pr(X > pN) is escencially non-existent.
+    #
+    N = 50000
+    rel_tol = 0.030  # 3.0% tolerance ==> Pr(X > pN) == 2.161e-41
+    frac_bits = 3
+    mode = QuantizationMode.STOCH_EQUAL
+    for i in range(2**frac_bits):
+        histogram: dict[int, int] = {0: 0, 1: 0}
+        for _ in range(N):
+            fx = APyFixed(i, int_bits=20, frac_bits=frac_bits).cast(20, 0, mode)
+            histogram[fx.to_bits()] += 1
+        assert histogram[0] <= N * (0.5 + rel_tol)
+        assert histogram[0] >= N * (0.5 - rel_tol)
+        assert histogram[1] <= N * (0.5 + rel_tol)
+        assert histogram[1] >= N * (0.5 - rel_tol)
+
+    # Stochastically "not" quantizing
+    for frac_bits in range(10, 15):
+        for _ in range(100):
+            fx = APyFixed.from_float(5.0, int_bits=10, frac_bits=10)
+            fx_cast = fx.cast(int_bits=15, frac_bits=frac_bits, quantization=mode)
+            fx_cast_ref = APyFixed.from_float(5.0, int_bits=15, frac_bits=frac_bits)
+            assert fx_cast.is_identical(fx_cast_ref)
 
 
-@pytest.mark.parametrize(
-    ("fixed_type", "im"), [(APyFixed, 1), (APyCFixed, 1), (APyCFixed, 1j)]
-)
-def test_stochastic_equal(fixed_type, im):
-    pass
+def test_stochastic_weighted():
+    #
+    # The probability of rounding `N` independent trials of
+    # `QuantizationMode.STOCH_WEIGHTED` up, follows a R.V. X, s.t.: X ~ Bin(N, k), where
+    # `k` = (x - floor(x))/(ceil(x) - floor(x)).
+    # Set `p` and `N` such that Pr(X >= pN) is escencially non-existent.
+    #
+    N = 50000
+    rel_tol = 0.030  # 3.0% tolerance ==> Pr(X > pN) == 2.161e-41
+    frac_bits = 3
+    mode = QuantizationMode.STOCH_WEIGHTED
+    for i in range(2**frac_bits):
+        k: float = i / 2**frac_bits
+        histogram: dict[int, int] = {0: 0, 1: 0}
+        for _ in range(N):
+            fx = APyFixed(i, int_bits=20, frac_bits=frac_bits).cast(20, 0, mode)
+            histogram[fx.to_bits()] += 1
+        assert histogram[0] <= N * ((1 - k) + rel_tol)
+        assert histogram[0] >= N * ((1 - k) - rel_tol)
+        assert histogram[1] <= N * (k + rel_tol)
+        assert histogram[1] >= N * (k - rel_tol)
+
+    # Stochastically "not" quantizing
+    for frac_bits in range(10, 15):
+        for _ in range(100):
+            fx = APyFixed.from_float(5.0, int_bits=10, frac_bits=10)
+            fx_cast = fx.cast(int_bits=15, frac_bits=frac_bits, quantization=mode)
+            fx_cast_ref = APyFixed.from_float(5.0, int_bits=15, frac_bits=frac_bits)
+            assert fx_cast.is_identical(fx_cast_ref)
 
 
 @pytest.mark.parametrize(
@@ -525,7 +571,9 @@ def test_stochastic_equal(fixed_type, im):
         QuantizationMode.JAM_UNBIASED,
     ],
 )
-def test_huge_narrowing_cast(fixed_type, im, mode):
+def test_huge_narrowing_cast(
+    fixed_type: type[APyCFixed], im: complex, mode: QuantizationMode
+):
     assert fixed_type.from_float(-0.75 * im, 1000, 500).cast(1, 4, mode) == -0.75 * im
 
 
@@ -547,36 +595,24 @@ def test_huge_narrowing_cast(fixed_type, im, mode):
         QuantizationMode.JAM_UNBIASED,
     ],
 )
-def test_huge_extending_cast(fixed_type, im, mode):
+def test_huge_extending_cast(
+    fixed_type: type[APyCFixed], im: complex, mode: QuantizationMode
+):
     assert fixed_type.from_float(-0.75 * im, 5, 2).cast(500, 500, mode) == -0.75 * im
 
 
-# All of the non-implemented Python quantization methods for APyFixed
-@pytest.mark.parametrize("fixed_type", [APyFixed, APyCFixed])
-@pytest.mark.parametrize(
-    "mode",
-    [
-        QuantizationMode.STOCH_WEIGHTED,
-        QuantizationMode.STOCH_EQUAL,
-    ],
-)
-def test_not_implemented(fixed_type, mode):
-    with pytest.raises(ValueError, match=r"Not implemented"):
-        fixed_type(0, 1, 0).cast(bits=1, int_bits=0, quantization=mode)
-
-
 @pytest.mark.parametrize(
     ("fixed_type", "im"), [(APyFixed, 1), (APyCFixed, 1), (APyCFixed, 1j)]
 )
-def test_issue_112(fixed_type, im):
+def test_issue_112(fixed_type: type[APyCFixed], im: complex):
     # Smoke test to make sure that it doesn't seg-fault
-    fixed_type.from_float(123 * im, int_bits=119, frac_bits=0).cast(4, 0)
+    _ = fixed_type.from_float(123 * im, int_bits=119, frac_bits=0).cast(4, 0)
 
 
 @pytest.mark.parametrize(
     ("fixed_type", "im"), [(APyFixed, 1), (APyCFixed, 1), (APyCFixed, 1j)]
 )
-def test_issue_179(fixed_type, im):
+def test_issue_179(fixed_type: type[APyCFixed], im: complex):
     #
     # https://github.com/apytypes/apytypes/issues/179
     #
@@ -623,7 +659,7 @@ def test_issue_179(fixed_type, im):
 @pytest.mark.parametrize(
     ("fixed_type", "im"), [(APyFixed, 1), (APyCFixed, 1), (APyCFixed, 1j)]
 )
-def test_exactly_full_limb_quantize(fixed_type, im):
+def test_exactly_full_limb_quantize(fixed_type: type[APyCFixed], im: complex):
     # Truncate towards minus infinity
     mode = QuantizationMode.TRN
     fx1 = fixed_type.from_float(-0.5 * im, 0, 64).cast(64, 0, quantization=mode)
@@ -762,7 +798,7 @@ def test_exactly_full_limb_quantize(fixed_type, im):
         QuantizationMode.JAM_UNBIASED,
     ],
 )
-def test_issue_335(fixed_type, mode):
+def test_issue_335(fixed_type: type[APyCFixed], mode: QuantizationMode):
     # Smoke test for GitHub issue #335.
     # These tests are designed to trigger invalid memory access using Valgrind memcheck.
     # Please don't remove it.
@@ -773,7 +809,7 @@ def test_issue_335(fixed_type, mode):
 @pytest.mark.parametrize(
     ("fixed_type", "im"), [(APyFixed, 1), (APyCFixed, 1), (APyCFixed, 1j)]
 )
-def test_quantize_away_all_bits(fixed_type, im):
+def test_quantize_away_all_bits(fixed_type: type[APyCFixed], im: complex):
     # Quantize away all of the bits. These are non-realistic quantizations, but need to
     # work nonetheless.
 
@@ -872,7 +908,7 @@ def test_quantize_away_all_bits(fixed_type, im):
 
 
 @pytest.mark.parametrize("fixed_type", [APyFixed, APyCFixed])
-def test_one_specifier(fixed_type):
+def test_one_specifier(fixed_type: type[APyCFixed]):
     # It is possible to specify only `int_bits` or `frac_bits`. Doing so preserves the
     # other specifier.
     a = fixed_type(0b0011_1100, int_bits=4, frac_bits=4)

--- a/lib/test/test_contextmanagers.py
+++ b/lib/test/test_contextmanagers.py
@@ -9,8 +9,10 @@ from apytypes import (
     APyFloatQuantizationContext,
     OverflowMode,
     QuantizationMode,
+    get_fixed_quantization_seed,
     get_float_quantization_mode,
     get_float_quantization_seed,
+    set_fixed_quantization_seed,
     set_float_quantization_mode,
     set_float_quantization_seed,
 )
@@ -95,8 +97,8 @@ class TestCastContext:
 
     def test_cast_context_overflow(self):
         """
-        If the previous tests pass for the quantization mode, then overflow should also work.
-        These are therefore more like sanity tests.
+        If the previous tests pass for the quantization mode, then overflow should also
+        work. These are therefore more like sanity tests.
         """
         a = APyFixed.from_float(4, int_bits=4, frac_bits=0)
         # WRAP by default
@@ -153,7 +155,8 @@ class TestCastContext:
 
     def test_cast_context_array(self):
         """
-        Basic sanity tests, if the scalar case works then it should work for arrays as well.
+        Basic sanity tests, if the scalar case works then it should work for arrays as
+        well.
         """
         a = APyFixedArray.from_float([4], int_bits=4, frac_bits=0)
         # WRAP by default
@@ -207,6 +210,13 @@ class TestCastContext:
             assert (_ := a.cast(int_bits=3, frac_bits=0)).is_identical(
                 APyFixedArray([3], int_bits=3, frac_bits=0)
             )
+
+    def test_cast_context_default_stoch_seed(self):
+        seed = get_fixed_quantization_seed()
+        new_seed = seed + 1
+        assert get_fixed_quantization_seed != new_seed
+        set_fixed_quantization_seed(new_seed)
+        assert get_fixed_quantization_seed() == new_seed
 
 
 class TestAccumulatorContext:
@@ -309,7 +319,6 @@ class TestQuantizationContext:
         set_float_quantization_seed(123)
         with APyFloatQuantizationContext(QuantizationMode.STOCH_EQUAL):
             assert get_float_quantization_mode() == QuantizationMode.STOCH_EQUAL
-            assert get_float_quantization_seed() == 123
         assert get_float_quantization_mode() == QuantizationMode.TO_POS
         assert get_float_quantization_seed() == 123
 

--- a/src/apyfixed.cc
+++ b/src/apyfixed.cc
@@ -1050,7 +1050,9 @@ APyFixed::cast_no_overflow(int bits, int int_bits, QuantizationMode quantization
     limb_vector_copy_sign_extend(src_begin, src_end, dst_begin, dst_end);
 
     // Perform quantization
-    quantize(dst_begin, dst_end, _bits, _int_bits, bits, int_bits, quantization);
+    quantize(
+        dst_begin, dst_end, _bits, _int_bits, bits, int_bits, quantization, rnd64_fx
+    );
 
     // Set the result bit-specifiers correctly
     result._bits = bits;

--- a/src/apytypes_context_wrapper.cc
+++ b/src/apytypes_context_wrapper.cc
@@ -1,5 +1,6 @@
 #include "apytypes_common.h"
 #include <nanobind/nanobind.h>
+#include <nanobind/stl/function.h>
 #include <nanobind/stl/optional.h>
 
 namespace nb = nanobind;
@@ -32,7 +33,7 @@ void bind_quantization_context(nb::module_& m)
         .def(
             nb::init<QuantizationMode, std::optional<std::uint64_t>>(),
             nb::arg("quantization"),
-            nb::arg("quantization_seed") = nb::none()
+            nb::arg("seed") = nb::none()
         )
 
         .def("__enter__", &context_enter_handler)

--- a/src/apytypes_wrapper.cc
+++ b/src/apytypes_wrapper.cc
@@ -248,36 +248,54 @@ void bind_common(nb::module_& m)
         )pbdoc")
         .def(
             "set_float_quantization_seed",
-            &set_float_quantization_seed,
+            &rst_default_rnd64_fp,
             nb::arg("seed"),
             R"pbdoc(
-        Set current quantization seed.
+            Reset the floating-point default stochastic quantization engine.
 
-        The quantization seed is used for stochastic quantization.
-
-        Parameters
-        ----------
-        seed : :class:`int`
-            The quantization seed to use.
-
-        See Also
-        --------
-        get_float_quantization_seed
+            Parameters
+            ----------
+            seed : :class:`int`
+                The quantization seed passed to the default engine.
         )pbdoc"
         )
-        .def("get_float_quantization_seed", &get_float_quantization_seed, R"pbdoc(
-        Set current quantization seed.
+        .def(
+            "set_fixed_quantization_seed",
+            &rst_default_rnd64_fx,
+            nb::arg("seed"),
+            R"pbdoc(
+            Reset the fixed-point default stochastic quantization engine.
 
-        The quantization seed is used for stochastic quantization.
+            Parameters
+            ----------
+            seed : :class:`int`
+                The quantization seed passed to the default engine.
+            )pbdoc"
+        )
+        .def(
+            "get_float_quantization_seed",
+            &get_rnd64_fp_seed,
+            R"pbdoc(
+            Retrieve the currently used floating-point quantization seed.
 
-        Returns
-        -------
-        :class:`int`
+            Returns
+            -------
+            :class:`int`
 
-        See Also
-        --------
-        set_float_quantization_seed
-        )pbdoc")
+            )pbdoc"
+        )
+        .def(
+            "get_fixed_quantization_seed",
+            &get_rnd64_fx_seed,
+            R"pbdoc(
+            Retrieve the currently used fixed-point quantization seed.
+
+            Returns
+            -------
+            :class:`int`
+
+            )pbdoc"
+        )
 
         /* Get the APyTypes SIMD version string */
         .def("_get_simd_version_str", &simd::get_simd_version_str);


### PR DESCRIPTION
# PR Summary
Removes the usage of `APyFixed` from `floating_point_mul_general()`.

## PR Checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

- N/A "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [ ] new and changed code is tested
- N/A relevant changes added to [CHANGELOG.md](https://github.com/apytypes/apytypes/blob/main/CHANGELOG.md)
- N/A new functionality is documented
