### PR TITLE
Fixes in LaTeX output for floating-point

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Segmentation violation in `APyCFixedArray` for division-by-zero.
 - Bug where array bit-constructors initialized from NumPy arrays resulted in
   wrong array values or downright caused a segmentation violation.
+- Issues in LaTeX rendering of special floating-point values.
 
 ### Changed
 

--- a/lib/test/apycfloat/test_representation.py
+++ b/lib/test/apycfloat/test_representation.py
@@ -54,15 +54,43 @@ def test_str():
 def test_latex():
     assert (
         APyCFloat((0, 0), exp=(0, 0), man=(0, 0), exp_bits=5, man_bits=5)._repr_latex_()
-        == "$0 + 0j$"
+        == "$0 + 0 j$"
+    )
+    assert (
+        APyCFloat((0, 1), exp=(0, 0), man=(0, 0), exp_bits=5, man_bits=5)._repr_latex_()
+        == "$0 -0 j$"
     )
     assert (
         APyCFloat((0, 1), exp=(5, 0), man=(1, 4), exp_bits=5, man_bits=5)._repr_latex_()
-        == "$\\left(1 + \\frac{1}{2^{5}}\\right)2^{5-15} - \\frac{4}{2^{5}}2^{1-15}j = 33\\times 2^{-15} - 4\\times 2^{-19}j = 0.001007080078125 - 0.00000762939453125j$"
+        == "$\\left(1 + \\frac{1}{2^{5}}\\right)2^{5-15} -\\frac{4}{2^{5}}2^{1-15} j = 33\\times 2^{-15} -4\\times 2^{-19} j = 0.001007080078125 -0.00000762939453125 j$"
     )
     assert (
         APyCFloat(
             (1, 0), exp=(5, 3), man=(14, 4), exp_bits=4, man_bits=5
         )._repr_latex_()
-        == "$-\\left(1 + \\frac{14}{2^{5}}\\right)2^{5-7} + \\left(1 + \\frac{4}{2^{5}}\\right)2^{3-7}j = -46\\times 2^{-7} + 36\\times 2^{-9}j = -0.359375 + 0.0703125j$"
+        == "$-\\left(1 + \\frac{14}{2^{5}}\\right)2^{5-7} + \\left(1 + \\frac{4}{2^{5}}\\right)2^{3-7} j = -46\\times 2^{-7} + 36\\times 2^{-9} j = -0.359375 + 0.0703125 j$"
+    )
+    assert (
+        APyCFloat(
+            (1, 1), exp=(31, 31), man=(1, 0), exp_bits=5, man_bits=5
+        )._repr_latex_()
+        == "$\\textrm{NaN} -\\infty j$"
+    )
+    assert (
+        APyCFloat(
+            (0, 1), exp=(15, 31), man=(0, 1), exp_bits=5, man_bits=5
+        )._repr_latex_()
+        == "$\\left(1 + \\frac{0}{2^{5}}\\right)2^{15-15} + \\textrm{NaN} j = 32\\times 2^{-5} + \\textrm{NaN} j = 1 + \\textrm{NaN} j$"
+    )
+    assert (
+        APyCFloat(
+            (1, 0), exp=(31, 16), man=(0, 0), exp_bits=5, man_bits=5
+        )._repr_latex_()
+        == "$-\\infty + \\left(1 + \\frac{0}{2^{5}}\\right)2^{16-15} j = -\\infty + 32\\times 2^{-4} j = -\\infty + 2 j$"
+    )
+    assert (
+        APyCFloat(
+            (1, 0), exp=(0, 16), man=(0, 0), exp_bits=5, man_bits=5
+        )._repr_latex_()
+        == "$-0 + \\left(1 + \\frac{0}{2^{5}}\\right)2^{16-15} j = -0 + 32\\times 2^{-4} j = -0 + 2 j$"
     )

--- a/lib/test/apyfloat/test_representation.py
+++ b/lib/test/apyfloat/test_representation.py
@@ -43,7 +43,9 @@ def test_repr():
 
 def test_latex():
     assert APyFloat.from_float(0, 2, 2)._repr_latex_() == "$0$"
+    assert APyFloat(1, 0, 0, 2, 2)._repr_latex_() == "$-0$"
     assert APyFloat.from_float(20, 2, 2)._repr_latex_() == r"$\infty$"
+    assert APyFloat.from_float(-20, 2, 2)._repr_latex_() == r"$-\infty$"
     assert (
         APyFloat.from_float(0.5, 2, 2)._repr_latex_()
         == r"$\frac{2}{2^{2}}2^{1-1} = 2\times 2^{-2} = 0.5$"
@@ -57,6 +59,7 @@ def test_latex():
         == r"$\left(1 + \frac{2}{2^{2}}\right)2^{1-1} = 6\times 2^{-2} = 1.5$"
     )
     assert APyFloat.from_float(float("NaN"), 2, 2)._repr_latex_() == r"$\textrm{NaN}$"
