### PR TITLE
Fix issues with division by zero

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,11 +13,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
--
+- Crash on division by zero for fixed-point arrays for some word lengths on some
+  platforms.
 
 ### Changed
 
--
+- BREAKING: Division by zero for fixed-point arrays will now always raise a `ZeroDivisionError`.
 
 ### Removed
 

--- a/lib/test/apycfixedarray/test_arithmetic.py
+++ b/lib/test/apycfixedarray/test_arithmetic.py
@@ -180,24 +180,24 @@ def test_arithmetic_with_apyfixed():
 
 def test_arithmetic_with_apyfixedarray():
     a = APyCFixedArray.from_complex([1 + 2j, -4, 3.5 - 2j], int_bits=7, frac_bits=3)
-    b = APyFixedArray.from_float([3.0, 0.0, 4.0], int_bits=5, frac_bits=0)
+    b = APyFixedArray.from_float([3.0, -1.0, 4.0], int_bits=5, frac_bits=0)
     assert (a + b).is_identical(
-        APyCFixedArray.from_complex([4 + 2j, -4, 7.5 - 2j], int_bits=8, frac_bits=3)
+        APyCFixedArray.from_complex([4 + 2j, -5, 7.5 - 2j], int_bits=8, frac_bits=3)
     )
     assert (a - b).is_identical(
-        APyCFixedArray.from_complex([-2 + 2j, -4, -0.5 - 2j], int_bits=8, frac_bits=3)
+        APyCFixedArray.from_complex([-2 + 2j, -3, -0.5 - 2j], int_bits=8, frac_bits=3)
     )
     assert (a * b).is_identical(
-        APyCFixedArray.from_complex([3 + 6j, 0, 14 - 8j], int_bits=13, frac_bits=3)
+        APyCFixedArray.from_complex([3 + 6j, 4, 14 - 8j], int_bits=13, frac_bits=3)
     )
     assert (a / b).is_identical(
-        APyCFixedArray([(85, 170), (0, 0), (224, 65408)], int_bits=8, frac_bits=8)
+        APyCFixedArray([(85, 170), (1024, 0), (224, 65408)], int_bits=8, frac_bits=8)
     )
     assert (b + a).is_identical(a + b)
     assert (b * a).is_identical(a * b)
     assert (b - a).is_identical((-(a - b)).cast(int_bits=8, frac_bits=3))
     assert (b / a).is_identical(
-        APyCFixedArray([(76, 65383), (0, 0), (110, 63)], int_bits=9, frac_bits=7)
+        APyCFixedArray([(76, 65383), (32, 0), (110, 63)], int_bits=9, frac_bits=7)
     )
 
     np = pytest.importorskip("numpy")
@@ -207,32 +207,36 @@ def test_arithmetic_with_apyfixedarray():
     assert not (np.all(b == a))
 
 
-@pytest.mark.parametrize("int_bits_1", [10, 30, 50, 100, 300])
-@pytest.mark.parametrize("int_bits_2", [10, 30, 50, 100, 300])
-def test_arrays_dont_crash_on_zero_div(int_bits_1: int, int_bits_2: int):
-    """
-    In APyTypes, array division-by-zero results in an undefined values. However,
-    APyTypes should not crash when such a division occurs
-    """
+@pytest.mark.parametrize("int_bits_1", [10, 20, 30, 34, 50, 100, 300])
+@pytest.mark.parametrize("int_bits_2", [10, 20, 30, 34, 50, 100, 300])
+def test_arrays_raises_on_zero_div(int_bits_1: int, int_bits_2: int):
     a = APyCFixedArray.from_complex([0.0, 1.0, 2.0], int_bits=int_bits_1, frac_bits=0)
     b = APyCFixedArray.from_complex([0.0, 0.0, 1.0], int_bits=int_bits_2, frac_bits=0)
-    _ = a / b
-    _ = b / a
+    with pytest.raises(ZeroDivisionError):
+        _ = a / b
+    with pytest.raises(ZeroDivisionError):
+        _ = b / a
 
     a = APyCFixedArray.from_complex([0.0, 1.0, 2.0], int_bits=int_bits_1, frac_bits=0)
     b = APyFixedArray.from_float([0.0, 1.0, 0.0], int_bits=int_bits_2, frac_bits=0)
-    _ = a / b
-    _ = b / a
+    with pytest.raises(ZeroDivisionError):
+        _ = a / b
+    with pytest.raises(ZeroDivisionError):
+        _ = b / a
 
     a = APyCFixedArray.from_complex([0.0, 1.0, 2.0], int_bits=int_bits_1, frac_bits=0)
     b = APyCFixed.from_complex(0.0, int_bits=int_bits_2, frac_bits=0)
-    _ = a / b
-    _ = b / a
+    with pytest.raises(ZeroDivisionError):
+        _ = a / b
+    with pytest.raises(ZeroDivisionError):
+        _ = b / a
 
     a = APyCFixedArray.from_complex([0.0, 1.0, 2.0], int_bits=int_bits_1, frac_bits=0)
     b = APyFixed.from_float(0.0, int_bits=int_bits_2, frac_bits=0)
-    _ = a / b
-    _ = b / a
+    with pytest.raises(ZeroDivisionError):
+        _ = a / b
+    with pytest.raises(ZeroDivisionError):
+        _ = b / a
 
 
 @pytest.mark.parametrize("bits", range(10, 200, 10))

--- a/lib/test/apycfixedarray/test_arithmetic.py
+++ b/lib/test/apycfixedarray/test_arithmetic.py
@@ -207,28 +207,30 @@ def test_arithmetic_with_apyfixedarray():
     assert not (np.all(b == a))
 
 
-def test_arrays_dont_crash_on_zero_div():
+@pytest.mark.parametrize("int_bits_1", [10, 30, 50, 100, 300])
+@pytest.mark.parametrize("int_bits_2", [10, 30, 50, 100, 300])
+def test_arrays_dont_crash_on_zero_div(int_bits_1: int, int_bits_2: int):
     """
     In APyTypes, array division-by-zero results in an undefined values. However,
     APyTypes should not crash when such a division occurs
     """
-    a = APyCFixedArray.from_complex([0.0, 1.0, 2.0], int_bits=10, frac_bits=0)
-    b = APyCFixedArray.from_complex([0.0, 0.0, 1.0], int_bits=10, frac_bits=0)
+    a = APyCFixedArray.from_complex([0.0, 1.0, 2.0], int_bits=int_bits_1, frac_bits=0)
+    b = APyCFixedArray.from_complex([0.0, 0.0, 1.0], int_bits=int_bits_2, frac_bits=0)
     _ = a / b
     _ = b / a
 
-    a = APyCFixedArray.from_complex([0.0, 1.0, 2.0], int_bits=10, frac_bits=0)
-    b = APyFixedArray.from_float([0.0, 1.0, 0.0], int_bits=10, frac_bits=0)
+    a = APyCFixedArray.from_complex([0.0, 1.0, 2.0], int_bits=int_bits_1, frac_bits=0)
+    b = APyFixedArray.from_float([0.0, 1.0, 0.0], int_bits=int_bits_2, frac_bits=0)
     _ = a / b
     _ = b / a
 
