### PR TITLE
src: add array-of-boolean slicing for `__getitem__` and `__setitem__`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Implemented `.to_bits()` and `.from_bits()` for `APyCFloat`.
 - LaTeX representation for `APyCFixed` and `APyCFloat`.
 - Array comparisons
+- Array slicing with boolean arrays slices (`__getitem__` and `__setitem__`)
 - Scalars are now instances of `Numbers` and `Real` and/or `Complex` (as appropriate).
 - `real` and `imag` properties for `APyFixed`, `APyFloat`, `APyFixedArray`, and `APyFloatArray`.
 - `trailing_zeros` property for `APyFixed`.

--- a/lib/apytypes/_apytypes.pyi
+++ b/lib/apytypes/_apytypes.pyi
@@ -1676,6 +1676,7 @@ class APyCFixedArray:
         key: int
         | slice
         | types.EllipsisType
+        | Annotated[NDArray[numpy.bool], dict(order="C")]
         | tuple[int | slice | types.EllipsisType, ...],
     ) -> APyCFixedArray | APyCFixed: ...
     def __setitem__(
@@ -1683,6 +1684,7 @@ class APyCFixedArray:
         key: int
         | slice
         | types.EllipsisType
+        | Annotated[NDArray[numpy.bool], dict(order="C")]
         | tuple[int | slice | types.EllipsisType, ...],
         val: APyCFixedArray | APyCFixed,
     ) -> None: ...
@@ -3214,6 +3216,7 @@ class APyCFloatArray:
         key: int
         | slice
         | types.EllipsisType
+        | Annotated[NDArray[numpy.bool], dict(order="C")]
         | tuple[int | slice | types.EllipsisType, ...],
     ) -> APyCFloatArray | APyCFloat: ...
     def __setitem__(
@@ -3221,6 +3224,7 @@ class APyCFloatArray:
         key: int
         | slice
         | types.EllipsisType
+        | Annotated[NDArray[numpy.bool], dict(order="C")]
         | tuple[int | slice | types.EllipsisType, ...],
         val: APyCFloatArray | APyCFloat,
     ) -> None: ...
@@ -4938,6 +4942,7 @@ class APyFixedArray:
         key: int
         | slice
         | types.EllipsisType
+        | Annotated[NDArray[numpy.bool], dict(order="C")]
         | tuple[int | slice | types.EllipsisType, ...],
     ) -> APyFixedArray | APyFixed: ...
     def __setitem__(
@@ -4945,6 +4950,7 @@ class APyFixedArray:
         key: int
         | slice
         | types.EllipsisType
+        | Annotated[NDArray[numpy.bool], dict(order="C")]
         | tuple[int | slice | types.EllipsisType, ...],
         val: APyFixedArray | APyFixed,
     ) -> None: ...
@@ -7097,6 +7103,7 @@ class APyFloatArray:
         key: int
         | slice
         | types.EllipsisType
+        | Annotated[NDArray[numpy.bool], dict(order="C")]
         | tuple[int | slice | types.EllipsisType, ...],
     ) -> APyFloatArray | APyFloat: ...
     def __setitem__(
@@ -7104,6 +7111,7 @@ class APyFloatArray:
         key: int
         | slice
         | types.EllipsisType
+        | Annotated[NDArray[numpy.bool], dict(order="C")]
         | tuple[int | slice | types.EllipsisType, ...],
         val: APyFloatArray | APyFloat,
     ) -> None: ...

--- a/src/array_utils.h
+++ b/src/array_utils.h
@@ -6,6 +6,7 @@
 #include "apytypes_util.h"
 
 #include <nanobind/nanobind.h>
+#include <nanobind/ndarray.h>
 #include <nanobind/stl/variant.h>
 namespace nb = nanobind;
 
@@ -23,7 +24,12 @@ using PyArrayKeyTuple_t = nb::
 //! and `__setitem__` array methods.
 //! Python signature:
 //! `int | slice | types.EllipsisType | tuple[int | slice | types.EllipsisType, ...]`
-using PyArrayKey_t = std::variant<nb::int_, nb::slice, nb::ellipsis, PyArrayKeyTuple_t>;
+using PyArrayKey_t = std::variant<
+    nb::int_,
+    nb::slice,
+    nb::ellipsis,
+    nb::ndarray<bool, nb::c_contig>,
+    PyArrayKeyTuple_t>;
 
 //! Typed Python tuple, used to denote the shape of array objects.
 //! Python signature: `tuple[int, ...]`


### PR DESCRIPTION
# PR Summary
This PR depends on:
* #813

This PR implements array-of-boolean slicing for the APyTypes arrays. The semantics of this new feature is, to the best of my knowledge, exactly the same as is in Numpy.

### Examples:

```python
>>> from apytypes import *

>>> a = fx([[0, 1, 2, 3],
>>>         [4, 5, 6, 7]], int_bits=10, frac_bits=0)
>>> a
APyFixedArray([[0, 1, 2, 3],
               [4, 5, 6, 7]], int_bits=10, frac_bits=0)


>>> a[a >= 3]
APyFixedArray([3, 4, 5, 6, 7], int_bits=10, frac_bits=0)

>>> a[a >= 3] = fx([10, 11, 12, 13, 14], int_bits=10, frac_bits=0)
>>> a
APyFixedArray([[ 0,  1,  2, 10],
               [11, 12, 13, 14]], int_bits=10, frac_bits=0)
```

## PR Checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

- [x] new and changed code is tested
- [x] relevant changes added to [CHANGELOG.md](https://github.com/apytypes/apytypes/blob/main/CHANGELOG.md)
