### PR TITLE
ci: bump cibuildwheel 3.0.1 -> 3.1.4

### DIFF
--- a/.github/workflows/publish-test-pypi.yml
+++ b/.github/workflows/publish-test-pypi.yml
@@ -50,7 +50,7 @@ jobs:
           python-version: "3.11"
 
       - name: Install cibuildwheel
-        run: python -m pip install cibuildwheel==3.0.1 setuptools_scm
+        run: python -m pip install cibuildwheel==3.1.4 setuptools_scm
 
       - name: Build wheels
         run: python -m cibuildwheel --output-dir wheelhouse

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -90,7 +90,7 @@ testpaths = ["lib/test"]
 
 [tool.cibuildwheel]
 skip = [
-    "*t-win*", # no free-threading versions on Windows
+    "*t-win*",  # no free-threading versions on Windows
     "*-win32*", # win32 does not work
 ]
 enable = ["cpython-freethreading", "cpython-prerelease"]


### PR DESCRIPTION
# PR Summary
Bumping cibuildwheel to 3.1.4 is necessary to build the modern pyodide wheels.

## PR Checklist

- N/A "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- N/A new and changed code is tested
- N/A relevant changes added to [CHANGELOG.md](https://github.com/apytypes/apytypes/blob/main/CHANGELOG.md)
- N/A new functionality is documented