-    a = APyCFixedArray.from_complex([0.0, 1.0, 2.0], int_bits=10, frac_bits=0)
-    b = APyCFixed.from_complex(0.0, int_bits=10, frac_bits=0)
+    a = APyCFixedArray.from_complex([0.0, 1.0, 2.0], int_bits=int_bits_1, frac_bits=0)
+    b = APyCFixed.from_complex(0.0, int_bits=int_bits_2, frac_bits=0)
     _ = a / b
     _ = b / a
 
-    a = APyCFixedArray.from_complex([0.0, 1.0, 2.0], int_bits=10, frac_bits=0)
-    b = APyFixed.from_float(0.0, int_bits=10, frac_bits=0)
+    a = APyCFixedArray.from_complex([0.0, 1.0, 2.0], int_bits=int_bits_1, frac_bits=0)
+    b = APyFixed.from_float(0.0, int_bits=int_bits_2, frac_bits=0)
     _ = a / b
     _ = b / a
 

--- a/lib/test/apyfixedarray/test_arithmetic.py
+++ b/lib/test/apyfixedarray/test_arithmetic.py
@@ -517,11 +517,6 @@ def test_array_div(fixed_array: type[APyCFixedArray]):
         )
     )
 
-    # Does not die
-    a = fixed_array.from_float([5], bits=100, int_bits=50)
-    b = fixed_array.from_float([0], bits=250, int_bits=100)
-    assert (a / b).is_identical(fixed_array([0], bits=351, int_bits=201))
-
 
 @pytest.mark.parametrize(
     ("fixed_array", "fixed_scalar"),
@@ -1443,21 +1438,21 @@ def test_two_limb_division_result_32_one_long():
 
 @pytest.mark.parametrize("int_bits_1", [10, 30, 50, 100, 300])
 @pytest.mark.parametrize("int_bits_2", [10, 30, 50, 100, 300])
-def test_arrays_dont_crash_on_zero_div(int_bits_1: int, int_bits_2: int):
-    """
-    In APyTypes, array division-by-zero results in an undefined values. However,
-    APyTypes should not crash when such a division occurs
-    """
+def test_arrays_raises_on_zero_div(int_bits_1: int, int_bits_2: int):
     a = APyFixedArray.from_float([0.0, 1.0, 2.0], int_bits=int_bits_1, frac_bits=0)
     b = APyFixedArray.from_float([0.0, 0.0, 1.0], int_bits=int_bits_2, frac_bits=0)
-    _ = a / b
-    _ = b / a
+    with pytest.raises(ZeroDivisionError):
+        _ = a / b
+    with pytest.raises(ZeroDivisionError):
+        _ = b / a
 
 
 @pytest.mark.parametrize("int_bits_1", [10, 30, 50, 100, 300])
 @pytest.mark.parametrize("int_bits_2", [10, 30, 50, 100, 300])
-def test_arrays_dont_crash_on_zero_div_with_scalar(int_bits_1: int, int_bits_2: int):
+def test_arrays_raises_on_zero_div_with_scalar(int_bits_1: int, int_bits_2: int):
     a = APyFixedArray.from_float([0.0, 1.0, 2.0], int_bits=int_bits_1, frac_bits=0)
     b = APyFixed.from_float(0.0, int_bits=int_bits_2, frac_bits=0)
-    _ = a / b
-    _ = b / a
+    with pytest.raises(ZeroDivisionError):
+        _ = a / b
+    with pytest.raises(ZeroDivisionError):
+        _ = b / a

--- a/lib/test/apyfixedarray/test_arithmetic.py
+++ b/lib/test/apyfixedarray/test_arithmetic.py
@@ -1439,3 +1439,25 @@ def test_two_limb_division_result_32_one_long():
             frac_bits=37,
         )
     )
+
+
+@pytest.mark.parametrize("int_bits_1", [10, 30, 50, 100, 300])
+@pytest.mark.parametrize("int_bits_2", [10, 30, 50, 100, 300])
+def test_arrays_dont_crash_on_zero_div(int_bits_1: int, int_bits_2: int):
+    """
+    In APyTypes, array division-by-zero results in an undefined values. However,
+    APyTypes should not crash when such a division occurs
+    """
+    a = APyFixedArray.from_float([0.0, 1.0, 2.0], int_bits=int_bits_1, frac_bits=0)
+    b = APyFixedArray.from_float([0.0, 0.0, 1.0], int_bits=int_bits_2, frac_bits=0)
+    _ = a / b
+    _ = b / a
+
+
+@pytest.mark.parametrize("int_bits_1", [10, 30, 50, 100, 300])
+@pytest.mark.parametrize("int_bits_2", [10, 30, 50, 100, 300])
+def test_arrays_dont_crash_on_zero_div_with_scalar(int_bits_1: int, int_bits_2: int):
+    a = APyFixedArray.from_float([0.0, 1.0, 2.0], int_bits=int_bits_1, frac_bits=0)
+    b = APyFixed.from_float(0.0, int_bits=int_bits_2, frac_bits=0)
+    _ = a / b
+    _ = b / a

--- a/src/apycfixedarray.cc
+++ b/src/apycfixedarray.cc
@@ -663,6 +663,9 @@ APyCFixedArray APyCFixedArray::operator/(const APyCFixedArray& rhs) const
                     __int128 den_real = (__int128)apy_limb_signed_t(rhs._data[i + 0]);
                     __int128 den_imag = (__int128)apy_limb_signed_t(rhs._data[i + 1]);
                     __int128 den = den_real * den_real + den_imag * den_imag;
+                    if (den == 0) {
+                        continue;
+                    }
                     __int128 num_real = (__int128)apy_limb_signed_t(_data[i + 0]);
                     __int128 num_imag = (__int128)apy_limb_signed_t(_data[i + 1]);
                     __int128 real = num_real * den_real + num_imag * den_imag;
@@ -677,7 +680,9 @@ APyCFixedArray APyCFixedArray::operator/(const APyCFixedArray& rhs) const
                     __int128 den_imag
                         = (__int128)apy_limb_signed_t(rhs._data[(i >> 1) + 1]);
                     __int128 den = den_real * den_real + den_imag * den_imag;
-
+                    if (den == 0) {
+                        continue;
+                    }
                     __int128 num_real
                         = (__int128)apy_limb_signed_t(_data[(i >> 1) + 0]);
                     __int128 num_imag
@@ -704,7 +709,9 @@ APyCFixedArray APyCFixedArray::operator/(const APyCFixedArray& rhs) const
                 __int128 den_imag
                     = (__int128)apy_limb_signed_t(rhs._data[(i >> 1) + 1]);
                 std::int64_t den = den_real * den_real + den_imag * den_imag;
-
+                if (den == 0) {
+                    continue;
+                }
                 __int128 num_real = (__int128)(_data[i + 0])
                     | (__int128)apy_limb_signed_t(_data[i + 1]) << APY_LIMB_SIZE_BITS;
                 __int128 num_imag = (__int128)(_data[i + 2])