+    assert APyFloat.from_float(float("-NaN"), 2, 2)._repr_latex_() == r"$\textrm{NaN}$"
 
     assert (
         APyFloat.from_float(800, 6, 8)._repr_latex_()

--- a/src/apycfloat.cc
+++ b/src/apycfloat.cc
@@ -594,10 +594,19 @@ std::string APyCFloat::latex() const
 
     const std::string real_normalized_str = real_val._latex_power_of_two_normalized();
     const std::string imag_normalized_str = imag_val._latex_power_of_two_normalized();
-    bool real_special = (real_val.is_inf() || real_val.is_nan() || real_val.is_zero());
-    bool imag_special = (imag_val.is_inf() || imag_val.is_nan() || imag_val.is_zero());
+    const bool real_special
+        = (real_val.is_inf() || real_val.is_nan() || real_val.is_zero());
+    const bool imag_special
+        = (imag_val.is_inf() || imag_val.is_nan() || imag_val.is_zero());
+
     if (real_special && imag_special) {
-        return fmt::format("${} + {}j$", real_normalized_str, imag_normalized_str);
+        // The space between '{} j' is important as it otherwise breaks the LaTeX code
+        // for \\infty
+        if (imag_normalized_str.substr(0, 1) == "-") {
+            // The minus sign is included in the string for the imaginary part
+            return fmt::format("${} {} j$", real_normalized_str, imag_normalized_str);
+        }
+        return fmt::format("${} + {} j$", real_normalized_str, imag_normalized_str);
     }
     const std::string real_integer_str = real_val._latex_power_of_two_integer();
     const std::string imag_integer_str = imag_val._latex_power_of_two_integer();
@@ -607,18 +616,19 @@ std::string APyCFloat::latex() const
         = (imag_special ? imag_normalized_str : imag_val.to_fixed().to_string_dec());
 
     if (imag_normalized_str.substr(0, 1) == "-") {
+        // The minus sign is included in the string for the imaginary part
         return fmt::format(
-            "${} - {}j = {} - {}j = {} - {}j$",
+            "${} {} j = {} {} j = {} {} j$",
             real_normalized_str,
-            imag_normalized_str.substr(1),
+            imag_normalized_str,
             real_integer_str,
-            imag_integer_str.substr(1),
+            imag_integer_str,
             real_dec_str,
-            imag_dec_str.substr(1)
+            imag_dec_str
         );
     }
     return fmt::format(
-        "${} + {}j = {} + {}j = {} + {}j$",
+        "${} + {} j = {} + {} j = {} + {} j$",
         real_normalized_str,
         imag_normalized_str,
         real_integer_str,

--- a/src/apyfloat.cc
+++ b/src/apyfloat.cc
@@ -484,9 +484,17 @@ std::string APyFloat::latex() const
     if (is_nan()) {
         return "$\\textrm{NaN}$";
     } else if (is_inf()) {
-        return "$\\infty$";
+        if (get_sign()) {
+            return "$-\\infty$";
+        } else {
+            return "$\\infty$";
+        }
     } else if (is_zero()) {
-        return "$0$";
+        if (get_sign()) {
+            return "$-0$";
+        } else {
+            return "$0$";
+        }
     }
 
     return fmt::format(
@@ -499,15 +507,16 @@ std::string APyFloat::latex() const
 
 std::string APyFloat::_latex_power_of_two_normalized() const
 {
+    std::string str = (sign ? "-" : "");
+
     if (is_nan()) {
         return "\\textrm{NaN}";
     } else if (is_inf()) {
-        return "\\infty";
+        return str + "\\infty";
     } else if (is_zero()) {
-        return "0";
+        return str + "0";
     }
 
-    std::string str = (sign ? "-" : "");
     if (is_normal()) {
         str += "\\left(1 + ";
     }
@@ -527,15 +536,16 @@ std::string APyFloat::_latex_power_of_two_normalized() const
 
 std::string APyFloat::_latex_power_of_two_integer() const
 {
+    std::string str = (sign ? "-" : "");
+
     if (is_nan()) {
         return "\\textrm{NaN}";
     } else if (is_inf()) {
-        return "\\infty";
+        return str + "\\infty";
     } else if (is_zero()) {
-        return "0";
+        return str + "0";
     }
 
-    std::string str = (sign ? "-" : "");
     str += std::to_string(true_man()) + "\\times 2^{"
         + std::to_string(true_exp() - man_bits) + "}";
 


### PR DESCRIPTION
<!--
Thank you so much for your PR!
-->

# PR Summary
<!-- Please provide at least 1-2 sentences describing the pull request in detail
(Why is this change required?  What problem does it solve?) and link to relevant
issues and PRs.
-->
Miscellaneous fixes in LaTeX rendering for floating-point values.

Previously, negative infinity was rendered as positive infinity, and the infinity symbol was broken when for the imaginary part in complex numbers. Negative zero is now also rendered as $-0$ instead of $0$.


## PR Checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

- [N/A] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] new and changed code is tested
- [x] relevant changes added to [CHANGELOG.md](https://github.com/apytypes/apytypes/blob/main/CHANGELOG.md)
- [N/A] new functionality is documented
