### PR TITLE
build: bump fmt-11.2.0-1 -> fmt-11.2.0-2

### DIFF
--- a/subprojects/fmt.wrap
+++ b/subprojects/fmt.wrap
@@ -3,11 +3,11 @@ directory = fmt-11.2.0
 source_url = https://github.com/fmtlib/fmt/archive/11.2.0.tar.gz
 source_filename = fmt-11.2.0.tar.gz
 source_hash = bc23066d87ab3168f27cef3e97d545fa63314f5c79df5ea444d41d56f962c6af
-patch_filename = fmt_11.2.0-1_patch.zip
-patch_url = https://wrapdb.mesonbuild.com/v2/fmt_11.2.0-1/get_patch
-patch_hash = 645bf1c335a24608b4b34f16ed10b9237bbb0131488668fb86454202239e086c
-source_fallback_url = https://github.com/mesonbuild/wrapdb/releases/download/fmt_11.2.0-1/fmt-11.2.0.tar.gz
-wrapdb_version = 11.2.0-1
+patch_filename = fmt_11.2.0-2_patch.zip
+patch_url = https://wrapdb.mesonbuild.com/v2/fmt_11.2.0-2/get_patch
+patch_hash = cc555cbfc9e334d5b670763894586ad6fbaf7f85eb5e67221cfe519b919c6542
+source_fallback_url = https://github.com/mesonbuild/wrapdb/releases/download/fmt_11.2.0-2/fmt-11.2.0.tar.gz
+wrapdb_version = 11.2.0-2
 
 [provide]
-fmt = fmt_dep
+dependency_names = fmt


### PR DESCRIPTION
# PR Summary
Bumps the fmt version from 11.2.0-1 -> 11.2.0-2. This should fix the problem with the Pyodide/WASM32 build:

* #576.

## PR Checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

- [N/A] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [N/A] new and changed code is tested
- [N/A] relevant changes added to [CHANGELOG.md](https://github.com/apytypes/apytypes/blob/main/CHANGELOG.md)
- [N/A] new functionality is documented