@@ -745,6 +752,9 @@ APyCFixedArray APyCFixedArray::operator/(const APyCFixedArray& rhs) const
                     std::int64_t den_imag
                         = (std::int64_t)apy_limb_signed_t(rhs._data[i + 1]);
                     std::int64_t den = den_real * den_real + den_imag * den_imag;
+                    if (den == 0) {
+                        continue;
+                    }
                     std::int64_t num_real
                         = (std::int64_t)apy_limb_signed_t(_data[i + 0]);
                     std::int64_t num_imag
@@ -761,6 +771,9 @@ APyCFixedArray APyCFixedArray::operator/(const APyCFixedArray& rhs) const
                     std::int64_t den_imag
                         = (std::int64_t)apy_limb_signed_t(rhs._data[i + 1]);
                     std::int64_t den = den_real * den_real + den_imag * den_imag;
+                    if (den == 0) {
+                        continue;
+                    }
                     std::int64_t num_real
                         = (std::int64_t)apy_limb_signed_t(_data[i + 0]);
                     std::int64_t num_imag
@@ -787,6 +800,9 @@ APyCFixedArray APyCFixedArray::operator/(const APyCFixedArray& rhs) const
                 std::int64_t den_imag
                     = (std::int64_t)apy_limb_signed_t(rhs._data[(i >> 1) + 1]);
                 std::int64_t den = den_real * den_real + den_imag * den_imag;
+                if (den == 0) {
+                    continue;
+                }
                 std::int64_t num_real = (std::int64_t)(_data[i + 0])
                     | (std::int64_t)apy_limb_signed_t(_data[i + 1])
                         << APY_LIMB_SIZE_BITS;
@@ -910,6 +926,10 @@ APyCFixedArray APyCFixedArray::operator/(const APyCFixed& rhs) const
         __int128 den_real = (__int128)apy_limb_signed_t(rhs._data[0]);
         __int128 den_imag = (__int128)apy_limb_signed_t(rhs._data[1]);
         __int128 den = den_real * den_real + den_imag * den_imag;
