### PR TITLE
Add `from_bits` and `to_bits` to complex arrays

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Proper nesting using multiple levels of APyTypes contexts
 - Utility functions `fp` and `fx` automatically detect complex-valued arrays
 - Correct output bias for logical operations on `APyFloat`
+- `APyFixedArray.to_bits` for 64-bit NumPy arrays on 32-bit systems
 
 ### Changed
 

--- a/docs/api/apycfixedarray.rst
+++ b/docs/api/apycfixedarray.rst
@@ -13,6 +13,8 @@
 
    .. automethod:: to_numpy
 
+   .. automethod:: to_bits
+
    Creation from other types
    -------------------------
 
@@ -21,6 +23,8 @@
    .. automethod:: from_complex
 
    .. automethod:: from_float
+
+   .. automethod:: from_bits
 
    Other creation functions
    ------------------------

--- a/lib/apytypes/_apytypes.pyi
+++ b/lib/apytypes/_apytypes.pyi
@@ -1044,6 +1044,27 @@ class APyCFixedArray:
         :class:`numpy.ndarray`
         """
 
+    def to_bits(
+        self, numpy: bool = False
+    ) -> (
+        list
+        | NDArray[numpy.uint64]
+        | NDArray[numpy.uint32]
+        | NDArray[numpy.uint16]
+        | NDArray[numpy.uint8]
+    ):
+        """
+        Return the underlying bit representations.
+
+        When `numpy` is true, the bit representations are returned in a
+        :class:`numpy.ndarray`. Otherwise, they are returned in a
+        :class:`list`.
+
+        Returns
+        -------
+        :class:`list` or :class:`numpy.ndarray`
+        """
+
     def reshape(self, new_shape: int | tuple[int, ...]) -> APyCFixedArray:
         """
         Reshape the APyCFixedArray to the specified shape without changing its data.
@@ -1757,6 +1778,32 @@ class APyCFixedArray:
         >>> print(a)
         [[1+0j, 2+0j, 3+0j],
          [4+0j, 5+0j, 6+0j]]
+
+        Returns
+        -------
+        :class:`APyCFixedArray`
+        """
+
+    @staticmethod
+    def from_bits(
+        bit_pattern_sequence: Iterable[Any],
+        int_bits: int | None = None,
+        frac_bits: int | None = None,
+        bits: int | None = None,
+    ) -> APyCFixedArray:
+        """
+        Create an :class:`APyCFixedArray` object from a sequence of bit patterns.
+
+        Parameters
+        ----------
+        bit_pattern_sequence : list
+            Bit patterns to initialize from.
+        int_bits : :class:`int`, optional
+            Number of integer bits in the created fixed-point tensor.
+        frac_bits : :class:`int`, optional
+            Number of fractional bits in the created fixed-point tensor.
+        bits : :class:`int`, optional
+            Total number of bits in the created fixed-point tensor.
 
         Returns
         -------

--- a/lib/apytypes/_apytypes.pyi
+++ b/lib/apytypes/_apytypes.pyi
@@ -2890,6 +2890,47 @@ class APyCFloatArray:
         from_float
         """
 
+    @staticmethod
+    def from_bits(
+        bits: Iterable[Any], exp_bits: int, man_bits: int, bias: int | None = None
+    ) -> APyCFloatArray:
+        """
+        Create an :class:`APyCFloatArray` object from bit-representations.
+
+        Parameters
+        ----------
+        bits : :class:`int`
+            The bit-representations.
+        exp_bits : :class:`int`
+            Number of exponent bits in the created floating-point tensor
+        man_bits : :class:`int`
+            Number of mantissa bits in the created floating-point tensor
+        bias : :class:`int`, optional
+            Exponent bias. If not provided, *bias* is ``2**exp_bits - 1``.
+
+        Examples
+        --------
+
+        >>> import apytypes as apy
+        >>> a = apy.APyCFloatArray.from_bits(
+        ...     [[60, 61], [80, 82]], exp_bits=5, man_bits=2
+        ... )
+        >>> a
+        APyCFloatArray(
+            [  (0, 0),   (0, 0)],
+            [(15, 15), (20, 20)],
+            [  (0, 1),   (0, 2)],
+            exp_bits=5,
+            man_bits=2
+        )
+        >>> print(a)
+        [1+1.25j,  32+48j]
+
+        Returns
+        -------
+        :class:`APyCFloatArray`
+        """
+
     def is_identical(self, other: object, ignore_zero_sign: bool = False) -> bool:
         """
         Test if two :py:class:`APyCFloatArray` objects are identical.
@@ -3261,6 +3302,26 @@ class APyCFloatArray:
         Returns
         -------
         :class:`numpy.ndarray`
