### PR TITLE
src: add complex conjugate and Hermitian transpose

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 `from_float`/`from_complex` to match the naming in Python 3.14.
 - Support for (de-)serialization of APyTypes' data types using the Python
   [pickle](https://docs.python.org/3/library/pickle.html) module.
+- Complex conjugate and Hermitian transpose.
 
 ### Fixed
 

--- a/docs/api/apycfixed.rst
+++ b/docs/api/apycfixed.rst
@@ -32,6 +32,13 @@
 
    .. automethod:: is_identical
 
+   Other
+   -----
+
+   .. automethod:: conj
+
+   .. automethod:: copy
+
    Properties
    ----------
 

--- a/docs/api/apycfixedarray.rst
+++ b/docs/api/apycfixedarray.rst
@@ -52,6 +52,8 @@
 
    .. automethod:: transpose
 
+   .. automethod:: hermitian_transpose
+
    Array shape manipulation
    ------------------------
 
@@ -75,6 +77,8 @@
    .. automethod:: cumsum
 
    .. automethod:: cumprod
+
+   .. automethod:: conj
 
    Convolution
    -----------
@@ -109,6 +113,8 @@
    ^^^^^^^^^^^^^
 
    .. autoproperty:: T
+
+   .. autoproperty:: H
 
    Real and imaginary part
    ^^^^^^^^^^^^^^^^^^^^^^^

--- a/docs/api/apycfloat.rst
+++ b/docs/api/apycfloat.rst
@@ -34,6 +34,13 @@
 
    .. automethod:: is_identical
 
+   Other
+   -----
+
+   .. automethod:: conj
+
+   .. automethod:: copy
+
    Properties
    ----------
 

--- a/docs/api/apycfloatarray.rst
+++ b/docs/api/apycfloatarray.rst
@@ -61,6 +61,8 @@
 
    .. automethod:: transpose
 
+   .. automethod:: hermitian_transpose
+
    Array shape manipulation
    ------------------------
 
@@ -100,6 +102,8 @@
    .. automethod:: nanmax
 
    .. automethod:: nanmin
+
+   .. automethod:: conj
 
    Broadcasting
    ------------
@@ -142,3 +146,12 @@
    ^^^^^^^^^^^^^
 
    .. autoproperty:: T
+
+   .. autoproperty:: H
+
+   Real and imaginary part
+   ^^^^^^^^^^^^^^^^^^^^^^^
+
+   .. autoproperty:: real
+
+   .. autoproperty:: imag

--- a/docs/api/apyfixed.rst
+++ b/docs/api/apyfixed.rst
@@ -39,6 +39,8 @@
 
    .. automethod:: to_fraction
 
+   .. automethod:: copy
+
    Properties
    ----------
 

--- a/docs/api/apyfloat.rst
+++ b/docs/api/apyfloat.rst
@@ -39,6 +39,8 @@
 
    .. automethod:: to_fraction
 
+   .. automethod:: copy
+
    Convenience methods
    -------------------
 

--- a/lib/apytypes/_apytypes.pyi
+++ b/lib/apytypes/_apytypes.pyi
@@ -535,6 +535,20 @@ class APyCFixed:
         :class:`APyCFixed`
         """
 
+    def conj(self) -> APyCFixed:
+        """
+        Retrieve complex conjugate.
+
+        The complex conjugate has one additional integer bit so that the result
+        never overflows.
+
+        .. versionadded:: 0.5
+
+        Returns
+        -------
+        :class:`APyCFixed`
+        """
+
     def __repr__(self) -> str: ...
     def __str__(self, base: int = 10) -> str: ...
     def __complex__(self) -> complex: ...
@@ -814,6 +828,22 @@ class APyCFixedArray:
                    Returns
                    -------
                    :class:`APyCFixedArray`
+        """
+
+    @property
+    def H(self) -> APyCFixedArray:
+        """
+        The Hermitian transpose of the array.
+
+        Equivalent to calling :func:`transpose` followed by :func:`conj`. The
+        Hermitian transpose has one additional integer bit so that the result never
+        overflows.
+
+        .. versionadded:: 0.5
+
+        Returns
+        -------
+        :class:`APyCFixedArray`
         """
 
     def to_numpy(
@@ -1659,6 +1689,35 @@ class APyCFixedArray:
             An array filled with the specified value.
         """
 
+    def conj(self) -> APyCFixedArray:
+        """
+        Retrieve complex conjugate.
+
+        The complex conjugate has one additional integer bit so that the result
+        never overflows.
+
+        .. versionadded:: 0.5
+
+        Returns
+        -------
+        :class:`APyCFixedArray`
+        """
+
+    def hermitian_transpose(self) -> APyCFixedArray:
+        """
+        Retrieve Hermitian transpose.
+
+        Equivalent to calling :func:`transpose` followed by :func:`conj`. The
+        Hermitian transpose has one additional integer bit so that the result never
+        overflows.
+
+        .. versionadded:: 0.5
+
+        Returns
+        -------
+        :class:`APyCFixedArray`
+        """
+
     def __matmul__(self, rhs: APyCFixedArray) -> APyCFixedArray | APyCFixed: ...
     def __repr__(self) -> str: ...
     def __str__(self, base: int = 10) -> str: ...
@@ -2058,6 +2117,17 @@ class APyCFloat:
         :class:`bool`
         """
 
+    def conj(self) -> APyCFloat:
+        """
+        Retrieve complex conjugate.
+
+        .. versionadded:: 0.5
+
+        Returns
+        -------
+        :class:`APyCFloat`
+        """
+
     @property
     def man_bits(self) -> int:
         """
@@ -2284,7 +2354,21 @@ class APyCFloatArray:
         """
         The transposition of the array.
 
-        Equivalent to calling :func:`APyCFloatArray.transpose`.
+        Equivalent to calling :func:`transpose`.
+
+        Returns
+        -------
+        :class:`APyCFloatArray`
+        """
+
+    @property
+    def H(self) -> APyCFloatArray:
+        """
+        The Hermitian transpose of the array.
+
+        Equivalent to calling :func:`transpose` followed by :func:`conj`.
+
+        .. versionadded:: 0.5
 
         Returns
         -------
@@ -3186,6 +3270,30 @@ class APyCFloatArray:
             The convolved array.
         """
 
+    def conj(self) -> APyCFloatArray:
+        """
+        Retrieve complex conjugate.
+
+        .. versionadded:: 0.5
+
+        Returns
+        -------
+        :class:`APyCFloatArray`
+        """
+
+    def hermitian_transpose(self) -> APyCFloatArray:
+        """
+        Retrieve the Hermitian transpose.
+
+        This is equivalent to calling :func:`transpose` followed by :func:`conj`.
+
+        .. versionadded:: 0.5
+
+        Returns
+        -------
+        :class:`APyCFloatArray`
+        """
+
     def __matmul__(self, rhs: APyCFloatArray) -> APyCFloatArray | APyCFloat: ...
     def __repr__(self) -> str: ...
     def __str__(self, base: int = 10) -> str: ...
@@ -3953,7 +4061,7 @@ class APyFixedArray:
         """
         The transposition of the array.
 
-        Equivalent to calling :func:`APyFixedArray.transpose`.
+        Equivalent to calling :func:`transpose`.
 
         Returns
         -------
@@ -6028,7 +6136,7 @@ class APyFloatArray:
         """
         The transposition of the array.
 
-        Equivalent to calling :func:`APyFloatArray.transpose`.
+        Equivalent to calling :func:`transpose`.
 
         Returns
         -------

--- a/lib/test/test_hermitian_transpose.py
+++ b/lib/test/test_hermitian_transpose.py
@@ -1,0 +1,120 @@
+import pytest
+
+from apytypes import fp, fx
+
+
+@pytest.mark.parametrize("int_bits", [10, 32, 40, 64])
+@pytest.mark.parametrize("frac_bits", [0, 32, 64])
+@pytest.mark.parametrize(
+    ("val", "conj"),
+    [
+        (0.0, 0.0),
+        (1j, -1j),
+        (-1j, 1j),
+        (123.5 + 7j, 123.5 - 7j),
+    ],
+)
+def test_fixed_conj(int_bits: int, frac_bits: int, val: complex, conj: complex):
+    dat = fx(val, int_bits=int_bits, frac_bits=frac_bits, force_complex=True)
+    ref = fx(conj, int_bits=int_bits + 1, frac_bits=frac_bits, force_complex=True)
+    assert dat.conj().is_identical(ref)
+    assert dat.conj() == ref
+    assert ref.conj() == dat
+
+
+@pytest.mark.parametrize("exp_bits", [3, 10])
+@pytest.mark.parametrize("man_bits", [10, 30, 60])
+@pytest.mark.parametrize(
+    ("val", "conj"),
+    [
+        (0.0, 0.0),
+        (1j, -1j),
+        (-1j, 1j),
+        (123.5 + 7j, 123.5 - 7j),
+    ],
+)
+def test_float_conj(exp_bits: int, man_bits: int, val: complex, conj: complex):
+    dat = fp(val, exp_bits=exp_bits, man_bits=man_bits, force_complex=True)
+    ref = fp(conj, exp_bits=exp_bits, man_bits=man_bits, force_complex=True)
+    assert dat.conj().is_identical(ref, ignore_zero_sign=True)
+    assert ref.conj().is_identical(dat, ignore_zero_sign=True)
+
+
+@pytest.mark.parametrize("int_bits", [10, 32, 40, 64])
+@pytest.mark.parametrize("frac_bits", [0, 32, 64])
+@pytest.mark.parametrize(
+    ("val", "conj"),
+    [
+        ([0.0, 1j, -1j, 2.0, 1.0 + 2.5j], [0.0, -1j, 1j, 2.0, 1.0 - 2.5j]),
+    ],
+)
+def test_fixedarray_conj(
+    int_bits: int, frac_bits: int, val: list[complex], conj: list[complex]
+):
+    np = pytest.importorskip("numpy")
+    dat = fx(val, int_bits=int_bits, frac_bits=frac_bits, force_complex=True)
+    ref = fx(conj, int_bits=int_bits + 1, frac_bits=frac_bits, force_complex=True)
+    assert dat.conj().is_identical(ref)
+    assert np.all(dat.conj() == ref)
+    assert np.all(ref.conj() == dat)
+
+
+@pytest.mark.parametrize("exp_bits", [3, 10])
+@pytest.mark.parametrize("man_bits", [10, 30, 60])
+@pytest.mark.parametrize(
+    ("val", "conj"),
+    [
+        ([0.0, 1j, -1j, 2.0, 1.0 + 2.5j], [0.0, -1j, 1j, 2.0, 1.0 - 2.5j]),
+    ],
+)
+def test_floatarray_conj(
+    exp_bits: int, man_bits: int, val: list[complex], conj: list[complex]
+):
+    dat = fp(val, exp_bits=exp_bits, man_bits=man_bits, force_complex=True)
+    ref = fp(conj, exp_bits=exp_bits, man_bits=man_bits, force_complex=True)
+    assert dat.conj().is_identical(ref, ignore_zero_sign=True)
+    assert ref.conj().is_identical(dat, ignore_zero_sign=True)
+
+
+@pytest.mark.parametrize("int_bits", [10, 32, 40, 64])
+@pytest.mark.parametrize("frac_bits", [0, 32, 64])
+@pytest.mark.parametrize(
+    ("val"),
+    [
+        [[1.0 - 2j, 3 + 1.5j], [2.25, 4j]],
+        [[-3, -3], [1j, 2j]],
+        [[0, 0], [1, 0]],
+    ],
+)
+def test_fixedarray_hermitian_transpose(
+    int_bits: int, frac_bits: int, val: list[complex]
+):
+    np = pytest.importorskip("numpy")
+    dat = fx(val, int_bits=int_bits, frac_bits=frac_bits, force_complex=True)
+    ref = fx(val, int_bits=int_bits, frac_bits=frac_bits, force_complex=True).T.conj()
+    assert dat.H.is_identical(ref)
+    assert np.all(ref == dat.H)
+    assert np.all(dat == ref.H)
+    assert np.all(dat.hermitian_transpose() == ref)
+    assert np.all(ref.hermitian_transpose() == dat)
+
+
+@pytest.mark.parametrize("exp_bits", [3, 10])
+@pytest.mark.parametrize("man_bits", [10, 30, 60])
+@pytest.mark.parametrize(
+    ("val"),
+    [
+        [[1.0 - 2j, 3 + 1.5j], [2.25, 4j]],
+        [[-3, -3], [1j, 2j]],
+        [[0, 0], [1, 0]],
+    ],
+)
+def test_floatarray_hermitian_transpose(
+    exp_bits: int, man_bits: int, val: list[complex]
+):
+    dat = fp(val, exp_bits=exp_bits, man_bits=man_bits, force_complex=True)
+    ref = fp(val, exp_bits=exp_bits, man_bits=man_bits, force_complex=True).T.conj()
+    assert dat.H.is_identical(ref)
+    assert ref.H.is_identical(dat)
+    assert dat.hermitian_transpose().is_identical(ref, ignore_zero_sign=True)
+    assert ref.hermitian_transpose().is_identical(dat, ignore_zero_sign=True)

--- a/src/apycfixed.cc
+++ b/src/apycfixed.cc
@@ -12,6 +12,7 @@
 #include "apyfixed.h"
 #include "apyfixed_util.h"
 #include "apyfloat.h"
+#include "apytypes_fwd.h"
 #include "apytypes_util.h"
 #include "python_util.h"
 
@@ -716,6 +717,19 @@ void APyCFixed::python_unpickle(
     new_fx._data = limb_vector_from_u64_vec<decltype(_data)>(u64_vec);
     new_fx._data.resize(2 * bits_to_limbs(bits));
     new (apycfixed) APyCFixed(new_fx);
+}
+
+APyCFixed APyCFixed::conj() const
+{
+    APyCFixed res(bits() + 1, int_bits() + 1);
+    std::copy(real_begin(), real_end(), res.real_begin());
+    std::copy(imag_begin(), imag_end(), res.imag_begin());
+    if (res._data.size() > _data.size()) {
+        *(res.real_end() - 1) = apy_limb_signed_t(*(real_end() - 1)) < 0 ? -1 : 0;
+        *(res.imag_end() - 1) = apy_limb_signed_t(*(imag_end() - 1)) < 0 ? -1 : 0;
+    }
+    limb_vector_negate_inplace(res.imag_begin(), res.imag_end());
+    return res;
 }
 
 /* ********************************************************************************** *

--- a/src/apycfixed.h
+++ b/src/apycfixed.h
@@ -264,6 +264,9 @@ public:
         const std::tuple<int, int, std::vector<std::uint64_t>>& state
     );
 
+    //! Retrieve complex conjugate
+    APyCFixed conj() const;
+
     /* ****************************************************************************** *
      *                     Resize and quantization method (cast)                    * *
      * ****************************************************************************** */

--- a/src/apycfixed_wrapper.cc
+++ b/src/apycfixed_wrapper.cc
@@ -335,6 +335,23 @@ void bind_cfixed(nb::module_& m)
             :class:`APyCFixed`
             )pbdoc"
         )
+        .def(
+            "conj",
+            &APyCFixed::conj,
+            R"pbdoc(
+            Retrieve complex conjugate.
+
+            The complex conjugate has one additional integer bit so that the result
+            never overflows.
+
+            .. versionadded:: 0.5
+
+            Returns
+            -------
+            :class:`APyCFixed`
+            )pbdoc"
+        )
+
         /*
          * Dunder methods
          */

--- a/src/apycfixedarray.h
+++ b/src/apycfixedarray.h
@@ -261,6 +261,12 @@ public:
             tuple<int, int, std::vector<std::size_t>, std::vector<std::uint64_t>>& state
     );
 
+    //! Retrieve complex conjugate
+    APyCFixedArray conj() const;
+
+    //! Retrieve Hermitian transpose
+    APyCFixedArray hermitian_transpose() const;
+
     /* ****************************************************************************** *
      * *                           Static array creation                            * *
      * ****************************************************************************** */

--- a/src/apycfixedarray_wrapper.cc
+++ b/src/apycfixedarray_wrapper.cc
@@ -270,6 +270,23 @@ void bind_cfixed_array(nb::module_& m)
             :class:`APyCFixedArray`
             )pbdoc"
         )
+        .def_prop_ro(
+            "H",
+            [](const APyCFixedArray& self) { return self.hermitian_transpose(); },
+            R"pbdoc(
+            The Hermitian transpose of the array.
+
+            Equivalent to calling :func:`transpose` followed by :func:`conj`. The
+            Hermitian transpose has one additional integer bit so that the result never
+            overflows.
+
+            .. versionadded:: 0.5
+
+            Returns
+            -------
+            :class:`APyCFixedArray`
+            )pbdoc"
+        )
 
         .def(
             "to_numpy",
@@ -1251,6 +1268,40 @@ void bind_cfixed_array(nb::module_& m)
                             [(6, 0), (6, 0), (6, 0)]], int_bits=5, frac_bits=0)
             )pbdoc"
         )
+        .def(
+            "conj",
+            &APyCFixedArray::conj,
+            R"pbdoc(
+            Retrieve complex conjugate.
+
+            The complex conjugate has one additional integer bit so that the result
+            never overflows.
+
+            .. versionadded:: 0.5
+
+            Returns
+            -------
+            :class:`APyCFixedArray`
+            )pbdoc"
+        )
+        .def(
+            "hermitian_transpose",
+            &APyCFixedArray::hermitian_transpose,
+            R"pbdoc(
+            Retrieve Hermitian transpose.
+
+            Equivalent to calling :func:`transpose` followed by :func:`conj`. The
+            Hermitian transpose has one additional integer bit so that the result never
+            overflows.
+
+            .. versionadded:: 0.5
+
+            Returns
+            -------
+            :class:`APyCFixedArray`
+            )pbdoc"
+        )
+
         /*
          * Dunder methods
          */

--- a/src/apycfloat.cc
+++ b/src/apycfloat.cc
@@ -735,3 +735,10 @@ void APyCFloat::python_unpickle(
     auto&& im = APyFloatData::from_tuple(data[1]);
     new (apycfloat_ptr) APyCFloat(re, im, exp_bits, man_bits, bias);
 }
+
+APyCFloat APyCFloat::conj() const
+{
+    APyCFloat res = *this;
+    res.imag().sign ^= true;
+    return res;
+}

--- a/src/apycfloat.h
+++ b/src/apycfloat.h
@@ -332,6 +332,9 @@ public:
         const std::tuple<APyFloatSpec::Tuple, std::array<APyFloatData::Tuple, 2>>& state
     );
 
+    //! Retrieve complex conjugate
+    APyCFloat conj() const;
+
     /* ****************************************************************************** *
      * *                           Friends of `APyCFloat`                           * *
      * ****************************************************************************** */

--- a/src/apycfloat_wrapper.cc
+++ b/src/apycfloat_wrapper.cc
@@ -485,6 +485,19 @@ void bind_cfloat(nb::module_& m)
             :class:`bool`
             )pbdoc"
         )
+        .def(
+            "conj",
+            &APyCFloat::conj,
+            R"pbdoc(
+            Retrieve complex conjugate.
+
+            .. versionadded:: 0.5
+
+            Returns
+            -------
+            :class:`APyCFloat`
+            )pbdoc"
+        )
 
         /*
          * Properties

--- a/src/apycfloatarray.cc
+++ b/src/apycfloatarray.cc
@@ -13,6 +13,7 @@
 
 #include <cmath> // std::isnan, std::signbit
 #include <initializer_list>
+#include <optional>
 
 /* ********************************************************************************** *
  * *                         Non-Python accessible constructors                     * *
@@ -464,6 +465,26 @@ void APyCFloatArray::python_unpickle(
         std::begin(data), std::end(data), std::begin(fp_res._data), from_tuple
     );
     new (apycfloatarray) APyCFloatArray(fp_res);
+}
+
+//! Retrieve complex conjugate
+APyCFloatArray APyCFloatArray::conj() const
+{
+    APyCFloatArray res = *this;
+    for (std::size_t i = 0; i < _nitems; i++) {
+        res._data[2 * i + 1].sign ^= true;
+    }
+    return res;
+}
+
+//! Retrieve hermitian transpose
+APyCFloatArray APyCFloatArray::hermitian_transpose() const
+{
+    APyCFloatArray res = transpose(std::nullopt);
+    for (std::size_t i = 0; i < _nitems; i++) {
+        res._data[2 * i + 1].sign ^= true;
+    }
+    return res;
 }
 
 /* ********************************************************************************** *

--- a/src/apycfloatarray.h
+++ b/src/apycfloatarray.h
@@ -228,6 +228,12 @@ public:
             std::vector<APyFloatData::Tuple>>& state
     );
 
+    //! Retrieve complex conjugate
+    APyCFloatArray conj() const;
+
+    //! Retrieve Hermitian transpose
+    APyCFloatArray hermitian_transpose() const;
+
     /* ****************************************************************************** *
      * *                           Static array creation                            * *
      * ****************************************************************************** */

--- a/src/apycfloatarray_wrapper.cc
+++ b/src/apycfloatarray_wrapper.cc
@@ -239,7 +239,22 @@ void bind_cfloat_array(nb::module_& m)
             "T", [](const APyCFloatArray& self) { return self.transpose(); }, R"pbdoc(
             The transposition of the array.
 
-            Equivalent to calling :func:`APyCFloatArray.transpose`.
+            Equivalent to calling :func:`transpose`.
+
+            Returns
+            -------
+            :class:`APyCFloatArray`
+            )pbdoc"
+        )
+        .def_prop_ro(
+            "H",
+            [](const APyCFloatArray& self) { return self.hermitian_transpose(); },
+            R"pbdoc(
+            The Hermitian transpose of the array.
+
+            Equivalent to calling :func:`transpose` followed by :func:`conj`.
+
+            .. versionadded:: 0.5
 
             Returns
             -------
@@ -1262,6 +1277,34 @@ void bind_cfloat_array(nb::module_& m)
             -------
             convolved : :class:`APyCFloatArray`
                 The convolved array.
+            )pbdoc"
+        )
+        .def(
+            "conj",
+            &APyCFloatArray::conj,
+            R"pbdoc(
+            Retrieve complex conjugate.
+
+            .. versionadded:: 0.5
+
+            Returns
+            -------
+            :class:`APyCFloatArray`
+            )pbdoc"
+        )
+        .def(
+            "hermitian_transpose",
+            &APyCFloatArray::hermitian_transpose,
+            R"pbdoc(
+            Retrieve the Hermitian transpose.
+
+            This is equivalent to calling :func:`transpose` followed by :func:`conj`.
+
+            .. versionadded:: 0.5
+
+            Returns
+            -------
+            :class:`APyCFloatArray`
             )pbdoc"
         )
 

--- a/src/apyfixed.cc
+++ b/src/apyfixed.cc
@@ -10,11 +10,11 @@
 #include "apyfixed_util.h"
 #include "apyfloat.h"
 #include "apytypes_common.h"
+#include "apytypes_fwd.h"
+#include "apytypes_scratch_vector.h"
 #include "apytypes_util.h"
 #include "ieee754.h"
 #include "python_util.h"
-#include "src/apytypes_fwd.h"
-#include "src/apytypes_scratch_vector.h"
 
 // Python object access through Pybind
 #include <nanobind/nanobind.h>

--- a/src/apyfixedarray_wrapper.cc
+++ b/src/apyfixedarray_wrapper.cc
@@ -247,7 +247,7 @@ void bind_fixed_array(nb::module_& m)
             "T", [](const APyFixedArray& self) { return self.transpose(); }, R"pbdoc(
             The transposition of the array.
 
-            Equivalent to calling :func:`APyFixedArray.transpose`.
+            Equivalent to calling :func:`transpose`.
 
             Returns
             -------

--- a/src/apyfloatarray_wrapper.cc
+++ b/src/apyfloatarray_wrapper.cc
@@ -272,7 +272,7 @@ void bind_float_array(nb::module_& m)
             "T", [](const APyFloatArray& self) { return self.transpose(); }, R"pbdoc(
             The transposition of the array.
 
-            Equivalent to calling :func:`APyFloatArray.transpose`.
+            Equivalent to calling :func:`transpose`.
 
             Returns
             -------

--- a/src/apytypes_util.h
+++ b/src/apytypes_util.h
@@ -856,7 +856,7 @@ template <class RANDOM_ACCESS_ITERATOR>
         = (begin_it[limb_idx] & bit_unmask) | (apy_limb_t(bit) << bit_idx);
 }
 
-//! Take the two's complement negative value of a limb vector and place onto `res_out`
+//! Compute two's complement negative value and place onto `res_out`
 template <class RANDOM_ACCESS_ITERATOR_IN, class RANDOM_ACCESS_ITERATOR_OUT>
 [[maybe_unused]] static APY_INLINE apy_limb_t limb_vector_negate(
     RANDOM_ACCESS_ITERATOR_IN cbegin_it,
@@ -949,6 +949,22 @@ template <class RANDOM_ACCESS_ITERATOR>
 
 //! Copy limbs from `src` to `dst` and possibly sign extend the data in `dst`
 template <typename RANDOM_ACCESS_ITERATOR_IN, typename RANDOM_ACCESS_ITERATOR_OUT>
+[[maybe_unused]] static APY_INLINE void limb_vector_copy_n_sign_extend(
+    RANDOM_ACCESS_ITERATOR_IN src_begin,
+    std::size_t src_n,
+    RANDOM_ACCESS_ITERATOR_OUT dst_begin,
+    std::size_t dst_n
+)
+{
+    std::copy_n(src_begin, std::min(src_n, dst_n), dst_begin);
+    if (src_n < dst_n) {
+        bool is_negative = limb_vector_is_negative(src_begin, src_begin + src_n);
+        std::fill_n(dst_begin + src_n, dst_n - src_n, is_negative ? -1 : 0);
+    }
+}
+
+//! Copy limbs from `src` to `dst` and possibly sign extend the data in `dst`
+template <typename RANDOM_ACCESS_ITERATOR_IN, typename RANDOM_ACCESS_ITERATOR_OUT>
 [[maybe_unused]] static APY_INLINE void limb_vector_copy_sign_extend(
     RANDOM_ACCESS_ITERATOR_IN src_begin,
     RANDOM_ACCESS_ITERATOR_IN src_end,
@@ -956,16 +972,9 @@ template <typename RANDOM_ACCESS_ITERATOR_IN, typename RANDOM_ACCESS_ITERATOR_OU
     RANDOM_ACCESS_ITERATOR_OUT dst_end
 )
 {
-    std::size_t src_vector_size = std::distance(src_begin, src_end);
-    std::size_t dst_vector_size = std::distance(dst_begin, dst_end);
-    std::copy_n(src_begin, std::min(src_vector_size, dst_vector_size), dst_begin);
-    if (src_vector_size < dst_vector_size) {
-        std::fill(
-            dst_begin + src_vector_size,
-            dst_end,
-            limb_vector_is_negative(src_begin, src_end) ? -1 : 0
-        );
-    }
+    std::size_t src_n = std::distance(src_begin, src_end);
+    std::size_t dst_n = std::distance(dst_begin, dst_end);
+    limb_vector_copy_n_sign_extend(src_begin, src_n, dst_begin, dst_n);
 }
 
 //! Read an unsigned 64-bit value from a limb vector. If `APY_LIMB_SIZE_BITS == 64`,


### PR DESCRIPTION
# PR Summary
This PR implements the complex conjugate (`a.conj()`) for scalars and arrays, and the Hermitian transpose (`A.H`) for arrays.

## PR Checklist

- N/A "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] new and changed code is tested
- [x] relevant changes added to [CHANGELOG.md](https://github.com/apytypes/apytypes/blob/main/CHANGELOG.md)
- [x] new functionality is documented
