### PR TITLE
Drop support for Python 3.10 and Numpy 1

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -59,7 +59,7 @@ jobs:
     - name: Setup Python
       uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
       with:
-        python-version: "3.10"
+        python-version: "3.11"
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
       uses: github/codeql-action/init@8aad20d150bbac5944a9f9d289da16a4b0d87c1e  # v4.36.2

--- a/.github/workflows/run_coverage.yml
+++ b/.github/workflows/run_coverage.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.10"]
+        python-version: ["3.11"]
         os: ["ubuntu-24.04-arm"]
 
     runs-on: ${{ matrix.os }}
@@ -69,7 +69,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.10"]
+        python-version: ["3.11"]
         os: ["ubuntu-latest"]
 
     runs-on: ${{ matrix.os }}
@@ -125,7 +125,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.10"]
+        python-version: ["3.11"]
         os: ["windows-latest"]
 
     runs-on: ${{ matrix.os }}
@@ -199,7 +199,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.10"]
+        python-version: ["3.11"]
         os: ["macos-14", "macos-15-intel"]
 
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/stub-and-doctests.yml
+++ b/.github/workflows/stub-and-doctests.yml
@@ -23,10 +23,10 @@ jobs:
         fetch-tags: true
         fetch-depth: 0
         persist-credentials: false
-    - name: Set up Python 3.10
+    - name: Set up Python 3.11
       uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
       with:
-        python-version: "3.10"
+        python-version: "3.11"
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip

--- a/.github/workflows/test-clash.yml
+++ b/.github/workflows/test-clash.yml
@@ -33,10 +33,10 @@ jobs:
         fetch-tags: true
         persist-credentials: false
     # - uses: nickg/setup-nvc@40dcbd31cf07b60479a31f94a5df70c0bfbb9ce5  # v1v1
-    - name: Set up Python 3.10
+    - name: Set up Python 3.11
       uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
       with:
-        python-version: "3.10"
+        python-version: "3.11"
     - name: Setup Haskell
       uses: haskell-actions/setup@v2
       with:

--- a/.github/workflows/tests-32-bits.yml
+++ b/.github/workflows/tests-32-bits.yml
@@ -24,10 +24,10 @@ jobs:
         fetch-tags: true
         fetch-depth: 0
         persist-credentials: false
-    - name: Set up Python 3.10
+    - name: Set up Python 3.11
       uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
       with:
-        python-version: "3.10"
+        python-version: "3.11"
     - name: Install dependencies
       run: |
         sudo apt-get install -yy lcov
@@ -78,7 +78,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
       with:
-        python-version: "3.10"
+        python-version: "3.11"
     - name: Install dependencies
       run: |
         brew update

--- a/.github/workflows/tests-cocotb.yml
+++ b/.github/workflows/tests-cocotb.yml
@@ -33,10 +33,10 @@ jobs:
         fetch-tags: true
         persist-credentials: false
     # - uses: nickg/setup-nvc@40dcbd31cf07b60479a31f94a5df70c0bfbb9ce5  # v1v1
-    - name: Set up Python 3.10
+    - name: Set up Python 3.11
       uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
       with:
-        python-version: "3.10"
+        python-version: "3.11"
     - uses: nickg/setup-nvc@master  # v1v1
       with:
         version: latest

--- a/.github/workflows/tests-min-deps.yml
+++ b/.github/workflows/tests-min-deps.yml
@@ -33,10 +33,10 @@ jobs:
         fetch-depth: 0
         fetch-tags: true
         persist-credentials: false
-    - name: Set up Python 3.10
+    - name: Set up Python 3.11
       uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
       with:
-        python-version: "3.10"
+        python-version: "3.11"
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -25,30 +25,15 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.10", "3.11", "3.12", "3.13", "3.13t", "3.14", "3.14t", "3.15-dev"]
+        python-version: ["3.11", "3.12", "3.13", "3.13t", "3.14", "3.14t", "3.15-dev"]
         os: [ubuntu-latest, ubuntu-24.04-arm, windows-latest, macos-14, macos-15, macos-15-intel, macos-26-intel, macos-26] # windows-11-arm,
