### PR TITLE
Add parameter for seed in APyFloatAccumulatorContext

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Getters for real and imaginary part of `APyCFloatArray`.
 - Support for logic NOT, AND, OR, and XOR in `APyCFloat`.
 - Convenience cast functions to `APyCFloat` and `APyCFloatArray`.
+- Parameter for `seed` in `APyFloatAccumulatorContext`.
 
 ### Fixed
 

--- a/lib/apytypes/_apytypes.pyi
+++ b/lib/apytypes/_apytypes.pyi
@@ -8135,6 +8135,7 @@ class APyFloatAccumulatorContext(ContextManager):
         man_bits: int | None = None,
         bias: int | None = None,
         quantization: QuantizationMode | None = None,
+        seed: int | None = None,
     ) -> None: ...
     def __enter__(self) -> None: ...
     def __exit__(

--- a/lib/test/test_contextmanagers.py
+++ b/lib/test/test_contextmanagers.py
@@ -312,6 +312,61 @@ class TestAccumulatorContext:
             ):
                 assert get_float_quantization_mode() == QuantizationMode.TO_POS
 
+    def test_with_seed(self):
+        # Test setting a stochastic quantization mode without changing the seed
+        set_float_quantization_seed(123)
+        with APyFloatAccumulatorContext(
+            exp_bits=5, man_bits=4, quantization=QuantizationMode.STOCH_EQUAL
+        ):
+            pass
+        assert get_float_quantization_seed() == 123
+
+        # Test setting a stochastic quantization mode and changing the seed
+        with APyFloatAccumulatorContext(
+            exp_bits=5,
+            man_bits=4,
+            quantization=QuantizationMode.STOCH_WEIGHTED,
+            seed=77,
+        ):
+            assert get_float_quantization_seed() == 77
+        assert get_float_quantization_seed() == 123
+
+    def test_nested_seed(self):
+        set_float_quantization_seed(123)
+        with APyFloatAccumulatorContext(
+            exp_bits=5,
+            man_bits=4,
+            quantization=QuantizationMode.STOCH_WEIGHTED,
+            seed=456,
+        ):
+            assert get_float_quantization_seed() == 456
+            with APyFloatAccumulatorContext(
+                exp_bits=5,
+                man_bits=4,
+                quantization=QuantizationMode.STOCH_EQUAL,
+                seed=789,
+            ):
+                assert get_float_quantization_seed() == 789
+            assert get_float_quantization_seed() == 456
+        assert get_float_quantization_seed() == 123
+
+    def test_seed_with_quantization_context(self):
+        set_float_quantization_seed(123)
+        with APyFloatAccumulatorContext(
+            exp_bits=5,
+            man_bits=4,
+            quantization=QuantizationMode.STOCH_WEIGHTED,
+            seed=456,
+        ):
+            assert get_float_quantization_seed() == 456
+            with APyFloatQuantizationContext(
+                quantization=QuantizationMode.STOCH_EQUAL, seed=789
+            ):
+                assert get_float_quantization_seed() == 789
+            assert get_float_quantization_seed() == 456
+        assert get_float_quantization_mode() == QuantizationMode.TIES_EVEN
+        assert get_float_quantization_seed() == 123
+
     def test_fx_context_state_captured_and_restored(self):
         """
         Contexts with state must be captured on enter and then properly restored on

--- a/src/apytypes_common.h
+++ b/src/apytypes_common.h
@@ -136,6 +136,10 @@ struct APyFloatAccumulatorOption {
     std::optional<exp_t> bias;
     //! Quantization mode
     QuantizationMode quantization;
+    //! Psueod RNG seed
+    std::uint64_t seed;
+    //! RNG engine
+    std::mt19937_64 rng_engine;
 
     APyFloatSpec get_spec(exp_t backup_bias) const noexcept
     {

--- a/src/apytypes_context.cc
+++ b/src/apytypes_context.cc
@@ -81,11 +81,12 @@ APyFloatAccumulatorContext::APyFloatAccumulatorContext(
     std::optional<int> exp_bits,
     std::optional<int> man_bits,
     std::optional<exp_t> bias,
-    std::optional<QuantizationMode> quantization
+    std::optional<QuantizationMode> quantization,
+    std::optional<std::uint64_t> seed
 )
 {
     // Extract the input
-    APyFloatAccumulatorOption new_mode {};
+    APyFloatAccumulatorOption new_mode;
 
     if (!exp_bits.has_value() || !man_bits.has_value()) {
         throw nb::value_error(
@@ -99,6 +100,8 @@ APyFloatAccumulatorContext::APyFloatAccumulatorContext(
     new_mode.man_bits = man_bits.value();
     new_mode.bias = bias;
     new_mode.quantization = quantization.value_or(get_float_quantization_mode());
+    new_mode.seed = seed.value_or(std::random_device {}());
+    new_mode.rng_engine = std::mt19937_64(new_mode.seed);
 
     // Setup the context mode
     context_mode = new_mode;
@@ -109,11 +112,19 @@ APyFloatAccumulatorContext::APyFloatAccumulatorContext(
 void APyFloatAccumulatorContext::enter_context()
 {
     previous_mode = get_accumulator_mode_float();
+    previous_seed = get_rnd64_fp_seed();
+    previous_engine = get_rnd64_fp_engine();
     set_accumulator_mode_float(context_mode);
+    // Apply seed
+    set_rnd64_fp_seed(context_mode.value().seed);
+    set_rnd64_fp_engine(context_mode.value().rng_engine);
 }
 void APyFloatAccumulatorContext::exit_context()
 {
     set_accumulator_mode_float(previous_mode);
+    // Apply seed
+    set_rnd64_fp_seed(previous_seed);
+    set_rnd64_fp_engine(previous_engine);
 }
 
 /* ********************************************************************************** *

--- a/src/apytypes_context.h
+++ b/src/apytypes_context.h
@@ -43,13 +43,16 @@ public:
         std::optional<int> = std::nullopt,
         std::optional<int> = std::nullopt,
         std::optional<exp_t> = std::nullopt,
-        std::optional<QuantizationMode> quantization = std::nullopt
+        std::optional<QuantizationMode> quantization = std::nullopt,
+        std::optional<std::uint64_t> seed = std::nullopt
     );
     void enter_context() override;
     void exit_context() override;
 
 private:
     std::optional<APyFloatAccumulatorOption> previous_mode, context_mode;
+    std::uint64_t previous_seed;
+    std::mt19937_64 previous_engine;
 };
 
 /* ********************************************************************************** *

--- a/src/apytypes_context_wrapper.cc
+++ b/src/apytypes_context_wrapper.cc
@@ -99,11 +99,13 @@ void bind_accumulator_context(nb::module_& m)
                 std::optional<int>,
                 std::optional<int>,
                 std::optional<exp_t>,
-                std::optional<QuantizationMode>>(),
+                std::optional<QuantizationMode>,
+                std::optional<std::uint64_t>>(),
             nb::arg("exp_bits") = nb::none(),
             nb::arg("man_bits") = nb::none(),
             nb::arg("bias") = nb::none(),
-            nb::arg("quantization") = nb::none()
+            nb::arg("quantization") = nb::none(),
+            nb::arg("seed") = nb::none()
         )
         .def("__enter__", &context_enter_handler)
         .def(


### PR DESCRIPTION
<!--
Thank you so much for your PR!
-->

# PR Summary
<!-- Please provide at least 1-2 sentences describing the pull request in detail
(Why is this change required?  What problem does it solve?) and link to relevant
issues and PRs.
-->

## PR Checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->
Add a parameter for setting the seed in `APyFloatAccumulatorContext`.
Note that setting this seed affects the seed set in `APyFloatQuantizationContext`.

- [N/A] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] new and changed code is tested
- [x] relevant changes added to [CHANGELOG.md](https://github.com/apytypes/apytypes/blob/main/CHANGELOG.md)
- [x] new functionality is documented