+        if (den == 0) {
+            return result; // early exit
+        }
+
         auto rhs_bits = unsigned(rhs.bits());
         if (unsigned(bits()) <= APY_LIMB_SIZE_BITS) {
             if (unsigned(res_bits) <= APY_LIMB_SIZE_BITS) {
@@ -978,6 +998,10 @@ APyCFixedArray APyCFixedArray::operator/(const APyCFixed& rhs) const
         std::int64_t den_real = (std::int64_t)apy_limb_signed_t(rhs._data[0]);
         std::int64_t den_imag = (std::int64_t)apy_limb_signed_t(rhs._data[1]);
         std::int64_t den = den_real * den_real + den_imag * den_imag;
+        if (den == 0) {
+            return result; // early exit
+        }
+
         auto rhs_bits = unsigned(rhs.bits());
         if (unsigned(bits()) <= APY_LIMB_SIZE_BITS) {
             if (unsigned(res_bits) <= APY_LIMB_SIZE_BITS) {
@@ -1175,6 +1199,9 @@ APyCFixedArray APyCFixedArray::rdiv(const APyCFixed& lhs) const
                     __int128 den_real = (__int128)apy_limb_signed_t(_data[i + 0]);
                     __int128 den_imag = (__int128)apy_limb_signed_t(_data[i + 1]);
                     __int128 den = den_real * den_real + den_imag * den_imag;
+                    if (den == 0) {
+                        continue;
+                    }
                     __int128 real = num_real * den_real + num_imag * den_imag;
                     __int128 imag = num_imag * den_real - num_real * den_imag;
                     result._data[i + 0] = apy_limb_signed_t((real << bits()) / den);
@@ -1185,7 +1212,9 @@ APyCFixedArray APyCFixedArray::rdiv(const APyCFixed& lhs) const
                     __int128 den_real = (__int128)apy_limb_signed_t(_data[i + 0]);
                     __int128 den_imag = (__int128)apy_limb_signed_t(_data[i + 1]);
                     __int128 den = den_real * den_real + den_imag * den_imag;
-
+                    if (den == 0) {
+                        continue;
+                    }
                     __int128 real = num_real * den_real + num_imag * den_imag;
                     __int128 imag = num_imag * den_real - num_real * den_imag;
                     __int128 res_real = (real << bits()) / den;
@@ -1211,6 +1240,9 @@ APyCFixedArray APyCFixedArray::rdiv(const APyCFixed& lhs) const
                 __int128 den_real = (__int128)apy_limb_signed_t(_data[i + 0]);
                 __int128 den_imag = (__int128)apy_limb_signed_t(_data[i + 1]);
                 __int128 den = den_real * den_real + den_imag * den_imag;
+                if (den == 0) {
+                    continue;
+                }
                 __int128 real = num_real * den_real + num_imag * den_imag;
                 __int128 imag = num_imag * den_real - num_real * den_imag;
                 __int128 res_real = (real << bits()) / den;
@@ -1250,6 +1282,9 @@ APyCFixedArray APyCFixedArray::rdiv(const APyCFixed& lhs) const
                     std::int64_t den_imag
                         = (std::int64_t)apy_limb_signed_t(_data[i + 1]);
                     std::int64_t den = den_real * den_real + den_imag * den_imag;
+                    if (den == 0) {
+                        continue;
+                    }
                     std::int64_t real = num_real * den_real + num_imag * den_imag;
                     std::int64_t imag = num_imag * den_real - num_real * den_imag;
                     result._data[i + 0] = apy_limb_signed_t((real << bits()) / den);
@@ -1262,7 +1297,9 @@ APyCFixedArray APyCFixedArray::rdiv(const APyCFixed& lhs) const
                     std::int64_t den_imag
                         = (std::int64_t)apy_limb_signed_t(_data[i + 1]);
                     std::int64_t den = den_real * den_real + den_imag * den_imag;
-
+                    if (den == 0) {
+                        continue;
+                    }
                     std::int64_t real = num_real * den_real + num_imag * den_imag;
                     std::int64_t imag = num_imag * den_real - num_real * den_imag;
                     std::int64_t res_real = (real << bits()) / den;
@@ -1288,6 +1325,9 @@ APyCFixedArray APyCFixedArray::rdiv(const APyCFixed& lhs) const
                 std::int64_t den_real = (std::int64_t)apy_limb_signed_t(_data[i + 0]);
                 std::int64_t den_imag = (std::int64_t)apy_limb_signed_t(_data[i + 1]);
                 std::int64_t den = den_real * den_real + den_imag * den_imag;
+                if (den == 0) {
+                    continue;
+                }
                 std::int64_t real = num_real * den_real + num_imag * den_imag;
                 std::int64_t imag = num_imag * den_real - num_real * den_imag;
                 std::int64_t res_real = (real << bits()) / den;

--- a/src/apycfixedarray.cc
+++ b/src/apycfixedarray.cc
@@ -628,7 +628,10 @@ APyCFixedArray APyCFixedArray::operator/(const APyCFixedArray& rhs) const
                 + apy_limb_signed_t(rhs._data[i + 1])
                     * apy_limb_signed_t(rhs._data[i + 1]);
             if (den == 0) {
-                continue;
+                PyErr_SetString(
+                    PyExc_ZeroDivisionError, "fixed-point division by zero"
+                );
+                throw nb::python_error();
             }
             apy_limb_signed_t real
                 = apy_limb_signed_t(_data[i + 0]) * apy_limb_signed_t(rhs._data[i + 0])
@@ -664,7 +667,10 @@ APyCFixedArray APyCFixedArray::operator/(const APyCFixedArray& rhs) const
                     __int128 den_imag = (__int128)apy_limb_signed_t(rhs._data[i + 1]);
                     __int128 den = den_real * den_real + den_imag * den_imag;
                     if (den == 0) {
-                        continue;
+                        PyErr_SetString(
+                            PyExc_ZeroDivisionError, "fixed-point division by zero"
+                        );
+                        throw nb::python_error();
                     }
                     __int128 num_real = (__int128)apy_limb_signed_t(_data[i + 0]);
                     __int128 num_imag = (__int128)apy_limb_signed_t(_data[i + 1]);
@@ -681,7 +687,10 @@ APyCFixedArray APyCFixedArray::operator/(const APyCFixedArray& rhs) const
                         = (__int128)apy_limb_signed_t(rhs._data[(i >> 1) + 1]);
                     __int128 den = den_real * den_real + den_imag * den_imag;
                     if (den == 0) {
-                        continue;
+                        PyErr_SetString(
+                            PyExc_ZeroDivisionError, "fixed-point division by zero"
+                        );
+                        throw nb::python_error();
                     }
                     __int128 num_real
                         = (__int128)apy_limb_signed_t(_data[(i >> 1) + 0]);
@@ -710,7 +719,10 @@ APyCFixedArray APyCFixedArray::operator/(const APyCFixedArray& rhs) const
                     = (__int128)apy_limb_signed_t(rhs._data[(i >> 1) + 1]);
                 std::int64_t den = den_real * den_real + den_imag * den_imag;
                 if (den == 0) {
-                    continue;
+                    PyErr_SetString(
+                        PyExc_ZeroDivisionError, "fixed-point division by zero"
+                    );
+                    throw nb::python_error();
                 }
                 __int128 num_real = (__int128)(_data[i + 0])
                     | (__int128)apy_limb_signed_t(_data[i + 1]) << APY_LIMB_SIZE_BITS;
@@ -753,7 +765,10 @@ APyCFixedArray APyCFixedArray::operator/(const APyCFixedArray& rhs) const
                         = (std::int64_t)apy_limb_signed_t(rhs._data[i + 1]);
                     std::int64_t den = den_real * den_real + den_imag * den_imag;
                     if (den == 0) {
-                        continue;
+                        PyErr_SetString(
+                            PyExc_ZeroDivisionError, "fixed-point division by zero"
+                        );
+                        throw nb::python_error();
                     }
                     std::int64_t num_real
                         = (std::int64_t)apy_limb_signed_t(_data[i + 0]);
@@ -772,7 +787,10 @@ APyCFixedArray APyCFixedArray::operator/(const APyCFixedArray& rhs) const
                         = (std::int64_t)apy_limb_signed_t(rhs._data[i + 1]);
                     std::int64_t den = den_real * den_real + den_imag * den_imag;
                     if (den == 0) {
-                        continue;
+                        PyErr_SetString(
+                            PyExc_ZeroDivisionError, "fixed-point division by zero"
+                        );
+                        throw nb::python_error();
                     }
                     std::int64_t num_real
                         = (std::int64_t)apy_limb_signed_t(_data[i + 0]);
@@ -801,7 +819,10 @@ APyCFixedArray APyCFixedArray::operator/(const APyCFixedArray& rhs) const
                     = (std::int64_t)apy_limb_signed_t(rhs._data[(i >> 1) + 1]);
                 std::int64_t den = den_real * den_real + den_imag * den_imag;
                 if (den == 0) {
-                    continue;
+                    PyErr_SetString(
+                        PyExc_ZeroDivisionError, "fixed-point division by zero"
+                    );
+                    throw nb::python_error();
                 }
                 std::int64_t num_real = (std::int64_t)(_data[i + 0])
                     | (std::int64_t)apy_limb_signed_t(_data[i + 1])
@@ -854,7 +875,8 @@ APyCFixedArray APyCFixedArray::operator/(const APyCFixedArray& rhs) const
             std::begin(rhs._data) + (i + 1) * rhs._itemsize
         );
         if (den_zero) {
-            continue;
+            PyErr_SetString(PyExc_ZeroDivisionError, "fixed-point division by zero");
+            throw nb::python_error();
         }
 
         complex_fixed_point_division(
@@ -880,6 +902,11 @@ APyCFixedArray APyCFixedArray::operator/(const APyCFixedArray& rhs) const
 
 APyCFixedArray APyCFixedArray::operator/(const APyCFixed& rhs) const
 {
+    if (rhs.is_zero()) {
+        PyErr_SetString(PyExc_ZeroDivisionError, "fixed-point division by zero");
+        throw nb::python_error();
+    }
+
     // Divider bits (denominator known to be positive)
     const int num_int_bits = 1 + int_bits() + rhs.int_bits();
     const int num_frac_bits = frac_bits() + rhs.frac_bits();
@@ -895,9 +922,6 @@ APyCFixedArray APyCFixedArray::operator/(const APyCFixed& rhs) const
         apy_limb_signed_t den
             = apy_limb_signed_t(rhs._data[0]) * apy_limb_signed_t(rhs._data[0])
             + apy_limb_signed_t(rhs._data[1]) * apy_limb_signed_t(rhs._data[1]);
-        if (den == 0) {
-            return result; // early exit
-        }
         for (std::size_t i = 0; i < result._nitems * 2; i += 2) {
             apy_limb_signed_t real
                 = apy_limb_signed_t(_data[i + 0]) * apy_limb_signed_t(rhs._data[0])
@@ -926,10 +950,6 @@ APyCFixedArray APyCFixedArray::operator/(const APyCFixed& rhs) const
         __int128 den_real = (__int128)apy_limb_signed_t(rhs._data[0]);
         __int128 den_imag = (__int128)apy_limb_signed_t(rhs._data[1]);
         __int128 den = den_real * den_real + den_imag * den_imag;
-        if (den == 0) {
-            return result; // early exit
-        }
-
         auto rhs_bits = unsigned(rhs.bits());
         if (unsigned(bits()) <= APY_LIMB_SIZE_BITS) {
             if (unsigned(res_bits) <= APY_LIMB_SIZE_BITS) {
@@ -998,10 +1018,6 @@ APyCFixedArray APyCFixedArray::operator/(const APyCFixed& rhs) const
         std::int64_t den_real = (std::int64_t)apy_limb_signed_t(rhs._data[0]);
         std::int64_t den_imag = (std::int64_t)apy_limb_signed_t(rhs._data[1]);
         std::int64_t den = den_real * den_real + den_imag * den_imag;
-        if (den == 0) {
-            return result; // early exit
-        }
-
         auto rhs_bits = unsigned(rhs.bits());
         if (unsigned(bits()) <= APY_LIMB_SIZE_BITS) {
             if (unsigned(res_bits) <= APY_LIMB_SIZE_BITS) {
@@ -1084,14 +1100,6 @@ APyCFixedArray APyCFixedArray::operator/(const APyCFixed& rhs) const
     auto den_imm = num_imm + div_limbs;
     auto qte_imm = den_imm + 2 * src2_limbs;
 
-    bool den_zero = limb_vector_is_zero(
-        std::begin(rhs._data), std::begin(rhs._data) + rhs._data.size()
-    );
-    if (den_zero) {
-        // Right-hand side is zero, simply return...
-        return result;
-    }
-
     for (std::size_t i = 0; i < result._nitems; i++) {
         complex_fixed_point_division(
             std::begin(_data) + i * _itemsize,               // src1
@@ -1163,7 +1171,10 @@ APyCFixedArray APyCFixedArray::rdiv(const APyCFixed& lhs) const
                 = apy_limb_signed_t(_data[i + 0]) * apy_limb_signed_t(_data[i + 0])
                 + apy_limb_signed_t(_data[i + 1]) * apy_limb_signed_t(_data[i + 1]);
             if (den == 0) {
-                continue;
+                PyErr_SetString(
+                    PyExc_ZeroDivisionError, "fixed-point division by zero"
+                );
+                throw nb::python_error();
             }
             apy_limb_signed_t real
                 = apy_limb_signed_t(lhs._data[0]) * apy_limb_signed_t(_data[i + 0])
@@ -1200,7 +1211,10 @@ APyCFixedArray APyCFixedArray::rdiv(const APyCFixed& lhs) const
                     __int128 den_imag = (__int128)apy_limb_signed_t(_data[i + 1]);
                     __int128 den = den_real * den_real + den_imag * den_imag;
                     if (den == 0) {
-                        continue;
+                        PyErr_SetString(
+                            PyExc_ZeroDivisionError, "fixed-point division by zero"
+                        );
+                        throw nb::python_error();
                     }
                     __int128 real = num_real * den_real + num_imag * den_imag;
                     __int128 imag = num_imag * den_real - num_real * den_imag;
@@ -1213,7 +1227,10 @@ APyCFixedArray APyCFixedArray::rdiv(const APyCFixed& lhs) const
                     __int128 den_imag = (__int128)apy_limb_signed_t(_data[i + 1]);
                     __int128 den = den_real * den_real + den_imag * den_imag;
                     if (den == 0) {
-                        continue;
+                        PyErr_SetString(
+                            PyExc_ZeroDivisionError, "fixed-point division by zero"
+                        );
+                        throw nb::python_error();
                     }
                     __int128 real = num_real * den_real + num_imag * den_imag;
                     __int128 imag = num_imag * den_real - num_real * den_imag;
@@ -1241,7 +1258,10 @@ APyCFixedArray APyCFixedArray::rdiv(const APyCFixed& lhs) const
                 __int128 den_imag = (__int128)apy_limb_signed_t(_data[i + 1]);
                 __int128 den = den_real * den_real + den_imag * den_imag;
                 if (den == 0) {
-                    continue;
+                    PyErr_SetString(
+                        PyExc_ZeroDivisionError, "fixed-point division by zero"
+                    );
+                    throw nb::python_error();
                 }
                 __int128 real = num_real * den_real + num_imag * den_imag;
                 __int128 imag = num_imag * den_real - num_real * den_imag;
@@ -1283,7 +1303,10 @@ APyCFixedArray APyCFixedArray::rdiv(const APyCFixed& lhs) const
                         = (std::int64_t)apy_limb_signed_t(_data[i + 1]);
                     std::int64_t den = den_real * den_real + den_imag * den_imag;
                     if (den == 0) {
-                        continue;
+                        PyErr_SetString(
+                            PyExc_ZeroDivisionError, "fixed-point division by zero"
+                        );
+                        throw nb::python_error();
                     }
                     std::int64_t real = num_real * den_real + num_imag * den_imag;
                     std::int64_t imag = num_imag * den_real - num_real * den_imag;
@@ -1298,7 +1321,10 @@ APyCFixedArray APyCFixedArray::rdiv(const APyCFixed& lhs) const
                         = (std::int64_t)apy_limb_signed_t(_data[i + 1]);
                     std::int64_t den = den_real * den_real + den_imag * den_imag;
                     if (den == 0) {
-                        continue;
+                        PyErr_SetString(
+                            PyExc_ZeroDivisionError, "fixed-point division by zero"
+                        );
+                        throw nb::python_error();
                     }
                     std::int64_t real = num_real * den_real + num_imag * den_imag;
                     std::int64_t imag = num_imag * den_real - num_real * den_imag;
@@ -1326,7 +1352,10 @@ APyCFixedArray APyCFixedArray::rdiv(const APyCFixed& lhs) const
                 std::int64_t den_imag = (std::int64_t)apy_limb_signed_t(_data[i + 1]);
                 std::int64_t den = den_real * den_real + den_imag * den_imag;
                 if (den == 0) {
-                    continue;
+                    PyErr_SetString(
+                        PyExc_ZeroDivisionError, "fixed-point division by zero"
+                    );
+                    throw nb::python_error();
                 }
                 std::int64_t real = num_real * den_real + num_imag * den_imag;
                 std::int64_t imag = num_imag * den_real - num_real * den_imag;
@@ -1374,8 +1403,8 @@ APyCFixedArray APyCFixedArray::rdiv(const APyCFixed& lhs) const
             std::begin(_data) + (i + 1) * _itemsize
         );
         if (den_zero) {
-            // Right-hand side is zero, simply continue
-            continue;
+            PyErr_SetString(PyExc_ZeroDivisionError, "fixed-point division by zero");
+            throw nb::python_error();
         }
 
         complex_fixed_point_division(

--- a/src/apyfixedarray.cc
+++ b/src/apyfixedarray.cc
@@ -611,6 +611,9 @@ APyFixedArray APyFixedArray::operator/(const APyFixedArray& rhs) const
             if (unsigned(bits()) <= APY_LIMB_SIZE_BITS) {
                 for (std::size_t i = 0; i < _nitems; i++) {
                     denominator = (__int128)(apy_limb_signed_t)rhs._data[i];
+                    if (denominator == 0) {
+                        continue;
+                    }
                     __int128 numerator = (__int128)(apy_limb_signed_t)_data[i];
                     numerator <<= rhs.bits();
                     auto tmp_res = numerator / denominator;
@@ -620,6 +623,9 @@ APyFixedArray APyFixedArray::operator/(const APyFixedArray& rhs) const
             } else {
                 for (std::size_t i = 0; i < _nitems; i++) {
                     denominator = (__int128)(apy_limb_signed_t)rhs._data[i];
+                    if (denominator == 0) {
+                        continue;
+                    }
                     __int128 numerator = (__int128)_data[2 * i];
                     numerator |= ((__int128)(apy_limb_signed_t)_data[2 * i + 1])
                         << APY_LIMB_SIZE_BITS;
@@ -636,6 +642,9 @@ APyFixedArray APyFixedArray::operator/(const APyFixedArray& rhs) const
                 denominator = (__int128)rhs._data[2 * i];
                 denominator |= (__int128)(apy_limb_signed_t)rhs._data[2 * i + 1]
                     << APY_LIMB_SIZE_BITS;
+                if (denominator == 0) {
+                    continue;
+                }
                 __int128 numerator = (__int128)(apy_limb_signed_t)_data[i];
                 numerator <<= rhs.bits();
                 auto tmp_res = numerator / denominator;
@@ -655,6 +664,9 @@ APyFixedArray APyFixedArray::operator/(const APyFixedArray& rhs) const
             if (unsigned(bits()) <= APY_LIMB_SIZE_BITS) {
                 for (std::size_t i = 0; i < _nitems; i++) {
                     denominator = (std::int64_t)(apy_limb_signed_t)rhs._data[i];
+                    if (denominator == 0) {
+                        continue;
+                    }
                     std::int64_t numerator = (std::int64_t)(apy_limb_signed_t)_data[i];
                     numerator <<= rhs.bits();
                     auto tmp_res = numerator / denominator;
@@ -664,6 +676,9 @@ APyFixedArray APyFixedArray::operator/(const APyFixedArray& rhs) const
             } else {
                 for (std::size_t i = 0; i < _nitems; i++) {
                     denominator = (std::int64_t)(apy_limb_signed_t)rhs._data[i];
+                    if (denominator == 0) {
+                        continue;
+                    }
                     std::int64_t numerator = (std::int64_t)_data[2 * i];
                     numerator |= ((std::int64_t)(apy_limb_signed_t)_data[2 * i + 1])
                         << APY_LIMB_SIZE_BITS;
@@ -680,6 +695,9 @@ APyFixedArray APyFixedArray::operator/(const APyFixedArray& rhs) const
                 denominator = (std::int64_t)rhs._data[2 * i];
                 denominator |= (std::int64_t)(apy_limb_signed_t)rhs._data[2 * i + 1]
                     << APY_LIMB_SIZE_BITS;
+                if (denominator == 0) {
+                    continue;
+                }
                 std::int64_t numerator = (std::int64_t)(apy_limb_signed_t)_data[i];
                 numerator <<= rhs.bits();
                 auto tmp_res = numerator / denominator;
@@ -775,6 +793,9 @@ APyFixedArray APyFixedArray::operator/(const APyFixed& rhs) const
             denominator |= (__int128)(apy_limb_signed_t)rhs._data[1]
                 << APY_LIMB_SIZE_BITS;
         }
+        if (denominator == 0) {
+            return result; // early exit with zero result
+        }
         if (unsigned(bits()) <= APY_LIMB_SIZE_BITS) {
             for (std::size_t i = 0; i < _nitems; i++) {
                 __int128 numerator = (__int128)(apy_limb_signed_t)_data[i];
@@ -808,6 +829,9 @@ APyFixedArray APyFixedArray::operator/(const APyFixed& rhs) const
             denominator = (std::int64_t)rhs._data[0];
             denominator |= (std::int64_t)(apy_limb_signed_t)rhs._data[1]
                 << APY_LIMB_SIZE_BITS;
+        }
+        if (denominator == 0) {
+            return result; // Early exit
         }
         if (unsigned(bits()) <= APY_LIMB_SIZE_BITS) {
             for (std::size_t i = 0; i < _nitems; i++) {
@@ -926,7 +950,9 @@ APyFixedArray APyFixedArray::rdiv(const APyFixed& lhs) const
         if (unsigned(bits()) <= APY_LIMB_SIZE_BITS) {
             for (std::size_t i = 0; i < _nitems; i++) {
                 __int128 denominator = (__int128)(apy_limb_signed_t)_data[i];
-
+                if (denominator == 0) {
+                    continue;
+                }
                 auto tmp_res = numerator / denominator;
                 result._data[2 * i + 0] = apy_limb_t(tmp_res);
                 result._data[2 * i + 1] = apy_limb_t(tmp_res >> APY_LIMB_SIZE_BITS);
@@ -936,6 +962,9 @@ APyFixedArray APyFixedArray::rdiv(const APyFixed& lhs) const
                 __int128 denominator = (__int128)_data[2 * i];
                 denominator |= ((__int128)(apy_limb_signed_t)_data[2 * i + 1])
                     << APY_LIMB_SIZE_BITS;
+                if (denominator == 0) {
+                    continue;
+                }
                 auto tmp_res = numerator / denominator;
                 result._data[2 * i + 0] = apy_limb_t(tmp_res);
                 result._data[2 * i + 1] = apy_limb_t(tmp_res >> APY_LIMB_SIZE_BITS);
@@ -960,6 +989,9 @@ APyFixedArray APyFixedArray::rdiv(const APyFixed& lhs) const
         if (unsigned(bits()) <= APY_LIMB_SIZE_BITS) {
             for (std::size_t i = 0; i < _nitems; i++) {
                 std::int64_t denominator = (std::int64_t)(apy_limb_signed_t)(_data[i]);
+                if (denominator == 0) {
+                    continue;
+                }
                 auto tmp_res = numerator / denominator;
                 result._data[2 * i + 0] = apy_limb_t(tmp_res);
                 result._data[2 * i + 1] = apy_limb_t(tmp_res >> APY_LIMB_SIZE_BITS);
@@ -969,6 +1001,10 @@ APyFixedArray APyFixedArray::rdiv(const APyFixed& lhs) const
                 std::int64_t denominator = std::int64_t(_data[2 * i]);
                 denominator |= (std::int64_t)(apy_limb_signed_t)_data[2 * i + 1]
                     << APY_LIMB_SIZE_BITS;
+                if (denominator == 0) {
+                    continue;
+                }
+
                 auto tmp_res = numerator / denominator;
                 result._data[2 * i + 0] = apy_limb_t(tmp_res);
                 result._data[2 * i + 1] = apy_limb_t(tmp_res >> APY_LIMB_SIZE_BITS);
@@ -1008,6 +1044,9 @@ APyFixedArray APyFixedArray::rdiv(const APyFixed& lhs) const
             std::begin(abs_num)
         );
 
+        if (limb_vector_is_zero(std::begin(abs_den), std::end(abs_den))) {
+            continue;
+        }
         // `apy_unsigned_division` requires the number of *significant* limbs in
         // denominator
         std::size_t den_significant_limbs

--- a/src/apyfixedarray.cc
+++ b/src/apyfixedarray.cc
@@ -583,6 +583,12 @@ APyFixedArray APyFixedArray::operator/(const APyFixedArray& rhs) const
         return try_broadcast_and_then<std::divides<>>(rhs, "__truediv__");
     }
 
+    if (std::size_t(rhs.bits()) <= APY_LIMB_SIZE_BITS
+        && simd::vector_any_zero(rhs._data.begin(), rhs._data.size())) {
+        PyErr_SetString(PyExc_ZeroDivisionError, "fixed-point division by zero");
+        throw nb::python_error();
+    }
+
     const int res_int_bits = int_bits() + rhs.frac_bits() + 1;
     const int res_frac_bits = frac_bits() + rhs.int_bits();
     const int res_bits = res_int_bits + res_frac_bits;
@@ -611,9 +617,8 @@ APyFixedArray APyFixedArray::operator/(const APyFixedArray& rhs) const
             if (unsigned(bits()) <= APY_LIMB_SIZE_BITS) {
                 for (std::size_t i = 0; i < _nitems; i++) {
                     denominator = (__int128)(apy_limb_signed_t)rhs._data[i];
-                    if (denominator == 0) {
-                        continue;
-                    }
+                    // No need to check if denominator is zero, as this is already
+                    // checked by SIMD specialization above
                     __int128 numerator = (__int128)(apy_limb_signed_t)_data[i];
                     numerator <<= rhs.bits();
                     auto tmp_res = numerator / denominator;
@@ -623,9 +628,8 @@ APyFixedArray APyFixedArray::operator/(const APyFixedArray& rhs) const
             } else {
                 for (std::size_t i = 0; i < _nitems; i++) {
                     denominator = (__int128)(apy_limb_signed_t)rhs._data[i];
-                    if (denominator == 0) {
-                        continue;
-                    }
+                    // No need to check if denominator is zero, as this is already
+                    // checked by SIMD specialization above
                     __int128 numerator = (__int128)_data[2 * i];
                     numerator |= ((__int128)(apy_limb_signed_t)_data[2 * i + 1])
                         << APY_LIMB_SIZE_BITS;
@@ -638,12 +642,14 @@ APyFixedArray APyFixedArray::operator/(const APyFixedArray& rhs) const
         } else {
             assert(unsigned(bits()) <= APY_LIMB_SIZE_BITS);
             for (std::size_t i = 0; i < _nitems; i++) {
-
                 denominator = (__int128)rhs._data[2 * i];
                 denominator |= (__int128)(apy_limb_signed_t)rhs._data[2 * i + 1]
                     << APY_LIMB_SIZE_BITS;
                 if (denominator == 0) {
-                    continue;
+                    PyErr_SetString(
+                        PyExc_ZeroDivisionError, "fixed-point division by zero"
+                    );
+                    throw nb::python_error();
                 }
                 __int128 numerator = (__int128)(apy_limb_signed_t)_data[i];
                 numerator <<= rhs.bits();
@@ -664,9 +670,8 @@ APyFixedArray APyFixedArray::operator/(const APyFixedArray& rhs) const
             if (unsigned(bits()) <= APY_LIMB_SIZE_BITS) {
                 for (std::size_t i = 0; i < _nitems; i++) {
                     denominator = (std::int64_t)(apy_limb_signed_t)rhs._data[i];
-                    if (denominator == 0) {
-                        continue;
-                    }
+                    // No need to check if denominator is zero, as this is already
+                    // checked by SIMD specialization above
                     std::int64_t numerator = (std::int64_t)(apy_limb_signed_t)_data[i];
                     numerator <<= rhs.bits();
                     auto tmp_res = numerator / denominator;
@@ -676,9 +681,8 @@ APyFixedArray APyFixedArray::operator/(const APyFixedArray& rhs) const
             } else {
                 for (std::size_t i = 0; i < _nitems; i++) {
                     denominator = (std::int64_t)(apy_limb_signed_t)rhs._data[i];
-                    if (denominator == 0) {
-                        continue;
-                    }
+                    // No need to check if denominator is zero, as this is already
+                    // checked by SIMD specialization above
                     std::int64_t numerator = (std::int64_t)_data[2 * i];
                     numerator |= ((std::int64_t)(apy_limb_signed_t)_data[2 * i + 1])
                         << APY_LIMB_SIZE_BITS;
@@ -696,7 +700,10 @@ APyFixedArray APyFixedArray::operator/(const APyFixedArray& rhs) const
                 denominator |= (std::int64_t)(apy_limb_signed_t)rhs._data[2 * i + 1]
                     << APY_LIMB_SIZE_BITS;
                 if (denominator == 0) {
-                    continue;
+                    PyErr_SetString(
+                        PyExc_ZeroDivisionError, "fixed-point division by zero"
+                    );
+                    throw nb::python_error();
                 }
                 std::int64_t numerator = (std::int64_t)(apy_limb_signed_t)_data[i];
                 numerator <<= rhs.bits();
@@ -723,7 +730,8 @@ APyFixedArray APyFixedArray::operator/(const APyFixedArray& rhs) const
                 std::begin(rhs._data) + (i + 0) * rhs._itemsize,
                 std::begin(rhs._data) + (i + 1) * rhs._itemsize
             )) {
-            continue;
+            PyErr_SetString(PyExc_ZeroDivisionError, "fixed-point division by zero");
+            throw nb::python_error();
         }
         bool den_sign = limb_vector_abs(
             std::begin(rhs._data) + (i + 0) * rhs._itemsize,
@@ -762,6 +770,11 @@ APyFixedArray APyFixedArray::operator/(const APyFixedArray& rhs) const
 
 APyFixedArray APyFixedArray::operator/(const APyFixed& rhs) const
 {
+    if (rhs.is_zero()) {
+        PyErr_SetString(PyExc_ZeroDivisionError, "fixed-point division by zero");
+        throw nb::python_error();
+    }
+
     const int res_int_bits = int_bits() + rhs.frac_bits() + 1;
     const int res_frac_bits = frac_bits() + rhs.int_bits();
     const int res_bits = res_int_bits + res_frac_bits;
@@ -792,9 +805,6 @@ APyFixedArray APyFixedArray::operator/(const APyFixed& rhs) const
             denominator = (__int128)rhs._data[0];
             denominator |= (__int128)(apy_limb_signed_t)rhs._data[1]
                 << APY_LIMB_SIZE_BITS;
-        }
-        if (denominator == 0) {
-            return result; // early exit with zero result
         }
         if (unsigned(bits()) <= APY_LIMB_SIZE_BITS) {
             for (std::size_t i = 0; i < _nitems; i++) {
@@ -829,9 +839,6 @@ APyFixedArray APyFixedArray::operator/(const APyFixed& rhs) const
             denominator = (std::int64_t)rhs._data[0];
             denominator |= (std::int64_t)(apy_limb_signed_t)rhs._data[1]
                 << APY_LIMB_SIZE_BITS;
-        }
-        if (denominator == 0) {
-            return result; // Early exit
         }
         if (unsigned(bits()) <= APY_LIMB_SIZE_BITS) {
             for (std::size_t i = 0; i < _nitems; i++) {
@@ -916,6 +923,12 @@ APyFixedArray APyFixedArray::operator/(const APyFixed& rhs) const
 
 APyFixedArray APyFixedArray::rdiv(const APyFixed& lhs) const
 {
+    if (std::size_t(bits()) <= APY_LIMB_SIZE_BITS
+        && simd::vector_any_zero(_data.begin(), _data.size())) {
+        PyErr_SetString(PyExc_ZeroDivisionError, "fixed-point division by zero");
+        throw nb::python_error();
+    }
+
     const int res_int_bits = lhs.int_bits() + frac_bits() + 1;
     const int res_frac_bits = lhs.frac_bits() + int_bits();
     const int res_bits = res_int_bits + res_frac_bits;
@@ -950,9 +963,8 @@ APyFixedArray APyFixedArray::rdiv(const APyFixed& lhs) const
         if (unsigned(bits()) <= APY_LIMB_SIZE_BITS) {
             for (std::size_t i = 0; i < _nitems; i++) {
                 __int128 denominator = (__int128)(apy_limb_signed_t)_data[i];
-                if (denominator == 0) {
-                    continue;
-                }
+                // No need to check if denominator is zero, as this is already checked
+                // by SIMD specialization above
                 auto tmp_res = numerator / denominator;
                 result._data[2 * i + 0] = apy_limb_t(tmp_res);
                 result._data[2 * i + 1] = apy_limb_t(tmp_res >> APY_LIMB_SIZE_BITS);
@@ -963,7 +975,10 @@ APyFixedArray APyFixedArray::rdiv(const APyFixed& lhs) const
                 denominator |= ((__int128)(apy_limb_signed_t)_data[2 * i + 1])
                     << APY_LIMB_SIZE_BITS;
                 if (denominator == 0) {
-                    continue;
+                    PyErr_SetString(
+                        PyExc_ZeroDivisionError, "fixed-point division by zero"
+                    );
+                    throw nb::python_error();
                 }
                 auto tmp_res = numerator / denominator;
                 result._data[2 * i + 0] = apy_limb_t(tmp_res);
@@ -989,9 +1004,8 @@ APyFixedArray APyFixedArray::rdiv(const APyFixed& lhs) const
         if (unsigned(bits()) <= APY_LIMB_SIZE_BITS) {
             for (std::size_t i = 0; i < _nitems; i++) {
                 std::int64_t denominator = (std::int64_t)(apy_limb_signed_t)(_data[i]);
-                if (denominator == 0) {
-                    continue;
-                }
+                // No need to check if denominator is zero, as this is already checked
+                // by SIMD specialization above
                 auto tmp_res = numerator / denominator;
                 result._data[2 * i + 0] = apy_limb_t(tmp_res);
                 result._data[2 * i + 1] = apy_limb_t(tmp_res >> APY_LIMB_SIZE_BITS);
@@ -1002,7 +1016,10 @@ APyFixedArray APyFixedArray::rdiv(const APyFixed& lhs) const
                 denominator |= (std::int64_t)(apy_limb_signed_t)_data[2 * i + 1]
                     << APY_LIMB_SIZE_BITS;
                 if (denominator == 0) {
-                    continue;
+                    PyErr_SetString(
+                        PyExc_ZeroDivisionError, "fixed-point division by zero"
+                    );
+                    throw nb::python_error();
                 }
 
                 auto tmp_res = numerator / denominator;
@@ -1045,7 +1062,8 @@ APyFixedArray APyFixedArray::rdiv(const APyFixed& lhs) const
         );
 
         if (limb_vector_is_zero(std::begin(abs_den), std::end(abs_den))) {
-            continue;
+            PyErr_SetString(PyExc_ZeroDivisionError, "fixed-point division by zero");
+            throw nb::python_error();
         }
         // `apy_unsigned_division` requires the number of *significant* limbs in
         // denominator

--- a/src/apytypes_simd.cc
+++ b/src/apytypes_simd.cc
@@ -445,6 +445,32 @@ namespace HWY_NAMESPACE { // required: unique per target
         return sum;
     }
 
+    HWY_ATTR bool
+    _hwy_vector_any_zero(const apy_limb_t* HWY_RESTRICT src, const std::size_t size)
+    {
+        constexpr const hn::ScalableTag<apy_limb_t> d;
+        const std::size_t size_simd = size - size % hn::Lanes(d);
+
+        const auto zeros = hn::Zero(d);
+        const auto ones = hn::Set(d, apy_limb_t(1));
+        std::size_t i = 0;
+        for (; i < size_simd; i += hn::Lanes(d)) {
+            const auto v = hn::LoadU(d, src + i);
+            const auto is_zero_mask = hn::Eq(v, zeros);
+            const auto flagged = hn::IfThenElseZero(is_zero_mask, ones);
+            if (hn::ReduceSum(d, flagged) != 0) {
+                return true;
+            }
+        }
+
+        for (; i < size; i++) {
+            if (src[i] == 0) {
+                return true;
+            }
+        }
+        return false;
+    }
+
     HWY_ATTR std::string _hwy_simd_version_str()
     {
         constexpr const hn::ScalableTag<apy_limb_t> d;
@@ -489,6 +515,7 @@ HWY_EXPORT(_hwy_vector_sub_const);
 HWY_EXPORT(_hwy_vector_rsub_const);
 HWY_EXPORT(_hwy_vector_rdiv_const_signed);
 HWY_EXPORT(_hwy_vector_multiply_accumulate);
+HWY_EXPORT(_hwy_vector_any_zero);
 
 std::string get_simd_version_str()
 {
@@ -753,6 +780,13 @@ apy_limb_t vector_multiply_accumulate(
     return HWY_DYNAMIC_DISPATCH(_hwy_vector_multiply_accumulate)(
         &*src1_begin, &*src2_begin, size
     );
+}
+
+bool vector_any_zero(
+    APyBuffer<apy_limb_t>::vector_type::const_iterator src_begin, std::size_t size
+)
+{
+    return HWY_DYNAMIC_DISPATCH(_hwy_vector_any_zero)(&*src_begin, size);
 }
 
 } // namespace simd

--- a/src/apytypes_simd.h
+++ b/src/apytypes_simd.h
@@ -239,6 +239,13 @@ apy_limb_t vector_multiply_accumulate(
     std::size_t size
 );
 
+/*!
+ * Return true if any element in [ `src_begin`, `src_begin + size` ) is zero.
+ */
+bool vector_any_zero(
+    APyBuffer<apy_limb_t>::vector_type::const_iterator src_begin, std::size_t size
+);
+
 /*
  * Functor export from functions
  */


### PR DESCRIPTION
<!--
Thank you so much for your PR!
-->

# PR Summary
<!-- Please provide at least 1-2 sentences describing the pull request in detail
(Why is this change required?  What problem does it solve?) and link to relevant
issues and PRs.
-->

There was a bug when introducing two-limb specializations for complex division. However, there was no test for real-valued division by zero for arrays. I was under the impression that we ignored division-by-zero errors because of SIMD? However, it turns out that there will be worse errors when actually dividing by zero (floating-point exception killing the Python session on my machine and this comes from the SIMD-part). So I think that we should raise for arrays as well? @miklhh 

## PR Checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

- [ ] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [ ] new and changed code is tested
- [x] relevant changes added to [CHANGELOG.md](https://github.com/apytypes/apytypes/blob/main/CHANGELOG.md)
- [ ] new functionality is documented