-        numpy-version: [">=1.26.4,<2", ">=2.1"]
+        numpy-version: [">=2.1"]
         exclude:
           # Only Python 3.13 and later for windows-11-arm
-          - os: "windows-11-arm"
-            python-version: "3.10"
           - os: "windows-11-arm"
             python-version: "3.11"
           - os: "windows-11-arm"
             python-version: "3.12"
-          # Do not test with NumPy 1 on free-threaded Python
-          - numpy-version: ">=1.26.4,<2"
-            python-version: "3.13t"
-          - numpy-version: ">=1.26.4,<2"
-            python-version: "3.14t"
-          # Do not test with NumPy 1 on 3.14 or 3.15
-          - numpy-version: ">=1.26.4,<2"
-            python-version: "3.14"
-          - numpy-version: ">=1.26.4,<2"
-            python-version: "3.15-dev"
-          # No numpy 1 on windows-11-arm
-          - os: windows-11-arm
-            numpy-version: ">=1.26.4,<2"
           # No free-threaded Python on Windows
           - os: "windows-latest"
             python-version: "3.13t"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Removed
 
--
+- Support for Python 3.10.
+- Support for Numpy 1.
 
 ## [0.5.1] - 2026-05-06
 

--- a/lib/test/apycfloat/test_arithmetic.py
+++ b/lib/test/apycfloat/test_arithmetic.py
@@ -198,9 +198,17 @@ def test_sub_double_precision(x: complex, y: complex):
 @pytest.mark.parametrize("man_bits", [10, 35, 52])
 @pytest.mark.parametrize(
     ("a_val", "b_val"),
-    product(
-        [0.0 + 0.0j, -1.0 + 0.0j, -0.0 - 1.0j, 3.0625 - 1.25j, -(2 ** (-4)) + 247.25j],
-        repeat=2,
+    list(
+        product(
+            [
+                0.0 + 0.0j,
+                -1.0 + 0.0j,
+                -0.0 - 1.0j,
+                3.0625 - 1.25j,
+                -(2 ** (-4)) + 247.25j,
+            ],
+            repeat=2,
+        )
     ),
 )
 def test_arithmetic_with_python_complex(

--- a/lib/test/apycfloat/test_comparisons.py
+++ b/lib/test/apycfloat/test_comparisons.py
@@ -110,8 +110,8 @@ def test_inf_comparison():
 
 
 @pytest.mark.float_comp
-@pytest.mark.parametrize("a_sign", product([0, 1], repeat=2))
-@pytest.mark.parametrize("b_sign", product([0, 1], repeat=2))
+@pytest.mark.parametrize("a_sign", list(product([0, 1], repeat=2)))
+@pytest.mark.parametrize("b_sign", list(product([0, 1], repeat=2)))
 def test_signed_zero_comparison(a_sign: tuple[int, int], b_sign: tuple[int, int]):
     a = APyCFloat(a_sign, (0, 0), (0, 0), 5, 10)
     b = APyCFloat(b_sign, (0, 0), (0, 0), 5, 10)

--- a/lib/test/apycfloat/test_methods.py
+++ b/lib/test/apycfloat/test_methods.py
@@ -113,9 +113,9 @@ def test_to_complex():
     )
 
 
-@pytest.mark.parametrize("exp_bits", product([5, 11], repeat=2))
-@pytest.mark.parametrize("man_bits", product([11, 30, 51], repeat=2))
-@pytest.mark.parametrize("bias", product([None, 14], repeat=2))
+@pytest.mark.parametrize("exp_bits", list(product([5, 11], repeat=2)))
+@pytest.mark.parametrize("man_bits", list(product([11, 30, 51], repeat=2)))
+@pytest.mark.parametrize("bias", list(product([None, 14], repeat=2)))
 @pytest.mark.parametrize(
     "value", [0.0, -0.0, 4.5, -62.0625, float("-inf"), -(2**11), 2**-11]
 )

--- a/lib/test/apyfloat/test_comparisons.py
+++ b/lib/test/apyfloat/test_comparisons.py
@@ -82,9 +82,11 @@ def test_comparisons_with_apyfixed():
 
 @pytest.mark.float_comp
 @pytest.mark.parametrize("apyfloat", [APyFloat, APyCFloat])
-@pytest.mark.parametrize("val", product([0.0, -2.5, -2.75, -(2**-9), 2**5], repeat=2))
-@pytest.mark.parametrize("exp_bits", product([4, 6], repeat=2))
-@pytest.mark.parametrize("man_bits", product([7, 8], repeat=2))
+@pytest.mark.parametrize(
+    "val", list(product([0.0, -2.5, -2.75, -(2**-9), 2**5], repeat=2))
+)
+@pytest.mark.parametrize("exp_bits", list(product([4, 6], repeat=2)))
+@pytest.mark.parametrize("man_bits", list(product([7, 8], repeat=2)))
 def test_equality(
     apyfloat: type[APyCFloat],
     val: tuple[float, float],
@@ -99,9 +101,11 @@ def test_equality(
 
 
 @pytest.mark.float_comp
-@pytest.mark.parametrize("val", product([0.0, -2.5, -2.75, -(2**-9), 2**5], repeat=2))
-@pytest.mark.parametrize("exp_bits", product([5, 7], repeat=2))
-@pytest.mark.parametrize("man_bits", product([6, 8], repeat=2))
+@pytest.mark.parametrize(
+    "val", list(product([0.0, -2.5, -2.75, -(2**-9), 2**5], repeat=2))
+)
+@pytest.mark.parametrize("exp_bits", list(product([5, 7], repeat=2)))
+@pytest.mark.parametrize("man_bits", list(product([6, 8], repeat=2)))
 def test_lt_gt(
     val: tuple[float, float],
     exp_bits: tuple[int, int],
@@ -116,9 +120,11 @@ def test_lt_gt(
 
 
 @pytest.mark.float_comp
-@pytest.mark.parametrize("val", product([0.0, -2.5, -2.75, -(2**-9), 2**5], repeat=2))
-@pytest.mark.parametrize("exp_bits", product([5, 7], repeat=2))
-@pytest.mark.parametrize("man_bits", product([6, 8], repeat=2))
+@pytest.mark.parametrize(
+    "val", list(product([0.0, -2.5, -2.75, -(2**-9), 2**5], repeat=2))
+)
+@pytest.mark.parametrize("exp_bits", list(product([5, 7], repeat=2)))
+@pytest.mark.parametrize("man_bits", list(product([6, 8], repeat=2)))
 def test_leq_geq(
     val: tuple[float, float],
     exp_bits: tuple[int, int],
@@ -134,8 +140,8 @@ def test_leq_geq(
 
 @pytest.mark.float_comp
 @pytest.mark.parametrize("val", [0.0, -2.5, -2.75, -(2**-9), 2**5])
-@pytest.mark.parametrize("exp_bits", product([5, 7], repeat=2))
-@pytest.mark.parametrize("man_bits", product([6, 8], repeat=2))
+@pytest.mark.parametrize("exp_bits", list(product([5, 7], repeat=2)))
+@pytest.mark.parametrize("man_bits", list(product([6, 8], repeat=2)))
 def test_nan_comparison(
     val: float,
     exp_bits: tuple[int, int],
@@ -164,8 +170,8 @@ def test_nan_comparison(
 @pytest.mark.float_special
 @pytest.mark.parametrize("val0", [float("inf"), float("-inf"), 0.0, -1.0])
 @pytest.mark.parametrize("val1", [float("inf"), float("-inf"), 0.0, -1.0])
-@pytest.mark.parametrize("exp_bits", product([5, 7], repeat=2))
-@pytest.mark.parametrize("man_bits", product([6, 8], repeat=2))
+@pytest.mark.parametrize("exp_bits", list(product([5, 7], repeat=2)))
+@pytest.mark.parametrize("man_bits", list(product([6, 8], repeat=2)))
 def test_inf_comparison(
     val0: float,
     val1: float,

--- a/lib/test/test_codegen.py
+++ b/lib/test/test_codegen.py
@@ -30,12 +30,14 @@ ADDRESSES = [
 @pytest.mark.skipif(not shutil.which("nvc"), reason="nvc not found")
 @pytest.mark.parametrize(
     ("table", "address", "ieee2008", "input_register", "output_register"),
-    product(
-        TABLES,
-        ADDRESSES,
-        [True, False],
-        [True, False],
-        [True, False],
+    list(
+        product(
+            TABLES,
+            ADDRESSES,
+            [True, False],
+            [True, False],
+            [True, False],
+        )
     ),
 )
 def test_generate_rom_nvc(
@@ -62,12 +64,14 @@ def test_generate_rom_nvc(
 @pytest.mark.skipif(not shutil.which("ghdl"), reason="ghdl not found")
 @pytest.mark.parametrize(
     ("table", "address", "ieee2008", "input_register", "output_register"),
-    product(
-        TABLES,
-        ADDRESSES,
-        [True, False],
-        [True, False],
-        [True, False],
+    list(
+        product(
+            TABLES,
+            ADDRESSES,
+            [True, False],
+            [True, False],
+            [True, False],
+        )
     ),
 )
 def test_generate_rom_ghdl(
@@ -99,12 +103,14 @@ def test_generate_rom_ghdl(
 @pytest.mark.skipif(not shutil.which("iverilog"), reason="iverilog not found")
 @pytest.mark.parametrize(
     ("table", "address", "systemverilog", "input_register", "output_register"),
-    product(
-        TABLES,
-        ADDRESSES,
-        [True, False],
-        [True, False],
-        [True, False],
+    list(
+        product(
+            TABLES,
+            ADDRESSES,
+            [True, False],
+            [True, False],
+            [True, False],
+        )
     ),
 )
 def test_generate_rom_iverilog(
@@ -135,12 +141,14 @@ def test_generate_rom_iverilog(
 @pytest.mark.skipif(not shutil.which("verilator"), reason="verilator not found")
 @pytest.mark.parametrize(
     ("table", "address", "systemverilog", "input_register", "output_register"),
-    product(
-        TABLES,
-        ADDRESSES,
-        [True, False],
-        [True, False],
-        [True, False],
+    list(
+        product(
+            TABLES,
+            ADDRESSES,
+            [True, False],
+            [True, False],
+            [True, False],
+        )
     ),
 )
 def test_generate_rom_verilator(
@@ -170,7 +178,7 @@ def test_generate_rom_verilator(
 @pytest.mark.skipif(not shutil.which("scala-cli"), reason="scala-cli not found")
 @pytest.mark.parametrize(
     ("table", "address", "input_register", "output_register"),
-    product(TABLES, ADDRESSES, [True, False], [True, False]),
+    list(product(TABLES, ADDRESSES, [True, False], [True, False])),
 )
 def test_generate_rom_chisel(table, address, input_register, output_register, tmp_path):
     filepath = tmp_path / "testrom.scala"
@@ -206,7 +214,7 @@ def test_generate_rom_chisel(table, address, input_register, output_register, tm
 )
 @pytest.mark.parametrize(
     ("table", "address", "input_register", "output_register"),
-    product(TABLES, ADDRESSES, [True, False], [True, False]),
+    list(product(TABLES, ADDRESSES, [True, False], [True, False])),
 )
 def test_generate_rom_amaranth(
     table, address, input_register, output_register, tmp_path
@@ -229,7 +237,7 @@ def test_generate_rom_amaranth(
 @pytest.mark.skipif(not shutil.which("scala-cli"), reason="scala-cli not found")
 @pytest.mark.parametrize(
     ("table", "address", "input_register", "output_register"),
-    product(TABLES, ADDRESSES, [True, False], [True, False]),
+    list(product(TABLES, ADDRESSES, [True, False], [True, False])),
 )
 def test_generate_rom_spinalhdl(
     table, address, input_register, output_register, tmp_path
@@ -264,11 +272,13 @@ def test_generate_rom_spinalhdl(
 @pytest.mark.skipif(not shutil.which("spade"), reason="spade not found")
 @pytest.mark.parametrize(
     ("table", "address", "input_register", "output_register"),
-    product(
-        TABLES,
-        ADDRESSES,
-        [True, False],
-        [True, False],
+    list(
+        product(
+            TABLES,
+            ADDRESSES,
+            [True, False],
+            [True, False],
+        )
     ),
 )
 def test_generate_rom_spade(table, address, input_register, output_register, tmp_path):
@@ -293,11 +303,13 @@ def test_generate_rom_spade(table, address, input_register, output_register, tmp
 @pytest.mark.skipif(not shutil.which("clash"), reason="clash not found")
 @pytest.mark.parametrize(
     ("table", "address", "input_register", "output_register"),
-    product(
-        TABLES,
-        ADDRESSES,
-        [True, False],
-        [True, False],
+    list(
+        product(
+            TABLES,
+            ADDRESSES,
+            [True, False],
+            [True, False],
+        )
     ),
 )
 def test_generate_rom_clash(table, address, input_register, output_register, tmp_path):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,14 +8,13 @@ authors = [
 ]
 description = "Python package for custom fixed-point and floating-point formats"
 readme = "README.md"
-requires-python = ">=3.10"
+requires-python = ">=3.11"
 classifiers = [
     "Development Status :: 4 - Beta",
     "Intended Audience :: Science/Research",
     "License :: OSI Approved :: MIT License",
     "Operating System :: OS Independent",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
@@ -43,21 +42,21 @@ docs = [
     "sphinx_gallery>=0.16",
     "m2r2",
     "docutils",
-    "numpy>=1.25",
+    "numpy>=2",
     "scipy",
     "cocotb>=2",
 ]
-test = ["numpy>=1.25", "pytest>=8.2"]
-test_hdl = ["numpy>=1.25", "pytest>=8.2", "cocotb>=2", "vunit-hdl", "packaging"]
+test = ["numpy>=2", "pytest>=8.2"]
+test_hdl = ["numpy>=2", "pytest>=8.2", "cocotb>=2", "vunit-hdl", "packaging"]
 dev = ["nanobind>=2.8.0"]
-benchmark = ["numpy>=1.25", "pytest>=8.2", "pytest-benchmark"]
+benchmark = ["numpy>=2", "pytest>=8.2", "pytest-benchmark"]
 comparison = [
     "fpbinary",
     "fixedpoint",
     "fxpmath>=0.4.9",
     "spfpm",
     "numfi>=0.5",
-    "numpy>=1.25",
+    "numpy>=2",
     "matplotlib>=3.7",
 ]
 
@@ -115,8 +114,8 @@ exclude = [".git", ".vscode", "_build", "build"]
 line-length = 88
 indent-width = 4
 
-# Assume Python 3.10
-target-version = "py310"
+# Assume Python 3.11
+target-version = "py311"
 
 [tool.ruff.lint]
 select = [


### PR DESCRIPTION
<!--
Thank you so much for your PR!
-->

# PR Summary
<!-- Please provide at least 1-2 sentences describing the pull request in detail
(Why is this change required?  What problem does it solve?) and link to relevant
issues and PRs.
-->

I think it is OK to drop this for the next version. Neither of these are supported by NumPy (although nothing has changed in the Python code as seen, so I'd still expect it to work for some time, if one builds it locally).

Maybe we should have a Python and NumPy version support policy? See:
- https://numpy.org/neps/nep-0029-deprecation_policy.html
- https://matplotlib.org/devdocs/devel/min_dep_policy.html

for examples.

## PR Checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

- [N/A] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [N/A] new and changed code is tested
- [x] relevant changes added to [CHANGELOG.md](https://github.com/apytypes/apytypes/blob/main/CHANGELOG.md)
- [N/A] new functionality is documented
