### PR TITLE
Handle dtype and copy arguments in __array__

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   functions.
 - Array creation methods: `fullrange`, `meshgrid`.
 - CSV import/export of arrays: `import_csv` and `export_csv`.
+- `to_numpy` and `__array__` now accepts `dtype` and `copy` arguments.
 
 ### Fixed
 

--- a/examples/approximate_multiplication.py
+++ b/examples/approximate_multiplication.py
@@ -47,9 +47,7 @@ ax.set_aspect("equal")
 ax.xaxis.set_major_locator(ticker.MultipleLocator(2 * 2**-MAN_BITS))
 ax.yaxis.set_major_locator(ticker.MultipleLocator(2 * 2**-MAN_BITS))
 
-pcol = ax.pcolormesh(
-    xx.to_numpy(), yy.to_numpy(), error.to_numpy(), ec="k", lw=0.1, cmap="Blues_r"
-)
+pcol = ax.pcolormesh(xx, yy, error, ec="k", lw=0.1, cmap="Blues_r")
 cbar = fig.colorbar(pcol)
 cbar.ax.set_title("Error")
 

--- a/lib/apytypes/_apytypes.pyi
+++ b/lib/apytypes/_apytypes.pyi
@@ -770,12 +770,21 @@ class APyCFixedArray:
                    :class:`APyCFixedArray`
         """
 
-    def to_numpy(self) -> Annotated[ArrayLike, dict(dtype="complex128")]:
+    def to_numpy(
+        self, dtype: object | None = None, copy: bool | None = None
+    ) -> Annotated[ArrayLike, dict(dtype="complex128")]:
         """
         Return array as a :class:`numpy.ndarray` of :class:`numpy.complex128`.
 
         The returned array has the same `shape` and values as `self`. This
         method rounds away from infinity on ties.
+
+        Parameters
+        ----------
+        dtype : :std:doc:`numpy:dtype`
+            The desired data type of the output array. This parameter is currently ignored.
+        copy : :class:`bool`
+            Whether to copy the data or not. Must be :code:`True` or :code:`None`.
 
         Returns
         -------
@@ -1623,7 +1632,9 @@ class APyCFixedArray:
         val: APyCFixedArray | APyCFixed,
     ) -> None: ...
     def __len__(self) -> int: ...
-    def __array__(self) -> Annotated[ArrayLike, dict(dtype="complex128")]: ...
+    def __array__(
+        self, dtype: object | None = None, copy: bool | None = None
+    ) -> Annotated[ArrayLike, dict(dtype="complex128")]: ...
 
 class APyCFloat:
     """
@@ -2680,12 +2691,21 @@ class APyCFloatArray:
             An array filled with the specified value.
         """
 
-    def to_numpy(self) -> Annotated[ArrayLike, dict(dtype="complex128")]:
+    def to_numpy(
+        self, dtype: object | None = None, copy: bool | None = None
+    ) -> Annotated[ArrayLike, dict(dtype="complex128")]:
         """
         Return array as a :class:`numpy.ndarray` of :class:`numpy.complex128`.
 
         The returned array has the same `shape` and values as `self`. This
         method rounds away from infinity on ties.
+
+        Parameters
+        ----------
+        dtype : :std:doc:`numpy:dtype`
+            The desired data type of the output array. This parameter is currently ignored.
+        copy : :class:`bool`
+            Whether to copy the data or not. Must be :code:`True` or :code:`None`.
 
         Returns
         -------
@@ -3076,6 +3096,9 @@ class APyCFloatArray:
         val: APyCFloatArray | APyCFloat,
     ) -> None: ...
     def __len__(self) -> int: ...
+    def __array__(
+        self, dtype: object | None = None, copy: bool | None = None
+    ) -> Annotated[ArrayLike, dict(dtype="complex128")]: ...
 
 class APyFixed:
     r"""
@@ -3687,12 +3710,21 @@ class APyFixedArray:
         :class:`APyFixedArray`
         """
 
-    def to_numpy(self) -> Annotated[ArrayLike, dict(dtype="float64")]:
+    def to_numpy(
+        self, dtype: object | None = None, copy: bool | None = None
+    ) -> Annotated[ArrayLike, dict(dtype="float64")]:
         """
         Return array as a :class:`numpy.ndarray` of :class:`numpy.float64`.
 
         The returned array has the same `shape` and values as `self`. This
         method rounds away from infinity on ties.
