### PR TITLE
Fix bug in floating-point cast

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `APyFixedArray.to_bits` for 64-bit NumPy arrays on 32-bit systems.
 - `prod` and `cumprod` are using fewer bits for fixed-point arrays, see the
   documentation for exact expressions.
+- Bug in floating-point cast for values between the largest subnormal and
+  the smallest normal value of the destination format.
 
 ### Changed
 

--- a/lib/test/apyfloat/test_methods.py
+++ b/lib/test/apyfloat/test_methods.py
@@ -499,6 +499,11 @@ def test_cast_special_cases():
     a = a.cast(4, 3)
     assert a.is_identical(APyFloat(0, 0, 0, 4, 3))
 
+    # Result is tentatively a subnormal but becomes the smallest normal
+    a = APyFloat(0, 12, 31, 5, 5)
+    a = a.cast(3, 4)
+    assert a.is_identical(APyFloat(0, 1, 0, 3, 4))
+
 
 def test_casting_special_numbers():
     # Cast -0 to -0

--- a/src/apyfloat_util.h
+++ b/src/apyfloat_util.h
@@ -453,15 +453,22 @@ template <typename QNTZ_FUNC_SIGNATURE>
         }
 
         const int MAN_BITS_DELTA = 1 - exp + (src_spec.man_bits - dst_spec.man_bits);
-        const man_t LEADING_ONE = (1ULL << src_spec.man_bits);
-        man |= (1ULL << src_spec.man_bits); // Add the hidden one
+        const man_t SRC_LEADING_ONE = (1ULL << src_spec.man_bits);
+        man |= SRC_LEADING_ONE; // Add the hidden one
         if (MAN_BITS_DELTA <= 0) {
             return { src.sign, 0, (man << -MAN_BITS_DELTA) };
         } else { /* man_bits_delta > 0 */
             const man_t STICKY = (1ULL << (MAN_BITS_DELTA - 1)) - 1;
             APyFloatData res = { src.sign, 0, man };
+            const man_t DST_LEADING_ONE = (1ULL << dst_spec.man_bits);
             qntz_func(
-                res.man, res.exp, MAX_EXP, MAN_BITS_DELTA, res.sign, LEADING_ONE, STICKY
+                res.man,
+                res.exp,
+                MAX_EXP,
+                MAN_BITS_DELTA,
+                res.sign,
+                DST_LEADING_ONE,
+                STICKY
             );
             return res;
         }


### PR DESCRIPTION
<!--
Thank you so much for your PR!
-->

# PR Summary
<!-- Please provide at least 1-2 sentences describing the pull request in detail
(Why is this change required?  What problem does it solve?) and link to relevant
issues and PRs.
-->
Closes #1023.

The problem was that the "source format's leading one" was used instead of the "destination format's leading one" in of the branches of the quantization code. This branch is active when the result is tentatively a subnormal number in the destination format, and the bug triggered when the mantissa spilled over and compared with the wrong constant (thus not zeroing the mantissa nor updating the exponent).

## PR Checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

- [x] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] new and changed code is tested
- [x] relevant changes added to [CHANGELOG.md](https://github.com/apytypes/apytypes/blob/main/CHANGELOG.md)
- [N/A] new functionality is documented