+        """
+
+    def to_bits(
+        self, numpy: bool = False
+    ) -> (
+        list
+        | NDArray[numpy.uint64]
+        | NDArray[numpy.uint32]
+        | NDArray[numpy.uint16]
+        | NDArray[numpy.uint8]
+    ):
+        """
+        Return the underlying bit representations.
+
+        When `numpy` is true, the bit representations are returned in a
+        :class:`numpy.ndarray`. Otherwise, they are returned in a :class:`list`.
+
+        Returns
+        -------
+        :class:`list` or :class:`numpy.ndarray`
         """
 
     def broadcast_to(self, shape: int | tuple[int, ...]) -> APyCFloatArray:

--- a/lib/test/apycfixedarray/test_methods.py
+++ b/lib/test/apycfixedarray/test_methods.py
@@ -136,3 +136,141 @@ def test_python_deepcopy():
     a[0] = APyCFixed((2, 1), 4, 5)
     assert a.is_identical(b)
     assert not a.is_identical(c)
+
+
+@pytest.mark.parametrize(
+    ("lst", "ref"),
+    [
+        ([1], APyCFixedArray.from_complex([1], int_bits=10, frac_bits=0)),
+        ([1, 2], APyCFixedArray.from_complex([1 + 2j], int_bits=10, frac_bits=0)),
+        ([1, 3, 4], APyCFixedArray.from_complex([1, 3, 4], int_bits=10, frac_bits=0)),
+        ([[1], [2]], APyCFixedArray.from_complex([[1], [2]], int_bits=10, frac_bits=0)),
+        (
+            [[1, 2], [3, 4]],
+            APyCFixedArray.from_complex([1 + 2j, 3 + 4j], int_bits=10, frac_bits=0),
+        ),
+        (
+            [[[1, 2]], [[3, 4]]],
+            APyCFixedArray.from_complex([[1 + 2j], [3 + 4j]], int_bits=10, frac_bits=0),
+        ),
+    ],
+)
+def test_from_bits(lst: list[list[int] | int], ref: APyCFixedArray):
+    assert APyCFixedArray.from_bits(lst, int_bits=10, frac_bits=0).is_identical(ref)
+
+
+@pytest.mark.parametrize(
+    ("lst", "ref"),
+    [
+        ([1], APyCFixedArray.from_complex([1], int_bits=10, frac_bits=0)),
+        ([1, 2], APyCFixedArray.from_complex([1 + 2j], int_bits=10, frac_bits=0)),
+        ([1, 3, 4], APyCFixedArray.from_complex([1, 3, 4], int_bits=10, frac_bits=0)),
+        ([[1], [2]], APyCFixedArray.from_complex([[1], [2]], int_bits=10, frac_bits=0)),
+        (
+            [[1, 2], [3, 4]],
+            APyCFixedArray.from_complex([1 + 2j, 3 + 4j], int_bits=10, frac_bits=0),
+        ),
+        (
+            [[[1, 2]], [[3, 4]]],
+            APyCFixedArray.from_complex([[1 + 2j], [3 + 4j]], int_bits=10, frac_bits=0),
+        ),
+    ],
+)
+def test_from_bits_np(lst: list[list[int] | int], ref: APyCFixedArray):
+    np = pytest.importorskip("numpy")
+    assert APyCFixedArray.from_bits(
+        np.asarray(lst), int_bits=10, frac_bits=0
+    ).is_identical(ref)
+
+
+@pytest.mark.parametrize(
+    "lst",
+    [
+        [(1, 1)],
+        [(1, 2), (2, 0)],
+        [(1, 3), (3, 8), (4, 1)],
+        [[(1, 7)], [(2, 8)]],
+        [[(1, 3), (2, 0)], [(3, 5), (4, 6)]],
+        [[[(1, 2**80 - 7), (2**90, 4)]], [[(3, 1), (2**65 - 4, 2**70)]]],
+    ],
+)
+def test_to_bits(lst: list[list[tuple[int, int]] | tuple[int, int]]):
+    assert APyCFixedArray(lst, int_bits=91, frac_bits=0).to_bits() == lst
+
+
+@pytest.mark.parametrize(
+    "lst",
+    [
+        [(1, 1)],
+        [(1, 2), (2, 0)],
+        [(1, 3), (3, 8), (4, 1)],
+        [[(1, 7)], [(2, 2**16 - 9)]],
+        [[(1, 3), (2, 0)], [(3, 7), (2**30 - 7, 6)]],
+        [[[(1, 1), (2**62 - 5, 4)]], [[(3, 1), (4, 0)]]],
+    ],
+)
+def test_to_bits_np(lst: list[list[tuple[int, int]] | tuple[int, int]]):
+    np = pytest.importorskip("numpy")
+    assert np.array_equal(
+        APyCFixedArray(lst, int_bits=63, frac_bits=0).to_bits(True), np.asarray(lst)
+    )
+
+
+def test_to_bits_np_neg():
+    np = pytest.importorskip("numpy")
+    assert np.array_equal(
+        APyCFixedArray.from_float(range(-3, 3), int_bits=4, frac_bits=1).to_bits(True),
+        np.array(
+            [
+                (0b11010, 0),
+                (0b11100, 0),
+                (0b11110, 0),
+                (0b00000, 0),
+                (0b00010, 0),
+                (0b00100, 0),
+            ]
+        ),
+    )
+
+    data = np.arange(-3, 3) + 1j * np.arange(2, -4, -1)
+    assert np.array_equal(
+        APyCFixedArray.from_complex(data, int_bits=4, frac_bits=1).to_bits(True),
+        np.array(
+            [
+                (0b11010, 0b00100),
+                (0b11100, 0b00010),
+                (0b11110, 0b00000),
+                (0b00000, 0b11110),
+                (0b00010, 0b11100),
+                (0b00100, 0b11010),
+            ]
+        ),
+    )
+
+
+@pytest.mark.parametrize(
+    "bits",
+    [8, 16, 32, 64],
+)
+def test_to_bits_np_sizes(bits: int):
+    np = pytest.importorskip("numpy")
+    dtype_map = {
+        8: np.uint8,
+        16: np.uint16,
+        32: np.uint32,
+        64: np.uint64,
+    }
+    dtype = dtype_map[bits]
+    a = APyCFixedArray([(2**bits - 7, 2 ** (bits - 1) + 9)], bits, 0).to_bits(True)
+    expected = np.asarray([(2**bits - 7, 2 ** (bits - 1) + 9)], dtype=dtype)
+    assert np.array_equal(a, expected)
+    assert a.dtype == dtype
+
+
+def test_to_bits_np_raise():
+    _ = pytest.importorskip("numpy")
+    with pytest.raises(
+        ValueError,
+        match=r"APyCFixedArray::to_bits_ndarray\(\): only supports",
+    ):
+        APyCFixedArray([0], 30, 60).to_bits(True)

--- a/lib/test/apycfloatarray/test_methods.py
+++ b/lib/test/apycfloatarray/test_methods.py
@@ -1,4 +1,120 @@
+import pytest
+
 from apytypes import APyCFloatArray, APyFloatArray, QuantizationMode
+
+
+@pytest.mark.float_array
+def test_from_bits():
+    # Test raises
+    with pytest.raises(
+        ValueError,
+        match=r"APyCFloatArray\.from_bits: exponent bits must be a non-negative integer less or equal to .. but 300 was given",
+    ):
+        APyCFloatArray.from_bits([0], 300, 5)
+
+    with pytest.raises(
+        ValueError, match=r"APyCFloatArray\.from_bits: unexpected type when traversing"
+    ):
+        APyCFloatArray.from_bits(["0"], 5, 10)
+
+    # Only reals
+    a = APyCFloatArray.from_bits([108, 112, 120, 4224], exp_bits=8, man_bits=4, bias=6)
+    assert a.is_identical(
+        APyCFloatArray(
+            [(0, 0), (0, 0), (0, 0), (1, 0)],
+            [(6, 0), (7, 0), (7, 0), (8, 0)],
+            [(12, 0), (0, 0), (8, 0), (0, 0)],
+            exp_bits=8,
+            man_bits=4,
+            bias=6,
+        )
+    )
+
+    # Complex as well
+    a = APyCFloatArray.from_bits([[108, 112], [120, 4224]], 8, 4)
+    assert a.is_identical(
+        APyCFloatArray(
+            [(0, 0), (0, 1)],
+            [(6, 7), (7, 8)],
+            [(12, 0), (8, 0)],
+            exp_bits=8,
+            man_bits=4,
+        )
+    )
+
+
+@pytest.mark.float_array
+def test_from_bits_np():
+    # Skip this test if `NumPy` is not present on the machine
+    np = pytest.importorskip("numpy")
+    # Only reals
+    a = APyCFloatArray.from_bits(
+        np.asarray([108, 112, 120, 4224]), exp_bits=8, man_bits=4, bias=6
+    )
+    assert a.is_identical(
+        APyCFloatArray(
+            [(0, 0), (0, 0), (0, 0), (1, 0)],
+            [(6, 0), (7, 0), (7, 0), (8, 0)],
+            [(12, 0), (0, 0), (8, 0), (0, 0)],
+            exp_bits=8,
+            man_bits=4,
+            bias=6,
+        )
+    )
+
+    # Complex as well
+    a = APyCFloatArray.from_bits(
+        np.asarray([[108, 112], [120, 4224]]), exp_bits=8, man_bits=4
+    )
+    assert a.is_identical(
+        APyCFloatArray(
+            [(0, 0), (0, 1)],
+            [(6, 7), (7, 8)],
+            [(12, 0), (8, 0)],
+            exp_bits=8,
+            man_bits=4,
+        )
+    )
+
+
+@pytest.mark.float_array
+def test_to_bits():
+    a = APyCFloatArray(
+        [(0, 0), (0, 0), (0, 0), (1, 0)],
+        [(6, 0), (7, 0), (7, 0), (8, 0)],
+        [(12, 0), (0, 0), (8, 0), (0, 0)],
+        exp_bits=8,
+        man_bits=4,
+        bias=6,
+    )
+    assert a.to_bits() == [(108, 0), (112, 0), (120, 0), (4224, 0)]
+
+    a = APyCFloatArray(
+        [(0, 0), (0, 1)], [(6, 7), (7, 8)], [(12, 0), (8, 0)], exp_bits=8, man_bits=4
+    )
+    assert a.to_bits() == [(108, 112), (120, 4224)]
+
+
+@pytest.mark.float_array
+def test_to_bits_np():
+    np = pytest.importorskip("numpy")
+
+    a = APyCFloatArray(
+        [(0, 0), (0, 0), (0, 0), (1, 0)],
+        [(6, 0), (7, 0), (7, 0), (8, 0)],
+        [(12, 0), (0, 0), (8, 0), (0, 0)],
+        exp_bits=8,
+        man_bits=4,
+        bias=6,
+    )
+    assert np.array_equal(
+        a.to_bits(True), np.asarray([[108, 0], [112, 0], [120, 0], [4224, 0]])
+    )
+
+    a = APyCFloatArray(
+        [(0, 0), (0, 1)], [(6, 7), (7, 8)], [(12, 0), (8, 0)], exp_bits=8, man_bits=4
+    )
+    assert np.array_equal(a.to_bits(True), np.asarray([(108, 112), (120, 4224)]))
 
 
 def test_real_imag():

--- a/lib/test/apycfloatarray/test_methods.py
+++ b/lib/test/apycfloatarray/test_methods.py
@@ -47,6 +47,13 @@ def test_from_bits():
 def test_from_bits_np():
     # Skip this test if `NumPy` is not present on the machine
     np = pytest.importorskip("numpy")
+
+    with pytest.raises(
+        TypeError,
+        match=r"APyCFloatArray::_set_bits_from_ndarray\(\): unsupported `dtype` expecting integer",
+    ):
+        APyCFloatArray.from_bits(np.asarray([1.0]), 8, 7)
+
     # Only reals
     a = APyCFloatArray.from_bits(
         np.asarray([108, 112, 120, 4224]), exp_bits=8, man_bits=4, bias=6
@@ -94,6 +101,15 @@ def test_to_bits():
     )
     assert a.to_bits() == [(108, 112), (120, 4224)]
 
+    a = APyCFloatArray(
+        [(0, 0), (0, 1), (0, 0), (0, 1)],
+        [(6, 7), (7, 8), (6, 7), (7, 8)],
+        [(12, 0), (8, 0), (12, 0), (8, 0)],
+        exp_bits=8,
+        man_bits=4,
+    ).reshape((2, 1, 2))
+    assert a.to_bits() == [[[(108, 112), (120, 4224)]], [[(108, 112), (120, 4224)]]]
+
 
 @pytest.mark.float_array
 def test_to_bits_np():
@@ -115,6 +131,51 @@ def test_to_bits_np():
         [(0, 0), (0, 1)], [(6, 7), (7, 8)], [(12, 0), (8, 0)], exp_bits=8, man_bits=4
     )
     assert np.array_equal(a.to_bits(True), np.asarray([(108, 112), (120, 4224)]))
+
+    a = APyCFloatArray(
+        [(0, 0), (0, 1), (0, 0), (0, 1)],
+        [(6, 7), (7, 8), (6, 7), (7, 8)],
+        [(12, 0), (8, 0), (12, 0), (8, 0)],
+        exp_bits=8,
+        man_bits=4,
+    ).reshape((2, 1, 2))
+    assert np.array_equal(
+        a.to_bits(True),
+        np.asarray([[[(108, 112), (120, 4224)]], [[(108, 112), (120, 4224)]]]),
+    )
+
+    # Test with 8, 16, 32, and 64 bit
+    a = APyCFloatArray([(0, 1)], [(2, 3)], [(4, 5)], exp_bits=3, man_bits=4).to_bits(
+        True
+    )
+    assert np.array_equal(a, np.asarray([(36, 181)], dtype=np.uint8))
+    assert a.dtype == np.uint8
+
+    a = APyCFloatArray([(0, 1)], [(2, 3)], [(4, 5)], exp_bits=7, man_bits=8).to_bits(
+        True
+    )
+    assert np.array_equal(a, np.asarray([(516, 33541)], dtype=np.uint16))
+    assert a.dtype == np.uint16
+
+    a = APyCFloatArray([(0, 1)], [(2, 3)], [(4, 5)], exp_bits=8, man_bits=23).to_bits(
+        True
+    )
+    assert np.array_equal(a, np.asarray([(16777220, 2172649477)], dtype=np.uint32))
+    assert a.dtype == np.uint32
+
+    a = APyCFloatArray([(0, 1)], [(2, 3)], [(4, 5)], exp_bits=11, man_bits=52).to_bits(
+        True
+    )
+    assert np.array_equal(
+        a, np.asarray([(9007199254740996, 9236882835736887301)], dtype=np.uint64)
+    )
+    assert a.dtype == np.uint64
+
+    with pytest.raises(
+        ValueError,
+        match=r"APyCFloatArray::to_bits_ndarray\(\): only supports",
+    ):
+        APyCFloatArray([0], [0], [0], 30, 60).to_bits(True)
 
 
 def test_real_imag():

--- a/lib/test/apyfixedarray/test_methods.py
+++ b/lib/test/apyfixedarray/test_methods.py
@@ -1252,6 +1252,17 @@ def test_to_bits_numpy():
         == np.array([[[2, 4], [6, 8], [10, 12]], [[14, 16], [18, 16], [14, 12]]])
     )
 
+    # Exporting 64-bit values. This will trigger a special case on 32-bit systems.
+    assert np.array_equal(
+        APyFixedArray([(1, 1)], int_bits=63, frac_bits=0).to_bits(True),
+        np.asarray([(1, 1)]),
+    )
+    # Similar case, but with bits being exactly 64.
+    assert np.array_equal(
+        APyFixedArray([(1, 1)], int_bits=64, frac_bits=0).to_bits(True),
+        np.asarray([(1, 1)]),
+    )
+
 
 def test_copy():
     a = APyFixedArray([3, 1], 4, 5)

--- a/src/apycfixedarray.cc
+++ b/src/apycfixedarray.cc
@@ -2386,6 +2386,148 @@ nb::ndarray<nb::numpy, std::complex<double>> APyCFixedArray::to_numpy(
     );
 }
 
+std::variant<
+    nb::list,
+    nb::ndarray<nb::numpy, std::uint64_t>,
+    nb::ndarray<nb::numpy, std::uint32_t>,
+    nb::ndarray<nb::numpy, std::uint16_t>,
+    nb::ndarray<nb::numpy, std::uint8_t>>
+APyCFixedArray::to_bits(bool numpy) const
+{
+    using RESULT_TYPE = std::variant<
+        nb::list,
+        nb::ndarray<nb::numpy, std::uint64_t>,
+        nb::ndarray<nb::numpy, std::uint32_t>,
+        nb::ndarray<nb::numpy, std::uint16_t>,
+        nb::ndarray<nb::numpy, std::uint8_t>>;
+
+    if (numpy) {
+        if (_bits <= 8) {
+            return RESULT_TYPE(
+                std::in_place_type<nb::ndarray<nb::numpy, std::uint8_t>>,
+                to_bits_ndarray<nb::numpy, std::uint8_t>()
+            );
+        } else if (_bits <= 16) {
+            return RESULT_TYPE(
+                std::in_place_type<nb::ndarray<nb::numpy, std::uint16_t>>,
+                to_bits_ndarray<nb::numpy, std::uint16_t>()
+            );
+        } else if (_bits <= 32) {
+            return RESULT_TYPE(
+                std::in_place_type<nb::ndarray<nb::numpy, std::uint32_t>>,
+                to_bits_ndarray<nb::numpy, std::uint32_t>()
+            );
+        } else {
+            return RESULT_TYPE(
+                std::in_place_type<nb::ndarray<nb::numpy, std::uint64_t>>,
+                to_bits_ndarray<nb::numpy, std::uint64_t>()
+            );
+        }
+    } else {
+        auto it = std::cbegin(_data);
+        return RESULT_TYPE(
+            std::in_place_type<nb::list>, to_bits_python_recursive_descent(0, it)
+        );
+    }
+}
+
+template <typename NB_ARRAY_TYPE, typename INT_TYPE>
+nb::ndarray<NB_ARRAY_TYPE, INT_TYPE> APyCFixedArray::to_bits_ndarray() const
+{
+    constexpr std::size_t INT_TYPE_SIZE_BITS = 8 * sizeof(INT_TYPE);
+    if (_bits > int(INT_TYPE_SIZE_BITS)) {
+        throw nb::value_error(
+            fmt::format(
+                "APyCFixedArray::to_bits_ndarray(): only supports <= {}-bit elements",
+                INT_TYPE_SIZE_BITS
+            )
+                .c_str()
+        );
+    }
+
+    INT_TYPE* result_data = new INT_TYPE[2 * _nitems]; // 2x for real and complex parts
+    const INT_TYPE MASK = (INT_TYPE(1) << (bits() % INT_TYPE_SIZE_BITS)) - 1;
+    if (_itemsize == 2) {
+        // Real and complex parts fit into one limb each
+        if (_bits % (INT_TYPE_SIZE_BITS)) {
+            for (std::size_t i = 0; i < _data.size(); i++) {
+                result_data[i] = INT_TYPE(_data[i]) & MASK;
+            }
+        } else {
+            for (std::size_t i = 0; i < _data.size(); i++) {
+                result_data[i] = INT_TYPE(_data[i]);
+            }
+        }
+    } else {                                  // _itemsize > 2
+        const auto part_size = _itemsize / 2; // Size of a real/imag part
+
+        if (_bits % (INT_TYPE_SIZE_BITS)) {
+            for (std::size_t i = 0; i < 2 * _nitems; i++) {
+                INT_TYPE value {};
+
+                // Endian-safe copy
+                for (std::size_t j = 0; j < part_size; j++) {
+                    const std::size_t shift = j * APY_LIMB_SIZE_BITS;
+                    value |= INT_TYPE(_data[i * part_size + j]) << shift;
+                }
+
+                result_data[i] = value & MASK;
+            }
+        } else {
+            for (std::size_t i = 0; i < 2 * _nitems; i++) {
+                INT_TYPE value {};
+                // Endian-safe copy
+                for (std::size_t j = 0; j < part_size; j++) {
+                    const std::size_t shift = j * APY_LIMB_SIZE_BITS;
+                    value |= INT_TYPE(_data[i * part_size + j]) << shift;
+                }
+                result_data[i] = value;
+            }
+        }
+    }
+
+    // Delete `result_data` when the `owner` capsule expires
+    nb::capsule owner(result_data, [](void* p) noexcept { delete[] (INT_TYPE*)p; });
+
+    std::vector<size_t> result_shape(_shape.begin(), _shape.end());
+    result_shape.push_back(2); // Split real and imaginary bit patterns
+
+    return nb::ndarray<NB_ARRAY_TYPE, INT_TYPE>(
+        result_data, ndim() + 1, result_shape.data(), owner
+    );
+}
+
+nb::list APyCFixedArray::to_bits_python_recursive_descent(
+    std::size_t dim, std::vector<apy_limb_t>::const_iterator& it
+) const
+{
+    nb::list result;
+    if (dim == ndim() - 1) {
+        // Most inner dimension: append data
+        for (std::size_t i = 0; i < _shape[dim]; i++) {
+            const auto complex_data = nb::make_tuple(
+                python_limb_vec_to_long(
+                    it, it + _itemsize / 2, false, _bits % APY_LIMB_SIZE_BITS
+                ),
+                python_limb_vec_to_long(
+                    it + _itemsize / 2,
+                    it + _itemsize,
+                    false,
+                    _bits % APY_LIMB_SIZE_BITS
+                )
+            );
+            result.append(complex_data);
+            it += _itemsize;
+        }
+    } else {
+        // We need to go deeper...
+        for (std::size_t i = 0; i < _shape[dim]; i++) {
+            result.append(to_bits_python_recursive_descent(dim + 1, it));
+        }
+    }
+    return result;
+}
+
 APyCFixedArray APyCFixedArray::cast(
     std::optional<int> int_bits,
     std::optional<int> frac_bits,
@@ -2843,6 +2985,16 @@ APyCFixedArray APyCFixedArray::from_array(
     APyCFixedArray result(shape, int_bits, frac_bits, bits);
     result._set_values_from_ndarray(ndarray);
     return result;
+}
+
+APyCFixedArray APyCFixedArray::from_bits(
+    const nb::typed<nb::iterable, nb::any>& bit_pattern_sequence,
+    std::optional<int> int_bits,
+    std::optional<int> frac_bits,
+    std::optional<int> bits
+)
+{
+    return APyCFixedArray(bit_pattern_sequence, int_bits, frac_bits, bits);
 }
 
 std::string APyCFixedArray::to_string_dec() const

--- a/src/apycfixedarray.h
+++ b/src/apycfixedarray.h
@@ -244,6 +244,15 @@ public:
         std::optional<bool> copy = std::nullopt
     ) const;
 
+    //! Extract bit-pattern
+    std::variant<
+        nb::list,
+        nb::ndarray<nb::numpy, uint64_t>,
+        nb::ndarray<nb::numpy, uint32_t>,
+        nb::ndarray<nb::numpy, uint16_t>,
+        nb::ndarray<nb::numpy, uint8_t>>
+    to_bits(bool numpy = false) const;
+
     //! Sum over one or more axes.
     std::variant<APyCFixedArray, APyCFixed>
     sum(const std::optional<PyShapeParam_t>& axis = std::nullopt) const;
@@ -323,6 +332,15 @@ public:
     //! Create an `APyCFixedArray` tensor object initialized with values from an ndarray
     static APyCFixedArray from_array(
         const nb::ndarray<nb::c_contig>& ndarray,
+        std::optional<int> int_bits = std::nullopt,
+        std::optional<int> frac_bits = std::nullopt,
+        std::optional<int> bits = std::nullopt
+    );
+
+    //! Create an `APyCFixedArray` tensor object initialized with values from bit
+    //! patterns
+    static APyCFixedArray from_bits(
+        const nb::typed<nb::iterable, nb::any>& bit_pattern_sequence,
         std::optional<int> int_bits = std::nullopt,
         std::optional<int> frac_bits = std::nullopt,
         std::optional<int> bits = std::nullopt
@@ -415,6 +433,15 @@ private:
      * before being copied into `*this`.
      */
     void _set_values_from_ndarray(const nb::ndarray<nb::c_contig>& ndarray);
+
+    //! Create an N-dimensional array containing bit-patterns.
+    template <typename NB_ARRAY_TYPE, typename INT_TYPE>
+    nb::ndarray<NB_ARRAY_TYPE, INT_TYPE> to_bits_ndarray() const;
+
+    //! Create a nested Python list containing bit-patterns as Python integers.
+    nb::list to_bits_python_recursive_descent(
+        std::size_t dim, std::vector<apy_limb_t>::const_iterator& it
+    ) const;
 };
 
 #endif

--- a/src/apycfixedarray_wrapper.cc
+++ b/src/apycfixedarray_wrapper.cc
@@ -429,22 +429,22 @@ void bind_cfixed_array(nb::module_& m)
             )pbdoc"
         )
 
-        //.def(
-        //    "to_bits",
-        //    &APyCFixedArray::to_bits,
-        //    nb::arg("numpy") = false,
-        //    R"pbdoc(
-        //    Return the underlying bit representations.
+        .def(
+            "to_bits",
+            &APyCFixedArray::to_bits,
+            nb::arg("numpy") = false,
+            R"pbdoc(
+            Return the underlying bit representations.
 
-        //    When `numpy` is true, the bit representations are returned in a
-        //    :class:`numpy.ndarray`. Otherwise, they are returned in a
-        //    :class:`list`.
+            When `numpy` is true, the bit representations are returned in a
+            :class:`numpy.ndarray`. Otherwise, they are returned in a
+            :class:`list`.
 
-        //    Returns
-        //    -------
-        //    :class:`list` or :class:`numpy.ndarray`
-        //    )pbdoc"
-        //)
+            Returns
+            -------
+            :class:`list` or :class:`numpy.ndarray`
+            )pbdoc"
+        )
 
         .def("reshape", &APyCFixedArray::python_reshape, nb::arg("new_shape"), R"pbdoc(
             Reshape the APyCFixedArray to the specified shape without changing its data.
@@ -1238,6 +1238,32 @@ void bind_cfixed_array(nb::module_& m)
             >>> print(a)
             [[1+0j, 2+0j, 3+0j],
              [4+0j, 5+0j, 6+0j]]
+
+            Returns
+            -------
+            :class:`APyCFixedArray`
+            )pbdoc"
+        )
+        .def_static(
+            "from_bits",
+            &APyCFixedArray::from_bits,
+            nb::arg("bit_pattern_sequence"),
+            nb::arg("int_bits") = nb::none(),
+            nb::arg("frac_bits") = nb::none(),
+            nb::arg("bits") = nb::none(),
+            R"pbdoc(
+            Create an :class:`APyCFixedArray` object from a sequence of bit patterns.
+
+            Parameters
+            ----------
+            bit_pattern_sequence : list
+                Bit patterns to initialize from.
+            int_bits : :class:`int`, optional
+                Number of integer bits in the created fixed-point tensor.
+            frac_bits : :class:`int`, optional
+                Number of fractional bits in the created fixed-point tensor.
+            bits : :class:`int`, optional
+                Total number of bits in the created fixed-point tensor.
 
             Returns
             -------

--- a/src/apycfloat.cc
+++ b/src/apycfloat.cc
@@ -763,8 +763,8 @@ std::complex<double> APyCFloat::to_complex() const
 nb::tuple APyCFloat::to_bits() const
 {
     return nb::make_tuple(
-        APyFloat(real(), exp_bits, man_bits, bias).to_bits(),
-        APyFloat(imag(), exp_bits, man_bits, bias).to_bits()
+        apyfloat_to_bits(real(), exp_bits, man_bits),
+        apyfloat_to_bits(imag(), exp_bits, man_bits)
     );
 }
 

--- a/src/apycfloatarray.cc
+++ b/src/apycfloatarray.cc
@@ -478,6 +478,134 @@ void APyCFloatArray::_set_man_bits_from_ndarray(const nb::ndarray<nb::c_contig>&
     );
 }
 
+APyCFloatArray APyCFloatArray::from_bits(
+    const nb::typed<nb::iterable, nb::any>& seq,
+    int exp_bits,
+    int man_bits,
+    std::optional<exp_t> bias
+)
+{
+    check_exponent_format(exp_bits, "APyCFloatArray.from_bits");
+    check_mantissa_format(man_bits, "APyCFloatArray.from_bits");
+
+    if (nb::isinstance<nb::ndarray<>>(seq)) {
+        const auto ndarray = nb::cast<nb::ndarray<nb::c_contig>>(seq);
+
+        assert(ndarray.ndim() > 0);
+        std::vector<std::size_t> shape(ndarray.ndim(), 0);
+        for (std::size_t i = 0; i < ndarray.ndim(); i++) {
+            shape[i] = ndarray.shape(i);
+        }
+
+        bool is_inner_dim_complex = false;
+        if (shape[ndarray.ndim() - 1] == 2) {
+            is_inner_dim_complex = true;
+            shape.pop_back();
+        }
+
+        APyCFloatArray result(shape, exp_bits, man_bits, bias);
+
+        result._set_bits_from_ndarray(ndarray, is_inner_dim_complex);
+        return result;
+    }
+
+    APyCFloatArray result(
+        python_iterable_extract_shape</* IS_COMPLEX_COLLAPSE = */ true>(
+            seq, "APyCFloatArray.from_bits"
+        ),
+        exp_bits,
+        man_bits,
+        bias
+    );
+
+    // 1D vector of Python int objects (`nb::int_` objects)
+    auto python_objs = python_iterable_walk<nb::int_>(seq, "APyCFloatArray.from_bits");
+
+    // If the walked sequence of Python integers is
+    assert(
+        python_objs.size() == result._nitems || python_objs.size() == 2 * result._nitems
+    );
+    bool is_inner_dim_complex = (python_objs.size() == 2 * result._nitems);
+
+    APyFloat f(exp_bits, man_bits, result.bias);
+    if (is_inner_dim_complex) {
+        for (std::size_t i = 0; i < 2 * result._nitems; i++) {
+            if (nb::isinstance<nb::int_>(python_objs[i])) {
+                result._data[i]
+                    = f.update_from_bits(nb::cast<nb::int_>(python_objs[i])).get_data();
+            } else {
+                throw std::domain_error("Invalid Python objects in sequence");
+            }
+        }
+    } else {
+        for (std::size_t i = 0; i < result._nitems; i++) {
+            if (nb::isinstance<nb::int_>(python_objs[i])) {
+                result._data[2 * i]
+                    = f.update_from_bits(nb::cast<nb::int_>(python_objs[i])).get_data();
+            } else {
+                throw std::domain_error("Invalid Python objects in sequence");
+            }
+        }
+    }
+    return result;
+}
+
+void APyCFloatArray::_set_bits_from_ndarray(
+    const nb::ndarray<nb::c_contig>& ndarray, bool is_inner_dim_complex
+)
+{
+    // Double value used for converting.
+    APyFloat f(exp_bits, man_bits, bias);
+
+#define CHECK_AND_SET_BITS_FROM_NPTYPE(__TYPE__)                                       \
+    do {                                                                               \
+        if (ndarray.dtype() == nb::dtype<__TYPE__>()) {                                \
+            const auto ndarray_view = ndarray.view<__TYPE__, nb::ndim<1>>();           \
+            if (is_inner_dim_complex) {                                                \
+                for (std::size_t i = 0; i < ndarray.size(); i++) {                     \
+                    const auto bits                                                    \
+                        = static_cast<std::uint64_t>(ndarray_view.data()[i]);          \
+                    f.update_from_bits(bits);                                          \
+                    _data[i] = f.get_data();                                           \
+                }                                                                      \
+            } else {                                                                   \
+                for (std::size_t i = 0; i < ndarray.size(); i++) {                     \
+                    const auto bits                                                    \
+                        = static_cast<std::uint64_t>(ndarray_view.data()[i]);          \
+                    f.update_from_bits(bits);                                          \
+                    _data[2 * i] = f.get_data();                                       \
+                    _data[2 * i + 1] = { 0, 0, 0 };                                    \
+                }                                                                      \
+            }                                                                          \
+            return; /* Conversion completed, exit function */                          \
+        }                                                                              \
+    } while (0)
+
+    // Each `CHECK_AND_SET_BITS_FROM_NPTYPE` checks the dtype of `ndarray` and
+    // converts all the data if it matches. If successful,
+    // `CHECK_AND_SET_BITS_FROM_NPTYPES` returns. Otherwise, the next attempted
+    // conversion will take place
+    CHECK_AND_SET_BITS_FROM_NPTYPE(std::int64_t);
+    CHECK_AND_SET_BITS_FROM_NPTYPE(std::int32_t);
+    CHECK_AND_SET_BITS_FROM_NPTYPE(std::int16_t);
+    CHECK_AND_SET_BITS_FROM_NPTYPE(std::int8_t);
+    CHECK_AND_SET_BITS_FROM_NPTYPE(std::uint64_t);
+    CHECK_AND_SET_BITS_FROM_NPTYPE(std::uint32_t);
+    CHECK_AND_SET_BITS_FROM_NPTYPE(std::uint16_t);
+    CHECK_AND_SET_BITS_FROM_NPTYPE(std::uint8_t);
+
+#undef CHECK_AND_SET_BITS_FROM_NPTYPE
+
+    // None of the `CHECK_AND_VALUES_FROM_NPTYPE` succeeded. Unsupported type, throw
+    // an error. If possible, it would be nice to show a string representation of
+    // the `dtype`. Seems hard to achieve with nanobind, but please fix this if you
+    // find out how this can be achieved.
+    throw nb::type_error(
+        "APyCFloatArray::_set_bits_from_ndarray(): "
+        "unsupported `dtype` expecting integer"
+    );
+}
+
 template <typename DTYPE>
 bool APyCFloatArray::_check_and_set_sign_bits_from_ndarray(
     const nb::ndarray<nb::c_contig>& ndarray_sign
@@ -562,6 +690,105 @@ std::string APyCFloatArray::repr() const
     }
 
     return array_repr(formatters, kw_args);
+}
+
+std::variant<
+    nb::list,
+    nb::ndarray<nb::numpy, std::uint64_t>,
+    nb::ndarray<nb::numpy, std::uint32_t>,
+    nb::ndarray<nb::numpy, std::uint16_t>,
+    nb::ndarray<nb::numpy, std::uint8_t>>
+APyCFloatArray::to_bits(bool numpy) const
+{
+    using RESULT_TYPE = std::variant<
+        nb::list,
+        nb::ndarray<nb::numpy, std::uint64_t>,
+        nb::ndarray<nb::numpy, std::uint32_t>,
+        nb::ndarray<nb::numpy, std::uint16_t>,
+        nb::ndarray<nb::numpy, std::uint8_t>>;
+
+    if (numpy) {
+        if (get_bits() <= 8) {
+            return RESULT_TYPE(
+                std::in_place_type<nb::ndarray<nb::numpy, std::uint8_t>>,
+                to_bits_ndarray<nb::numpy, std::uint8_t>()
+            );
+        } else if (get_bits() <= 16) {
+            return RESULT_TYPE(
+                std::in_place_type<nb::ndarray<nb::numpy, std::uint16_t>>,
+                to_bits_ndarray<nb::numpy, std::uint16_t>()
+            );
+        } else if (get_bits() <= 32) {
+            return RESULT_TYPE(
+                std::in_place_type<nb::ndarray<nb::numpy, std::uint32_t>>,
+                to_bits_ndarray<nb::numpy, std::uint32_t>()
+            );
+        } else {
+            return RESULT_TYPE(
+                std::in_place_type<nb::ndarray<nb::numpy, std::uint64_t>>,
+                to_bits_ndarray<nb::numpy, std::uint64_t>()
+            );
+        }
+    } else {
+        auto it = std::cbegin(_data);
+        return RESULT_TYPE(
+            std::in_place_type<nb::list>, to_bits_python_recursive_descent(0, it)
+        );
+    }
+}
+
+template <typename NB_ARRAY_TYPE, typename INT_TYPE>
+nb::ndarray<NB_ARRAY_TYPE, INT_TYPE> APyCFloatArray::to_bits_ndarray() const
+{
+    constexpr std::size_t INT_TYPE_SIZE_BITS = 8 * sizeof(INT_TYPE);
+    if (get_bits() > int(INT_TYPE_SIZE_BITS)) {
+        throw nb::value_error(
+            fmt::format(
+                "APyCFloatArray::to_bits_ndarray(): only supports <= {}-bit elements",
+                INT_TYPE_SIZE_BITS
+            )
+                .c_str()
+        );
+    }
+
+    INT_TYPE* result_data = new INT_TYPE[_data.size()];
+    for (std::size_t i = 0; i < _data.size(); i++) {
+        result_data[i] = to_bits_uint64(_data[i], exp_bits, man_bits);
+    }
+
+    // Delete `result_data` when the `owner` capsule expires
+    nb::capsule owner(result_data, [](void* p) noexcept { delete[] (INT_TYPE*)p; });
+
+    std::vector<size_t> result_shape(_shape.begin(), _shape.end());
+    result_shape.push_back(2); // Split real and imaginary bit patterns
+
+    return nb::ndarray<NB_ARRAY_TYPE, INT_TYPE>(
+        result_data, ndim() + 1, result_shape.data(), owner
+    );
+}
+
+nb::list APyCFloatArray::to_bits_python_recursive_descent(
+    std::size_t dim, std::vector<APyFloatData>::const_iterator& it
+) const
+{
+    nb::list result;
+    if (dim == ndim() - 1) {
+        // Most inner dimension: append data
+        for (std::size_t i = 0; i < _shape[dim]; i++) {
+            const auto complex_data = nb::make_tuple(
+                apyfloat_to_bits(*it, exp_bits, man_bits),
+                apyfloat_to_bits(*(it + 1), exp_bits, man_bits)
+            );
+            result.append(complex_data);
+            it += 2;
+        }
+    } else {
+        // We need to go deeper...
+        for (std::size_t i = 0; i < _shape[dim]; i++) {
+            result.append(to_bits_python_recursive_descent(dim + 1, it));
+        }
+    }
+    return result;
 }
 
 std::string APyCFloatArray::to_string_dec() const

--- a/src/apycfloatarray.h
+++ b/src/apycfloatarray.h
@@ -201,6 +201,24 @@ public:
     std::string to_string(int base = 10) const;
     std::string to_string_dec() const;
 
+    //! Extract bit-pattern
+    std::variant<
+        nb::list,
+        nb::ndarray<nb::numpy, uint64_t>,
+        nb::ndarray<nb::numpy, uint32_t>,
+        nb::ndarray<nb::numpy, uint16_t>,
+        nb::ndarray<nb::numpy, uint8_t>>
+    to_bits(bool numpy = false) const;
+
+    //! Create an N-dimensional array containing bit-patterns.
+    template <typename NB_ARRAY_TYPE, typename INT_TYPE>
+    nb::ndarray<NB_ARRAY_TYPE, INT_TYPE> to_bits_ndarray() const;
+
+    //! Create a nested Python list containing bit-patterns as Python integers.
+    nb::list to_bits_python_recursive_descent(
+        std::size_t dim, std::vector<APyFloatData>::const_iterator& it
+    ) const;
+
     //! Convert to a NumPy array
     nanobind::ndarray<nanobind::numpy, std::complex<double>> to_numpy(
         std::optional<nb::object> dtype = std::nullopt,
@@ -317,9 +335,22 @@ public:
         std::optional<exp_t> bias = std::nullopt
     );
 
+    //! Create an `APyCFloatArray` tensor object initialized from bit-representation
+    static APyCFloatArray from_bits(
+        const nb::typed<nb::iterable, nb::any>& seq,
+        int exp_bits,
+        int man_bits,
+        std::optional<exp_t> bias
+    );
+
 private:
     //! Set data fields based on an ndarray of doubles
     void _set_values_from_ndarray(const nanobind::ndarray<nanobind::c_contig>& ndarray);
+
+    //! Set data fields based on an ndarray of doubles
+    void _set_bits_from_ndarray(
+        const nanobind::ndarray<nanobind::c_contig>& ndarray, bool is_inner_dim_complex
+    );
 
     //! Set `sign` bits from ndarray
     void _set_sign_bits_from_ndarray(const nb::ndarray<nb::c_contig>& array);

--- a/src/apycfloatarray_wrapper.cc
+++ b/src/apycfloatarray_wrapper.cc
@@ -512,6 +512,52 @@ void bind_cfloat_array(nb::module_& m)
 
             )pbdoc"
         )
+        .def_static(
+            "from_bits",
+            &APyCFloatArray::from_bits,
+            nb::arg("bits"),
+            nb::arg("exp_bits"),
+            nb::arg("man_bits"),
+            nb::arg("bias") = nb::none(),
+            R"pbdoc(
+            Create an :class:`APyCFloatArray` object from bit-representations.
+
+            Parameters
+            ----------
+            bits : :class:`int`
+                The bit-representations.
+            exp_bits : :class:`int`
+                Number of exponent bits in the created floating-point tensor
+            man_bits : :class:`int`
+                Number of mantissa bits in the created floating-point tensor
+            bias : :class:`int`, optional
+                Exponent bias. If not provided, *bias* is ``2**exp_bits - 1``.
+
+            Examples
+            --------
+
+            >>> import apytypes as apy
+            >>> a = apy.APyCFloatArray.from_bits(
+            ...     [[60, 61], [80, 82]],
+            ...     exp_bits=5,
+            ...     man_bits=2
+            ... )
+            >>> a
+            APyCFloatArray(
+                [  (0, 0),   (0, 0)],
+                [(15, 15), (20, 20)],
+                [  (0, 1),   (0, 2)],
+                exp_bits=5,
+                man_bits=2
+            )
+            >>> print(a)
+            [1+1.25j,  32+48j]
+
+            Returns
+            -------
+            :class:`APyCFloatArray`
+            )pbdoc"
+        )
 
         /*
          * Public methods
@@ -988,6 +1034,22 @@ void bind_cfloat_array(nb::module_& m)
             Returns
             -------
             :class:`numpy.ndarray`
+            )pbdoc"
+        )
+
+        .def(
+            "to_bits",
+            &APyCFloatArray::to_bits,
+            nb::arg("numpy") = false,
+            R"pbdoc(
+            Return the underlying bit representations.
+
+            When `numpy` is true, the bit representations are returned in a
+            :class:`numpy.ndarray`. Otherwise, they are returned in a :class:`list`.
+
+            Returns
+            -------
+            :class:`list` or :class:`numpy.ndarray`
             )pbdoc"
         )
 

--- a/src/apyfixedarray.cc
+++ b/src/apyfixedarray.cc
@@ -2022,10 +2022,40 @@ nb::ndarray<NB_ARRAY_TYPE, INT_TYPE> APyFixedArray::to_bits_ndarray() const
     }
 
     INT_TYPE* result_data = new INT_TYPE[_nitems];
-    for (std::size_t i = 0; i < _nitems; i++) {
-        result_data[i] = INT_TYPE(_data[i]);
-        if (bits() % (INT_TYPE_SIZE_BITS)) {
-            result_data[i] &= (INT_TYPE(1) << (bits() % INT_TYPE_SIZE_BITS)) - 1;
+    const INT_TYPE MASK = (INT_TYPE(1) << (_bits % INT_TYPE_SIZE_BITS)) - 1;
+    if (_itemsize == 1) {
+        if (_bits % (INT_TYPE_SIZE_BITS)) {
+            for (std::size_t i = 0; i < _nitems; i++) {
+                result_data[i] = INT_TYPE(_data[i]) & MASK;
+            }
+        } else {
+            for (std::size_t i = 0; i < _nitems; i++) {
+                result_data[i] = INT_TYPE(_data[i]);
+            }
+        }
+    } else {
+        if (_bits % (INT_TYPE_SIZE_BITS)) {
+            for (std::size_t i = 0; i < _nitems; i++) {
+                INT_TYPE value {};
+
+                // Endian-safe copy
+                for (std::size_t j = 0; j < _itemsize; j++) {
+                    const std::size_t shift = j * APY_LIMB_SIZE_BITS;
+                    value |= INT_TYPE(_data[i * _itemsize + j]) << shift;
+                }
+
+                result_data[i] = value & MASK;
+            }
+        } else {
+            for (std::size_t i = 0; i < _nitems; i++) {
+                INT_TYPE value {};
+                // Endian-safe copy
+                for (std::size_t j = 0; j < _itemsize; j++) {
+                    const std::size_t shift = j * APY_LIMB_SIZE_BITS;
+                    value |= INT_TYPE(_data[i * _itemsize + j]) << shift;
+                }
+                result_data[i] = value;
+            }
         }
     }
 


### PR DESCRIPTION
<!--
Thank you so much for your PR!
-->

# PR Summary
<!-- Please provide at least 1-2 sentences describing the pull request in detail
(Why is this change required?  What problem does it solve?) and link to relevant
issues and PRs.
-->
Related to #686.

Also fixing a bug where `APyFixedArray.to_bits` didn't work correctly on 32-bit systems when outputting 64-bit NumPy arrays:
```Python
APyFixedArray([(1, 1)], int_bits=63, frac_bits=0).to_bits(True) # Becomes [(1, 0)]
 ```


## PR Checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

- [x] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] new and changed code is tested
- [x] relevant changes added to [CHANGELOG.md](https://github.com/apytypes/apytypes/blob/main/CHANGELOG.md)
- [x] new functionality is documented