+
+        Parameters
+        ----------
+        dtype : :std:doc:`numpy:dtype`
+            The desired data type of the output array. This parameter is currently ignored.
+        copy : :class:`bool`
+            Whether to copy the data or not. Must be :code:`True` or :code:`None`.
 
         Returns
         -------
@@ -4641,7 +4673,9 @@ class APyFixedArray:
     ) -> None: ...
     def __len__(self) -> int: ...
     def __iter__(self) -> APyFixedArrayIterator: ...
-    def __array__(self) -> Annotated[ArrayLike, dict(dtype="float64")]: ...
+    def __array__(
+        self, dtype: object | None = None, copy: bool | None = None
+    ) -> Annotated[ArrayLike, dict(dtype="float64")]: ...
 
 class APyFixedArrayIterator:
     def __iter__(self) -> APyFixedArrayIterator: ...
@@ -5593,12 +5627,21 @@ class APyFloatArray:
         :class:`APyFloatArray`
         """
 
-    def to_numpy(self) -> Annotated[ArrayLike, dict(dtype="float64")]:
+    def to_numpy(
+        self, dtype: object | None = None, copy: bool | None = None
+    ) -> Annotated[ArrayLike, dict(dtype="float64")]:
         """
         Return array as a :class:`numpy.ndarray` of :class:`numpy.float64`.
 
         The returned array has the same `shape` and values as `self`. This
         method rounds away from infinity on ties.
+
+        Parameters
+        ----------
+        dtype : :std:doc:`numpy:dtype`
+            The desired data type of the output array. This parameter is currently ignored.
+        copy : :class:`bool`
+            Whether to copy the data or not. Must be :code:`True` or :code:`None`.
 
         Returns
         -------
@@ -6652,7 +6695,9 @@ class APyFloatArray:
         val: APyFloatArray | APyFloat,
     ) -> None: ...
     def __iter__(self) -> APyFloatArrayIterator: ...
