### PR TITLE
src: fix UB found by GCC address/undefined sanitizer

### DIFF
--- a/.github/workflows/tests-ub-sanitizers.yml
+++ b/.github/workflows/tests-ub-sanitizers.yml
@@ -1,0 +1,49 @@
+name: UB Sanitizers
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.number }}-${{ github.event.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
+jobs:
+  build:
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: [3.11]
+        limb-size: [32, 64]
+    runs-on: "ubuntu-24.04"
+
+    steps:
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+      with:
+        fetch-depth: 0
+        fetch-tags: true
+        persist-credentials: false
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
+      with:
+        python-version: ${{ matrix.python-version }}
+        allow-prereleases: true
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+    - name: Install NumPy
+      run: |
+        python -m pip install numpy
+    - name: Install APyTypes
+      run: |
+        git fetch --tags
+        python -m pip install .[test] -v              \
+          -Csetup-args="-Db_sanitize=undefined"       \
+          -Csetup-args="-Dlimb_size=${{ matrix.limb-size }}"
+    - name: Test with pytest
+      run: |
+        pytest --color=yes lib/test

--- a/src/apycfixed.cc
+++ b/src/apycfixed.cc
@@ -901,7 +901,7 @@ APyCFixed APyCFixed::from_double(
 {
     APyCFixed result(int_bits, frac_bits, bits);
     if (result._data.size() == 2) {
-        unsigned shift = 64 - (result._bits & (64 - 1));
+        unsigned shift = (APY_LIMB_SIZE_BITS - result._bits) & (APY_LIMB_SIZE_BITS - 1);
         int frac_bits = result.frac_bits();
         result._data[0] = fixed_point_from_double_single_limb(value, frac_bits, shift);
     } else {
@@ -959,7 +959,7 @@ APyCFixed APyCFixed::from_complex(
     double real = value.real();
     double imag = value.imag();
     if (result._data.size() == 2) {
-        unsigned shift = 64 - (result._bits & (64 - 1));
+        unsigned shift = (APY_LIMB_SIZE_BITS - result._bits) & (APY_LIMB_SIZE_BITS - 1);
         int frac_bits = result.frac_bits();
         result._data[0] = fixed_point_from_double_single_limb(real, frac_bits, shift);
         result._data[1] = fixed_point_from_double_single_limb(imag, frac_bits, shift);

--- a/src/apycfixedarray.cc
+++ b/src/apycfixedarray.cc
@@ -1366,7 +1366,7 @@ APyCFixedArray APyCFixedArray::from_complex(
     unsigned float_shift {};
     std::function<void(APyCFixedArray&, std::size_t, double, unsigned)> from_fp;
     if (result._itemsize == 2) {
-        float_shift = 64 - (result._bits & (64 - 1));
+        float_shift = (APY_LIMB_SIZE_BITS - result._bits) & (APY_LIMB_SIZE_BITS - 1);
         from_fp = [](APyCFixedArray& res, std::size_t i, double val, unsigned shift) {
             res._data[i]
                 = fixed_point_from_double_single_limb(val, res.frac_bits(), shift);
@@ -1635,16 +1635,16 @@ void APyCFixedArray::_set_values_from_ndarray(const nb::ndarray<nb::c_contig>& n
         if (ndarray.dtype() == nb::dtype<__TYPE__>()) {                                \
             auto view = ndarray.view<__TYPE__, nb::ndim<1>>();                         \
             if (_itemsize == 2) {                                                      \
-                unsigned limb_shift_val = bits() & (64 - 1);                           \
-                unsigned twos_complement_shift = 64 - limb_shift_val;                  \
+                unsigned limb_shift_val                                                \
+                    = (APY_LIMB_SIZE_BITS - bits()) & (APY_LIMB_SIZE_BITS - 1);        \
                 int _frac_bits = frac_bits();                                          \
                 for (std::size_t i = 0; i < ndarray.size(); i++) {                     \
                     std::complex<double> cplx = view.data()[i];                        \
                     _data[2 * i + 0] = fixed_point_from_double_single_limb(            \
-                        cplx.real(), _frac_bits, twos_complement_shift                 \
+                        cplx.real(), _frac_bits, limb_shift_val                        \
                     );                                                                 \
                     _data[2 * i + 1] = fixed_point_from_double_single_limb(            \
-                        cplx.imag(), _frac_bits, twos_complement_shift                 \
+                        cplx.imag(), _frac_bits, limb_shift_val                        \
                     );                                                                 \
                 }                                                                      \
             } else {                                                                   \
@@ -1677,12 +1677,12 @@ void APyCFixedArray::_set_values_from_ndarray(const nb::ndarray<nb::c_contig>& n
         if (ndarray.dtype() == nb::dtype<__TYPE__>()) {                                \
             auto view = ndarray.view<__TYPE__, nb::ndim<1>>();                         \
             if (_itemsize == 2) {                                                      \
-                unsigned limb_shift_val = bits() & (64 - 1);                           \
-                unsigned twos_complement_shift = 64 - limb_shift_val;                  \
+                unsigned limb_shift_val                                                \
+                    = (APY_LIMB_SIZE_BITS - bits()) & (APY_LIMB_SIZE_BITS - 1);        \
                 int _frac_bits = frac_bits();                                          \
                 for (std::size_t i = 0; i < ndarray.size(); i++) {                     \
                     _data[2 * i + 0] = fixed_point_from_double_single_limb(            \
-                        view.data()[i], _frac_bits, twos_complement_shift              \
+                        view.data()[i], _frac_bits, limb_shift_val                     \
                     );                                                                 \
                     _data[2 * i + 1] = 0;                                              \
                 }                                                                      \

--- a/src/apyfixed.cc
+++ b/src/apyfixed.cc
@@ -1030,10 +1030,9 @@ APyFixed APyFixed::from_double(
 {
     APyFixed result(int_bits, frac_bits, bits);
     if (result._data.size() == 1) {
-        unsigned shift_amount = 64 - (result._bits & (64 - 1));
-        result._data[0] = fixed_point_from_double_single_limb(
-            value, result.frac_bits(), shift_amount
-        );
+        unsigned shift = (APY_LIMB_SIZE_BITS - result._bits) & (APY_LIMB_SIZE_BITS - 1);
+        result._data[0]
+            = fixed_point_from_double_single_limb(value, result.frac_bits(), shift);
     } else {
         assert(result._data.size() > 1);
         fixed_point_from_double(

--- a/src/apyfixed_util.h
+++ b/src/apyfixed_util.h
@@ -1230,7 +1230,7 @@ fixed_point_from_double_single_limb(double value, int frac_bits, unsigned shift_
     }
 
     // Two's complement overflow
-    man = apy_limb_t(std::int64_t(man << shift_amount) >> shift_amount);
+    man = apy_limb_t(apy_limb_signed_t(man << shift_amount) >> shift_amount);
     return man;
 }
 

--- a/src/apyfixedarray.cc
+++ b/src/apyfixedarray.cc
@@ -7,6 +7,7 @@
 #include "apyfixed_util.h"
 #include "apyfixedarray.h"
 #include "apytypes_common.h"
+#include "apytypes_fwd.h"
 #include "apytypes_intrinsics.h"
 #include "apytypes_mp.h"
 #include "apytypes_simd.h"
@@ -1607,7 +1608,7 @@ APyFixedArray APyFixedArray::from_numbers(
     unsigned float_shift {};
     std::function<void(APyFixedArray&, std::size_t, double, unsigned)> from_fp;
     if (result._itemsize == 1) {
-        float_shift = 64 - (result._bits & (64 - 1));
+        float_shift = (APY_LIMB_SIZE_BITS - result.bits()) & (APY_LIMB_SIZE_BITS - 1);
         from_fp = [](APyFixedArray& res, std::size_t i, double val, unsigned shift) {
             res._data[i]
                 = fixed_point_from_double_single_limb(val, res.frac_bits(), shift);
@@ -1987,12 +1988,12 @@ void APyFixedArray::_set_values_from_ndarray(const nb::ndarray<nb::c_contig>& nd
         if (ndarray.dtype() == nb::dtype<__TYPE__>()) {                                \
             auto view = ndarray.view<__TYPE__, nb::ndim<1>>();                         \
             if (_itemsize == 1) {                                                      \
-                unsigned limb_shift_val = bits() & (64 - 1);                           \
-                unsigned twos_complement_shift = 64 - limb_shift_val;                  \
+                unsigned limb_shift_val                                                \
+                    = (APY_LIMB_SIZE_BITS - bits()) & (APY_LIMB_SIZE_BITS - 1);        \
                 int _frac_bits = frac_bits();                                          \
                 for (std::size_t i = 0; i < ndarray.size(); i++) {                     \
                     _data[i] = fixed_point_from_double_single_limb(                    \
-                        view.data()[i], _frac_bits, twos_complement_shift              \
+                        view.data()[i], _frac_bits, limb_shift_val                     \
                     );                                                                 \
                 }                                                                      \
             } else { /* _itemsize > 1 */                                               \


### PR DESCRIPTION
# PR Summary

Fixes for all the undefined behaviors throughout the code base found by the GCC undefined sanitizer (GCC: `-fsanitize=undefined`) and address sanitizer (GCC: `-fsanitize=address`) while running the APyTypes test suite.

### Enable sanitizers from meson:

```
python3 -m pip install . -v -Csetup-args="-Db_sanitize=undefined"
```
```
python3 -m pip install . -v -Csetup-args="-Db_sanitize=address"
```
```
python3 -m pip install . -v -Csetup-args="-Db_sanitize=address,undefined"
```

### Running Python on Ubuntu 24.04 with ASan enabled:
```
LD_PRELOAD="/lib/x86_64-linux-gnu/libasan.so.8:/lib/x86_64-linux-gnu/libstdc++.so.6:/lib/x86_64-linux-gnu/libgcc_s.so.1" python3 
```

## Bug 1:

```text
../src/apyfixed_util.h:1233:39: runtime error: shift exponent 64 is too large for 64-bit type 'long unsigned int'
../src/apyfixed_util.h:1233:56: runtime error: shift exponent 64 is too large for 64-bit type 'long int'
```

* [x] `src/apycfixed.cc:906`
* [x] `src/apycfixed.cc:964`
* [x] `src/apycfixed.cc:965`
* [x] `src/apycfixedarray.cc:1372`
* [x] `src/apycfixedarray.cc:1643`
* [x] `src/apycfixedarray.cc:1646`
* [x] `src/apycfixedarray.cc:1684`
* [x] `src/apyfixed.cc:1034`
* [x] `src/apyfixed_util.h:1194`
* [x] `src/apyfixedarray.cc:1611`
* [x] `src/apyfixedarray.cc:1992`




## PR Checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

- [x] add address- and undefined sanitizing in at least one CI job
- [x] new and changed code is tested
- [ ] relevant changes added to [CHANGELOG.md](https://github.com/apytypes/apytypes/blob/main/CHANGELOG.md)
