### PR TITLE
src: make RNG function pointers stateless

### DIFF
--- a/src/apyfixed_util.h
+++ b/src/apyfixed_util.h
@@ -434,7 +434,7 @@ static APY_INLINE void _quantize_stoch_equal(
     int int_bits,
     int new_bits,
     int new_int_bits,
-    std::function<std::uint64_t()> get_random_uint64
+    Rnd64FuncPtr_t get_random_uint64
 )
 {
     int frac_bits = bits - int_bits;
@@ -462,7 +462,7 @@ static APY_INLINE void _quantize_stoch_weighted(
     int int_bits,
     int new_bits,
     int new_int_bits,
-    std::function<std::uint64_t()> get_random_uint64
+    Rnd64FuncPtr_t get_random_uint64
 )
 {
     int frac_bits = bits - int_bits;
@@ -508,7 +508,7 @@ static void quantize(
     int new_bits,
     int new_int_bits,
     QuantizationMode quantization,
-    std::optional<std::function<std::uint64_t()>> get_random_uint64 = std::nullopt
+    Rnd64FuncPtr_t get_random_uint64 = nullptr
 )
 {
     /*
@@ -564,12 +564,12 @@ static void quantize(
         break;
     case QuantizationMode::STOCH_EQUAL:
         _quantize_stoch_equal(
-            it_begin, it_end, bits, int_bits, new_bits, new_int_bits, *get_random_uint64
+            it_begin, it_end, bits, int_bits, new_bits, new_int_bits, get_random_uint64
         );
         break;
     case QuantizationMode::STOCH_WEIGHTED:
         _quantize_stoch_weighted(
-            it_begin, it_end, bits, int_bits, new_bits, new_int_bits, *get_random_uint64
+            it_begin, it_end, bits, int_bits, new_bits, new_int_bits, get_random_uint64
         );
         break;
     default:

--- a/src/apytypes_common.h
+++ b/src/apytypes_common.h
@@ -46,6 +46,12 @@ enum class OverflowMode {
  * *            Random number engines for APyTypes stochastic quantization          * *
  * ********************************************************************************** */
 
+//! Uniform 64-bit random number generator function type
+using Rnd64Func_t = std::uint64_t();
+
+//! Uniform 64-bit random number generator function pointer type
+using Rnd64FuncPtr_t = Rnd64Func_t*;
+
 //! 64-bit uniform random number generator for fixed-point stachastic quantization
 std::uint64_t rnd64_fx();
 std::uint64_t rnd64_fp();
@@ -102,10 +108,7 @@ public:
 private:
     QuantizationMode prev_mode, new_mode;
     std::uint64_t prev_seed, new_seed;
-    const std::function<std::uint64_t()>& prev_engine;
-
-    std::mt19937_64 default_engine;
-    std::function<std::uint64_t()> new_engine;
+    std::mt19937_64 prev_engine, new_engine;
 };
 
 //! Set the global quantization mode for APyFloat


### PR DESCRIPTION
# PR Summary
This makes the pointers to random-number generators pure function pointers, which are always stateless. This may give some speedup to floating-point arithmetic and will speed up fixed-point quantization.

Related:
* #753 

## PR Checklist

- N/A "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] new and changed code is tested
- N/A relevant changes added to [CHANGELOG.md](https://github.com/apytypes/apytypes/blob/main/CHANGELOG.md)
- N/A new functionality is documented