-    def __array__(self) -> Annotated[ArrayLike, dict(dtype="float64")]: ...
+    def __array__(
+        self, dtype: object | None = None, copy: bool | None = None
+    ) -> Annotated[ArrayLike, dict(dtype="float64")]: ...
     def cast(
         self,
         exp_bits: int | None = None,

--- a/lib/test/apyfixedarray/test_methods.py
+++ b/lib/test/apyfixedarray/test_methods.py
@@ -674,6 +674,80 @@ def test_to_numpy(fixed_array: type[APyCFixedArray]):
     assert np.array_equal(fx_arr.to_numpy(), np.array(float_seq))
 
 
+@pytest.mark.parametrize(
+    "dt",
+    [
+        "int8",
+        "int16",
+        "int32",
+        "int64",
+        "uint8",
+        "uint16",
+        "uint32",
+        "uint64",
+        "float32",
+        "float64",
+    ],
+)
+@pytest.mark.parametrize(
+    "copy",
+    [
+        False,
+        True,
+    ],
+)
+def test_to_numpy_args_real(dt: str, copy: bool):
+    # Skip this test if `NumPy` is not present on the machine
+    np = pytest.importorskip("numpy")
+
+    # Test with different dtypes
+    fp_arr = APyFixedArray.from_float(range(5), 10, 10)
+
+    if copy:
+        assert np.array_equal(
+            fp_arr.to_numpy(dtype=dt, copy=copy), np.array(range(5), dtype=dt)
+        )
+    else:
+        with pytest.raises(
+            ValueError,
+            match=r"APyFixedArray\.to_numpy: copy must be True",
+        ):
+            _ = fp_arr.to_numpy(dtype=dt, copy=copy)
+
+
+@pytest.mark.parametrize(
+    "dt",
+    [
+        "complex64",
+        "complex128",
+    ],
+)
+@pytest.mark.parametrize(
+    "copy",
+    [
+        False,
+        True,
+    ],
+)
+def test_to_numpy_args_complex(dt: str, copy: bool):
+    # Skip this test if `NumPy` is not present on the machine
+    np = pytest.importorskip("numpy")
+
+    # Test with different dtypes
+    fp_arr = APyCFixedArray.from_float(range(5), 10, 10)
+
+    if copy:
+        assert np.array_equal(
+            fp_arr.to_numpy(dtype=dt, copy=copy), np.array(range(5), dtype=dt)
+        )
+    else:
+        with pytest.raises(
+            ValueError,
+            match=r"APyCFixedArray\.to_numpy: copy must be True",
+        ):
+            _ = fp_arr.to_numpy(dtype=dt, copy=copy)
+
+
 def test_iterator():
     fx_array = APyFixedArray([1, 2, 3, 4, 5, 6], bits=10, int_bits=10)
     iterator = iter(fx_array)

--- a/lib/test/apyfloatarray/test_methods.py
+++ b/lib/test/apyfloatarray/test_methods.py
@@ -394,6 +394,80 @@ def test_to_numpy(float_array: type[APyCFloatArray]):
     assert np.array_equal(fp_arr.to_numpy(), np.array(float_seq))
 
 
+@pytest.mark.parametrize(
+    "dt",
+    [
+        "int8",
+        "int16",
+        "int32",
+        "int64",
+        "uint8",
+        "uint16",
+        "uint32",
+        "uint64",
+        "float32",
+        "float64",
+    ],
+)
+@pytest.mark.parametrize(
+    "copy",
+    [
+        False,
+        True,
+    ],
+)
+def test_to_numpy_args_real(dt: str, copy: bool):
+    # Skip this test if `NumPy` is not present on the machine
+    np = pytest.importorskip("numpy")
+
+    # Test with different dtypes
+    fp_arr = APyFloatArray.from_float(range(5), 10, 10)
+
+    if copy:
+        assert np.array_equal(
+            fp_arr.to_numpy(dtype=dt, copy=copy), np.array(range(5), dtype=dt)
+        )
+    else:
+        with pytest.raises(
+            ValueError,
+            match=r"APyFloatArray\.to_numpy: copy must be True",
+        ):
+            _ = fp_arr.to_numpy(dtype=dt, copy=copy)
+
+
+@pytest.mark.parametrize(
+    "dt",
+    [
+        "complex64",
+        "complex128",
+    ],
+)
+@pytest.mark.parametrize(
+    "copy",
+    [
+        False,
+        True,
+    ],
+)
+def test_to_numpy_args_complex(dt: str, copy: bool):
+    # Skip this test if `NumPy` is not present on the machine
+    np = pytest.importorskip("numpy")
+
+    # Test with different dtypes
+    fp_arr = APyCFloatArray.from_float(range(5), 10, 10)
+
+    if copy:
+        assert np.array_equal(
+            fp_arr.to_numpy(dtype=dt, copy=copy), np.array(range(5), dtype=dt)
+        )
+    else:
+        with pytest.raises(
+            ValueError,
+            match=r"APyCFloatArray\.to_numpy: copy must be True",
+        ):
+            _ = fp_arr.to_numpy(dtype=dt, copy=copy)
+
+
 @pytest.mark.float_array
 def test_iterator():
     fx_array = APyFloatArray.from_float([1, 2, 3, 4, 5, 6], exp_bits=10, man_bits=10)

--- a/src/apyarray.h
+++ b/src/apyarray.h
@@ -969,7 +969,7 @@ public:
         }
 
         // Check that arrays have the same bit specifiers and a 1-D shape
