### PR TITLE
Add example for approximate floating-point multiplication

### DIFF
--- a/examples/approximate_multiplication.py
+++ b/examples/approximate_multiplication.py
@@ -1,0 +1,56 @@
+"""
+Approximate floating-point multiplication
+=========================================
+
+This example compares an approximate floating-point multiplication to the mathematically correct result.
+The approximation is based on Mitchell's logarithm approximation and the reference is the unquantized result.
+
+(Example inspired from T. Lindberg and O. Gustafsson, "Exact Eight-Bit Floating-Point Multiplication Using Integer Arithmetic", in *Proc. Asilomar Conf. Signals Syst. Comput.*, 2025.)
+"""
+
+import matplotlib.pyplot as plt
+from matplotlib import ticker
+
+import apytypes as apy
+
+EXP_BITS, MAN_BITS = (4, 3)
+
+input_values = apy.fullrange(1, 2, exp_bits=EXP_BITS, man_bits=MAN_BITS)
+
+xx, yy = apy.meshgrid(input_values, input_values)
+
+# Calculate the reference using a format wide enough to capture the exact result
+ref = xx.cast(EXP_BITS, 2 * MAN_BITS) * yy
+
+
+def approx_mul(x, y):
+    return apy.APyFloat.from_bits(
+        x.to_bits() + y.to_bits() - (x.bias << x.man_bits), EXP_BITS, MAN_BITS
+    )
+
+
+result = apy.zeros_like(ref, exp_bits=EXP_BITS, man_bits=MAN_BITS)
+for xi, x in enumerate(input_values):
+    for yi, y in enumerate(input_values):
+        result[xi, yi] = approx_mul(x, y)
+
+error = result - ref
+
+# %%
+# Plot the results
+fig, ax = plt.subplots()
+
+ax.set_xlabel(r"$x$")
+ax.set_ylabel(r"$y$")
+ax.set_aspect("equal")
+
+ax.xaxis.set_major_locator(ticker.MultipleLocator(2 * 2**-MAN_BITS))
+ax.yaxis.set_major_locator(ticker.MultipleLocator(2 * 2**-MAN_BITS))
+
+pcol = ax.pcolormesh(
+    xx.to_numpy(), yy.to_numpy(), error.to_numpy(), ec="k", lw=0.1, cmap="Blues_r"
+)
+cbar = fig.colorbar(pcol)
+cbar.ax.set_title("Error")
+
+plt.show()

--- a/examples/ode_solver.py
+++ b/examples/ode_solver.py
@@ -15,7 +15,7 @@ The ODE in question is
 
 and the solution is the unit circle in the (u, v) plane.
 
-(Example was inspired from M. Croci, M. Fasi, N. J Higham, T. Mary, M. Mikaitis. "Stochastic Rounding: Implementation, Error Analysis, and Applications", in *Royal Society Open Science*, 2022.)
+(Example inspired from M. Croci, M. Fasi, N. J Higham, T. Mary, M. Mikaitis. "Stochastic Rounding: Implementation, Error Analysis, and Applications", in *Royal Society Open Science*, 2022.)
 """
 
 import math


### PR DESCRIPTION
<!--
Thank you so much for your PR!
-->

# PR Summary
<!-- Please provide at least 1-2 sentences describing the pull request in detail
(Why is this change required?  What problem does it solve?) and link to relevant
issues and PRs.
-->
New example: plot the error of an approximate E4M3 multiplication. 

`.to_numpy()` is used before plotting at the moment, see issue #769.

## PR Checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

- [N/A] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [N/A] new and changed code is tested
- [N/A] relevant changes added to [CHANGELOG.md](https://github.com/apytypes/apytypes/blob/main/CHANGELOG.md)
- [N/A] new functionality is documented
