### PR TITLE
Investigate failing Windows CI

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -36,6 +36,9 @@ jobs:
             python-version: "3.11"
           - os: "windows-11-arm"
             python-version: "3.12"
+          # NumPy 1.26.4 is only supported for 3.9-3.12
+          - numpy-version: ">=1.26.4,<2"
+            python-version: "3.13"
           # Do not test with NumPy 1 on free-threaded Python
           - numpy-version: ">=1.26.4,<2"
             python-version: "3.13t"


### PR DESCRIPTION
<!--
Thank you so much for your PR!
-->

# PR Summary
<!-- Please provide at least 1-2 sentences describing the pull request in detail
(Why is this change required?  What problem does it solve?) and link to relevant
issues and PRs.
-->
Two Windows CI jobs are failing in multiple PRs. For one of the jobs, I suspect the cause is Numpy 1.26.4 being used with Python 3.13, which is not [officially supported](https://numpy.org/doc/2.1/release/1.26.4-notes.html). 
This occurs in for example
[Unit tests / build (3.13, windows-latest, >=1.26.4,<2) (pull_request)](https://github.com/apytypes/apytypes/actions/runs/27563158343/job/81605948182?pr=984)
and
[Unit tests / build (3.13, windows-latest, >=1.26.4,<2) (pull_request)](https://github.com/apytypes/apytypes/actions/runs/27769720989/job/82166149114?pr=986)

The second failing job, I haven't figured out yet:
[Coverage / windows_msvc (3.10, windows-latest) (pull_request)](https://github.com/apytypes/apytypes/actions/runs/27563158313/job/81480154987?pr=984)

## PR Checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

- [N/A] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [N/A] new and changed code is tested
- [N/A] relevant changes added to [CHANGELOG.md](https://github.com/apytypes/apytypes/blob/main/CHANGELOG.md)
- [N/A] new functionality is documented