-        for (auto i = 0; i < array_vec.size(); ++i) {
+        for (std::size_t i = 0; i < array_vec.size(); ++i) {
             if (!array_vec[i].is_same_spec(array_vec[0])) {
                 throw nb::value_error(
                     "meshgrid: all arrays must have the same bit specifiers"

--- a/src/apycfixedarray.cc
+++ b/src/apycfixedarray.cc
@@ -961,8 +961,16 @@ std::string APyCFixedArray::repr() const
     return array_repr({ formatter }, kw_args);
 }
 
-nb::ndarray<nb::numpy, std::complex<double>> APyCFixedArray::to_numpy() const
+nb::ndarray<nb::numpy, std::complex<double>> APyCFixedArray::to_numpy(
+    std::optional<nb::object> dtype, std::optional<bool> copy
+) const
 {
+    (void)dtype;
+
+    if (!copy.value_or(true)) {
+        throw nb::value_error("APyCFixedArray.to_numpy: copy must be True");
+    }
+
     // Dynamically allocate data to be passed to python
     std::complex<double>* result = new std::complex<double>[_nitems];
     auto _frac_bits = frac_bits();

--- a/src/apycfixedarray.h
+++ b/src/apycfixedarray.h
@@ -206,7 +206,10 @@ public:
     std::string repr() const;
 
     //! Convert to a NumPy array
-    nb::ndarray<nb::numpy, std::complex<double>> to_numpy() const;
+    nb::ndarray<nb::numpy, std::complex<double>> to_numpy(
+        std::optional<nb::object> dtype = std::nullopt,
+        std::optional<bool> copy = std::nullopt
+    ) const;
 
     //! Sum over one or more axes.
     std::variant<APyCFixedArray, APyCFixed>

--- a/src/apycfixedarray_wrapper.cc
+++ b/src/apycfixedarray_wrapper.cc
@@ -238,16 +238,29 @@ void bind_cfixed_array(nb::module_& m)
             )pbdoc"
         )
 
-        .def("to_numpy", &APyCFixedArray::to_numpy, R"pbdoc(
+        .def(
+            "to_numpy",
+            &APyCFixedArray::to_numpy,
+            nb::arg("dtype") = nb::none(),
+            nb::arg("copy") = nb::none(),
+            R"pbdoc(
             Return array as a :class:`numpy.ndarray` of :class:`numpy.complex128`.
 
             The returned array has the same `shape` and values as `self`. This
             method rounds away from infinity on ties.
 
+            Parameters
+            ----------
+            dtype : :std:doc:`numpy:dtype`
+                The desired data type of the output array. This parameter is currently ignored.
+            copy : :class:`bool`
+                Whether to copy the data or not. Must be :code:`True` or :code:`None`.
+
             Returns
             -------
             :class:`numpy.ndarray`
-            )pbdoc")
+            )pbdoc"
+        )
 
         //.def(
         //    "to_bits",
@@ -1222,7 +1235,12 @@ void bind_cfixed_array(nb::module_& m)
         //             );
         //         }
         //     )
-        .def("__array__", &APyCFixedArray::to_numpy)
+        .def(
+            "__array__",
+            &APyCFixedArray::to_numpy,
+            nb::arg("dtype") = nb::none(),
+            nb::arg("copy") = nb::none()
+        )
 
         ;
 

--- a/src/apycfloatarray.cc
+++ b/src/apycfloatarray.cc
@@ -392,8 +392,16 @@ std::string APyCFloatArray::to_string(int base) const
     }
 }
 
-nb::ndarray<nb::numpy, std::complex<double>> APyCFloatArray::to_numpy() const
+nb::ndarray<nb::numpy, std::complex<double>> APyCFloatArray::to_numpy(
+    std::optional<nb::object> dtype, std::optional<bool> copy
+) const
 {
+    (void)dtype;
+
+    if (!copy.value_or(true)) {
+        throw nb::value_error("APyCFloatArray.to_numpy: copy must be True");
+    }
+
     // Dynamically allocate data to be passed to Python
     std::complex<double>* result_data = new std::complex<double>[_nitems];
     auto fp_re = APyFloat(exp_bits, man_bits, bias);

--- a/src/apycfloatarray.h
+++ b/src/apycfloatarray.h
@@ -185,7 +185,10 @@ public:
     std::string to_string_dec() const;
 
     //! Convert to a NumPy array
-    nanobind::ndarray<nanobind::numpy, std::complex<double>> to_numpy() const;
+    nanobind::ndarray<nanobind::numpy, std::complex<double>> to_numpy(
+        std::optional<nb::object> dtype = std::nullopt,
+        std::optional<bool> copy = std::nullopt
+    ) const;
 
     //! Return the bias.
     APY_INLINE exp_t get_bias() const noexcept { return bias; }

--- a/src/apycfloatarray_wrapper.cc
+++ b/src/apycfloatarray_wrapper.cc
@@ -842,16 +842,29 @@ void bind_cfloat_array(nb::module_& m)
             )pbdoc"
         )
 
