### PR TITLE
build: constrain `meson<=1.9.1` and remove ci macos-13

### DIFF
--- a/.github/workflows/publish-test-pypi.yml
+++ b/.github/workflows/publish-test-pypi.yml
@@ -36,7 +36,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, ubuntu-24.04-arm, windows-latest, macos-13, macos-latest] #  windows-11-arm,
+        os: [ubuntu-latest, ubuntu-24.04-arm, windows-latest, macos-15-intel, macos-latest] #  windows-11-arm,
 
     steps:
       - uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3  # v6.0.0

--- a/.github/workflows/run_coverage.yml
+++ b/.github/workflows/run_coverage.yml
@@ -34,7 +34,7 @@ jobs:
       run: |
         sudo apt-get install -yy lcov
         python -m pip install --upgrade pip
-        python -m pip install pytest-cov gcovr ninja meson-python numpy setuptools_scm
+        python -m pip install pytest-cov gcovr ninja "meson<=1.9.1" meson-python numpy setuptools_scm
     - name: Install APyTypes
       run: |
         git fetch --tags
@@ -70,7 +70,7 @@ jobs:
       fail-fast: false
       matrix:
         python-version: ["3.10"]
-        os: ["macos-13", "macos-14"]
+        os: ["macos-14", "macos-15-intel"]
 
     runs-on: ${{ matrix.os }}
     steps:
@@ -101,7 +101,7 @@ jobs:
         brew uninstall --ignore-dependencies --force pkg-config@0.29.2
         brew install ninja
         python -m pip install --upgrade pip
-        python -m pip install pytest-cov gcovr ninja meson-python numpy setuptools_scm
+        python -m pip install pytest-cov gcovr ninja "meson<=1.9.1" meson-python numpy setuptools_scm
     - name: Install APyTypes
       run: |
         git fetch --tags

--- a/.github/workflows/tests-32-bits.yml
+++ b/.github/workflows/tests-32-bits.yml
@@ -32,7 +32,7 @@ jobs:
       run: |
         sudo apt-get install -yy lcov
         python -m pip install --upgrade pip
-        python -m pip install pytest-cov gcovr ninja meson-python numpy setuptools_scm
+        python -m pip install pytest-cov gcovr ninja "meson<=1.9.1" meson-python numpy setuptools_scm
     - name: Install APyTypes
       run: |
         git fetch --tags
@@ -95,7 +95,7 @@ jobs:
         brew uninstall --ignore-dependencies --force pkg-config@0.29.2
         brew install ninja
         python -m pip install --upgrade pip
-        python -m pip install pytest-cov gcovr ninja meson-python numpy setuptools_scm
+        python -m pip install pytest-cov gcovr ninja "meson<=1.9.1" meson-python numpy setuptools_scm
     - name: Install APyTypes
       run: |
         git fetch --tags

--- a/.github/workflows/tests-cocotb.yml
+++ b/.github/workflows/tests-cocotb.yml
@@ -49,7 +49,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        python -m pip install pytest numpy meson-python setuptools_scm cocotb pytest-cov ninja vunit-hdl
+        python -m pip install pytest numpy "meson<=1.9.1" meson-python setuptools_scm cocotb pytest-cov ninja vunit-hdl
     - name: Install APyTypes
       run: |
         git fetch --tags

--- a/.github/workflows/tests-debug-memcheck.yml
+++ b/.github/workflows/tests-debug-memcheck.yml
@@ -44,7 +44,7 @@ jobs:
         sudo apt-get update
         sudo apt-get -y install ninja-build valgrind
         python -m pip install --upgrade pip
-        python -m pip install pytest numpy meson-python setuptools_scm
+        python -m pip install pytest numpy "meson<=1.9.1" meson-python setuptools_scm
     - name: Install APyTypes (debug mode)
       run: |
         git fetch --tags

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -26,7 +26,7 @@ jobs:
       fail-fast: false
       matrix:
         python-version: ["3.10", "3.11", "3.12", "3.13", "3.13t", "3.14", "3.14t"]
-        os: [ubuntu-latest, ubuntu-24.04-arm, windows-latest, macos-13, macos-14, macos-15] # windows-11-arm,
+        os: [ubuntu-latest, ubuntu-24.04-arm, windows-latest, macos-14, macos-15, macos-15-intel] # windows-11-arm,
         numpy-version: [">=1.26.4,<2", ">=2.1"]
         exclude:
           # Only Python 3.13 and later for windows-11-arm

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,7 +63,7 @@ comparison = [
 
 [build-system]
 build-backend = 'mesonpy'
-requires = ['meson-python>=0.16', 'setuptools_scm>=8.1']
+requires = ['meson<=1.9.1', 'meson-python>=0.16', 'setuptools_scm>=8.1']
 
 [tool.meson-python.args]
 install = ['--skip-subprojects']


### PR DESCRIPTION
Should temporarily fix the build.

Related:
* #855 

Closes: #830 