-        .def("to_numpy", &APyCFloatArray::to_numpy, R"pbdoc(
+        .def(
+            "to_numpy",
+            &APyCFloatArray::to_numpy,
+            nb::arg("dtype") = nb::none(),
+            nb::arg("copy") = nb::none(),
+            R"pbdoc(
             Return array as a :class:`numpy.ndarray` of :class:`numpy.complex128`.
 
             The returned array has the same `shape` and values as `self`. This
             method rounds away from infinity on ties.
 
+            Parameters
+            ----------
+            dtype : :std:doc:`numpy:dtype`
+                The desired data type of the output array. This parameter is currently ignored.
+            copy : :class:`bool`
+                Whether to copy the data or not. Must be :code:`True` or :code:`None`.
+
             Returns
             -------
             :class:`numpy.ndarray`
-            )pbdoc")
+            )pbdoc"
+        )
 
         .def(
             "broadcast_to",
@@ -1240,6 +1253,10 @@ void bind_cfloat_array(nb::module_& m)
         .def("__getitem__", &APyCFloatArray::get_item, nb::arg("key"))
         .def("__setitem__", &APyCFloatArray::set_item, nb::arg("key"), nb::arg("val"))
         .def("__len__", &APyCFloatArray::size)
-
-        ;
+        .def(
+            "__array__",
+            &APyCFloatArray::to_numpy,
+            nb::arg("dtype") = nb::none(),
+            nb::arg("copy") = nb::none()
+        );
 }

--- a/src/apyfixedarray.cc
+++ b/src/apyfixedarray.cc
@@ -1244,8 +1244,15 @@ nb::list APyFixedArray::to_signed_bits() const
     return to_bits_python_recursive_descent(0, it, true);
 }
 
-nb::ndarray<nb::numpy, double> APyFixedArray::to_numpy() const
+nb::ndarray<nb::numpy, double>
+APyFixedArray::to_numpy(std::optional<nb::object> dtype, std::optional<bool> copy) const
 {
+    (void)dtype;
+
+    if (!copy.value_or(true)) {
+        throw nb::value_error("APyFixedArray.to_numpy: copy must be True");
+    }
+
     // Dynamically allocate data to be passed to python
     double* result_data = new double[_nitems];
 

--- a/src/apyfixedarray.h
+++ b/src/apyfixedarray.h
@@ -242,7 +242,10 @@ public:
     nb::list to_signed_bits() const;
 
     //! Convert to a NumPy array
-    nb::ndarray<nb::numpy, double> to_numpy() const;
+    nanobind::ndarray<nanobind::numpy, double> to_numpy(
+        std::optional<nb::object> dtype = std::nullopt,
+        std::optional<bool> copy = std::nullopt
+    ) const;
 
     //! Elementwise absolute value
     APyFixedArray abs() const;

--- a/src/apyfixedarray_wrapper.cc
+++ b/src/apyfixedarray_wrapper.cc
@@ -208,16 +208,29 @@ void bind_fixed_array(nb::module_& m)
             )pbdoc"
         )
 
-        .def("to_numpy", &APyFixedArray::to_numpy, R"pbdoc(
+        .def(
+            "to_numpy",
+            &APyFixedArray::to_numpy,
+            nb::arg("dtype") = nb::none(),
+            nb::arg("copy") = nb::none(),
+            R"pbdoc(
             Return array as a :class:`numpy.ndarray` of :class:`numpy.float64`.
 
             The returned array has the same `shape` and values as `self`. This
             method rounds away from infinity on ties.
 
+            Parameters
+            ----------
+            dtype : :std:doc:`numpy:dtype`
+                The desired data type of the output array. This parameter is currently ignored.
+            copy : :class:`bool`
+                Whether to copy the data or not. Must be :code:`True` or :code:`None`.
+
             Returns
             -------
             :class:`numpy.ndarray`
-            )pbdoc")
+            )pbdoc"
+        )
 
         .def(
             "to_bits",
@@ -1367,7 +1380,12 @@ void bind_fixed_array(nb::module_& m)
                 );
             }
         )
-        .def("__array__", &APyFixedArray::to_numpy)
+        .def(
+            "__array__",
+            &APyFixedArray::to_numpy,
+            nb::arg("dtype") = nb::none(),
+            nb::arg("copy") = nb::none()
+        )
 
         ;
 

--- a/src/apyfloatarray.cc
+++ b/src/apyfloatarray.cc
@@ -1037,8 +1037,23 @@ nb::list APyFloatArray::to_bits_python_recursive_descent(
     return result;
 }
 
-nb::ndarray<nb::numpy, double> APyFloatArray::to_numpy() const
+nb::ndarray<nb::numpy, double>
+APyFloatArray::to_numpy(std::optional<nb::object> dtype, std::optional<bool> copy) const
 {
+
+    // If someone in the future wants to check the dtype, this is how it can be done:
+    // const auto np = nb::module_::import_("numpy");
+    // const auto t = dtype.value_or(np.attr("float64"));
+    // if (!t.equal(np.attr("float64"))) {
+    //     throw nb::value_error("APyFloatArray::to_numpy: only supports float64
+    //     dtype");
+    // }
+    (void)dtype;
+
+    if (!copy.value_or(true)) {
+        throw nb::value_error("APyFloatArray.to_numpy: copy must be True");
+    }
+
     // Dynamically allocate data to be passed to Python
     double* result_data = new double[_nitems];
     auto fp = APyFloat(exp_bits, man_bits, bias);

--- a/src/apyfloatarray.h
+++ b/src/apyfloatarray.h
@@ -379,7 +379,10 @@ public:
     ) const;
 
     //! Convert to a NumPy array
-    nanobind::ndarray<nanobind::numpy, double> to_numpy() const;
+    nanobind::ndarray<nanobind::numpy, double> to_numpy(
+        std::optional<nb::object> dtype = std::nullopt,
+        std::optional<bool> copy = std::nullopt
+    ) const;
 
     //! Test if two floating-point arrays are identical, i.e., has the same values, and
     //! the same format

--- a/src/apyfloatarray_wrapper.cc
+++ b/src/apyfloatarray_wrapper.cc
@@ -233,16 +233,29 @@ void bind_float_array(nb::module_& m)
             :class:`APyFloatArray`
             )pbdoc"
         )
-        .def("to_numpy", &APyFloatArray::to_numpy, R"pbdoc(
+        .def(
+            "to_numpy",
+            &APyFloatArray::to_numpy,
+            nb::arg("dtype") = nb::none(),
+            nb::arg("copy") = nb::none(),
+            R"pbdoc(
             Return array as a :class:`numpy.ndarray` of :class:`numpy.float64`.
 
             The returned array has the same `shape` and values as `self`. This
             method rounds away from infinity on ties.
 
+            Parameters
+            ----------
+            dtype : :std:doc:`numpy:dtype`
+                The desired data type of the output array. This parameter is currently ignored.
+            copy : :class:`bool`
+                Whether to copy the data or not. Must be :code:`True` or :code:`None`.
+
             Returns
             -------
             :class:`numpy.ndarray`
-            )pbdoc")
+            )pbdoc"
+        )
         .def(
             "to_bits",
             &APyFloatArray::to_bits,
@@ -1454,7 +1467,12 @@ void bind_float_array(nb::module_& m)
                 );
             }
         )
-        .def("__array__", &APyFloatArray::to_numpy)
+        .def(
+            "__array__",
+            &APyFloatArray::to_numpy,
+            nb::arg("dtype") = nb::none(),
+            nb::arg("copy") = nb::none()
+        )
 
         .def(
             "cast",


### PR DESCRIPTION
<!--
Thank you so much for your PR!
-->

# PR Summary
<!-- Please provide at least 1-2 sentences describing the pull request in detail
(Why is this change required?  What problem does it solve?) and link to relevant
issues and PRs.
-->
Closes #777 and starts solving #769.

An exception is thrown if `copy=False` is passed, `copy=None` and `copy=True` are fine.

The `dtype` parameter is currently ignored and  `np.float64`/`np.complex128` is always returned.
NumPy seems to check the type afterwards and cast it if needed. I think this is fine, at least for now. Letting NumPy cast types automatically (if needed) will make APyTypes play more nicely with other libraries, although these conversions aren't exactly correct. 

I also removed the `.to_numpy()` from the example of approximate FP multiplication, PR #776.

## PR Checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

- [x] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] new and changed code is tested
- [x] relevant changes added to [CHANGELOG.md](https://github.com/apytypes/apytypes/blob/main/CHANGELOG.md)
- [x] new functionality is documented
