### PR TITLE
src: remove all `.value_or()` that requires function evaluation

### DIFF
--- a/src/apycfloat.cc
+++ b/src/apycfloat.cc
@@ -173,7 +173,7 @@ APyCFloat APyCFloat::from_number(
     const nb::object& py_obj, int exp_bits, int man_bits, std::optional<exp_t> bias
 )
 {
-    exp_t res_bias = bias.value_or(ieee_bias(exp_bits));
+    exp_t res_bias = bias ? *bias : ieee_bias(exp_bits);
     if (nb::isinstance<nb::int_>(py_obj)) {
         const nb::int_& val = nb::cast<nb::int_>(py_obj);
         return APyCFloat::from_integer(val, exp_bits, man_bits, res_bias);
@@ -251,7 +251,7 @@ APyCFloat APyCFloat::from_double(
         sign_of_double(value), exp_of_double(value), man_of_double(value), 11, 52, 1023
     );
 
-    const exp_t res_bias = bias.value_or(ieee_bias(exp_bits));
+    const exp_t res_bias = bias ? *bias : ieee_bias(exp_bits);
     return APyCFloat(
         real.cast_from_double(exp_bits, man_bits, res_bias).get_data(),
         exp_bits,
@@ -267,7 +267,7 @@ APyCFloat APyCFloat::from_integer(
     check_exponent_format(exp_bits, "APyCFloat.from_integer");
     check_mantissa_format(man_bits, "APyCFloat.from_integer");
 
-    const exp_t res_bias = bias.value_or(ieee_bias(exp_bits));
+    const exp_t res_bias = bias ? *bias : ieee_bias(exp_bits);
     return APyCFloat(
         APyFloat::from_integer(value, exp_bits, man_bits, res_bias).get_data(),
         exp_bits,
@@ -292,7 +292,7 @@ APyCFloat APyCFloat::from_complex(
         sign_of_double(imag), exp_of_double(imag), man_of_double(imag), 11, 52, 1023
     );
 
-    const exp_t res_bias = bias.value_or(ieee_bias(exp_bits));
+    const exp_t res_bias = bias ? *bias : ieee_bias(exp_bits);
     return APyCFloat(
         apy_real.cast_from_double(exp_bits, man_bits, res_bias).get_data(),
         apy_imag.cast_from_double(exp_bits, man_bits, res_bias).get_data(),
@@ -309,7 +309,7 @@ APyCFloat APyCFloat::from_fixed(
     check_exponent_format(exp_bits, "APyCFloat.from_fixed");
     check_mantissa_format(man_bits, "APyCFloat.from_fixed");
 
-    const exp_t bias = opt_bias.value_or(ieee_bias(exp_bits));
+    const exp_t bias = opt_bias ? *opt_bias : ieee_bias(exp_bits);
     APyFloatData re = floating_point_from_fixed_point(
         fixed.real_cbegin(), // src_cbegin
         fixed.real_cend(),   // src_cend
@@ -339,7 +339,7 @@ APyCFloat APyCFloat::from_fixed(
     check_exponent_format(exp_bits, "APyCFloat.from_fixed");
     check_mantissa_format(man_bits, "APyCFloat.from_fixed");
 
-    const exp_t bias = opt_bias.value_or(ieee_bias(exp_bits));
+    const exp_t bias = opt_bias ? *opt_bias : ieee_bias(exp_bits);
     APyFloatData re = floating_point_from_fixed_point(
         std::begin(fixed._data), // src_cbegin_it
         std::end(fixed._data),   // src_cend_it
@@ -362,7 +362,7 @@ APyCFloat APyCFloat::from_bits(
 {
     check_exponent_format(exp_bits, "APyCFloat.from_bits");
     check_mantissa_format(man_bits, "APyCFloat.from_bits");
-    const exp_t bias = opt_bias.value_or(ieee_bias(exp_bits));
+    const exp_t bias = opt_bias ? *opt_bias : ieee_bias(exp_bits);
 
     APyFloatData real, imag {};
 
@@ -648,29 +648,29 @@ APyCFloat APyCFloat::cast(
     return checked_cast(
         actual_exp_bits,
         actual_man_bits,
-        new_bias.value_or(ieee_bias(actual_exp_bits)),
-        quantization.value_or(get_float_quantization_mode())
+        new_bias ? *new_bias : ieee_bias(actual_exp_bits),
+        quantization ? *quantization : get_float_quantization_mode()
     );
 }
 
 APyCFloat APyCFloat::cast_to_double(std::optional<QuantizationMode> qntz) const
 {
-    return checked_cast(11, 52, 1023, qntz.value_or(get_float_quantization_mode()));
+    return checked_cast(11, 52, 1023, qntz ? *qntz : get_float_quantization_mode());
 }
 
 APyCFloat APyCFloat::cast_to_single(std::optional<QuantizationMode> qntz) const
 {
-    return checked_cast(8, 23, 127, qntz.value_or(get_float_quantization_mode()));
+    return checked_cast(8, 23, 127, qntz ? *qntz : get_float_quantization_mode());
 }
 
 APyCFloat APyCFloat::cast_to_half(std::optional<QuantizationMode> qntz) const
 {
-    return checked_cast(5, 10, 15, qntz.value_or(get_float_quantization_mode()));
+    return checked_cast(5, 10, 15, qntz ? *qntz : get_float_quantization_mode());
 }
 
 APyCFloat APyCFloat::cast_to_bfloat16(std::optional<QuantizationMode> qntz) const
 {
-    return checked_cast(8, 7, 127, qntz.value_or(get_float_quantization_mode()));
+    return checked_cast(8, 7, 127, qntz ? *qntz : get_float_quantization_mode());
 }
 
 APyCFloat APyCFloat::checked_cast(
@@ -835,7 +835,7 @@ APyFloat APyCFloat::get_imag() const
 APyCFloat
 APyCFloat::one(std::uint8_t exp_bits, std::uint8_t man_bits, std::optional<exp_t> bias)
 {
-    const exp_t res_bias = bias.value_or(ieee_bias(exp_bits));
+    const exp_t res_bias = bias ? *bias : ieee_bias(exp_bits);
     return APyCFloat({ 0, res_bias, 0 }, { 0, 0, 0 }, exp_bits, man_bits, res_bias);
 }
 

--- a/src/apycfloatarray.cc
+++ b/src/apycfloatarray.cc
@@ -31,7 +31,7 @@ APyCFloatArray::APyCFloatArray(
     : APyArray(shape, /* itemsize= */ 2)
     , exp_bits(exp_bits)
     , man_bits(man_bits)
-    , bias(bias.value_or(ieee_bias(exp_bits)))
+    , bias(bias ? *bias : ieee_bias(exp_bits))
 {
 }
 
@@ -67,7 +67,7 @@ APyCFloatArray::APyCFloatArray(
       )
     , exp_bits { check_exponent_format(exp_bits, "APyCFloatArray.__init__") }
     , man_bits { check_mantissa_format(man_bits, "APyCFloatArray.__init__") }
-    , bias { bias.value_or(ieee_bias(exp_bits)) }
+    , bias { bias ? *bias : ieee_bias(exp_bits) }
 {
     constexpr std::string_view NAME = "APyCFloatArray.__init__";
 
@@ -1168,33 +1168,41 @@ APyCFloatArray APyCFloatArray::cast(
     return _cast(
         actual_exp_bits,
         actual_man_bits,
-        new_bias.value_or(APyFloat::ieee_bias(actual_exp_bits)),
-        quantization.value_or(get_float_quantization_mode())
+        new_bias ? *new_bias : APyFloat::ieee_bias(actual_exp_bits),
+        quantization ? *quantization : get_float_quantization_mode()
     );
 }
 
 APyCFloatArray
 APyCFloatArray::cast_to_double(std::optional<QuantizationMode> quantization) const
 {
-    return _cast(11, 52, 1023, quantization.value_or(get_float_quantization_mode()));
+    return _cast(
+        11, 52, 1023, quantization ? *quantization : get_float_quantization_mode()
+    );
 }
 
 APyCFloatArray
 APyCFloatArray::cast_to_single(std::optional<QuantizationMode> quantization) const
 {
-    return _cast(8, 23, 127, quantization.value_or(get_float_quantization_mode()));
+    return _cast(
+        8, 23, 127, quantization ? *quantization : get_float_quantization_mode()
+    );
 }
 
 APyCFloatArray
 APyCFloatArray::cast_to_half(std::optional<QuantizationMode> quantization) const
 {
-    return _cast(5, 10, 15, quantization.value_or(get_float_quantization_mode()));
+    return _cast(
+        5, 10, 15, quantization ? *quantization : get_float_quantization_mode()
+    );
 }
 
 APyCFloatArray
 APyCFloatArray::cast_to_bfloat16(std::optional<QuantizationMode> quantization) const
 {
-    return _cast(8, 7, 127, quantization.value_or(get_float_quantization_mode()));
+    return _cast(
+        8, 7, 127, quantization ? *quantization : get_float_quantization_mode()
+    );
 }
 
 APyCFloatArray APyCFloatArray::_cast(

--- a/src/apyfloat.cc
+++ b/src/apyfloat.cc
@@ -47,7 +47,7 @@ APyFloat::APyFloat(
 )
     : exp_bits(exp_bits)
     , man_bits(man_bits)
-    , bias(bias.value_or(ieee_bias()))
+    , bias(bias ? *bias : ieee_bias())
     , sign(sign)
     , exp(exp)
     , man(man)
@@ -76,7 +76,7 @@ APyFloat::APyFloat(
 )
     : exp_bits(exp_bits)
     , man_bits(man_bits)
-    , bias(bias.value_or(ieee_bias()))
+    , bias(bias ? *bias : ieee_bias())
     , sign(false)
     , exp(0)
     , man(0)
@@ -149,7 +149,7 @@ APyFloat APyFloat::from_double(
         sign_of_double(value), exp_of_double(value), man_of_double(value), 11, 52, 1023
     );
     return apytypes_double.cast_from_double(
-        exp_bits, man_bits, bias.value_or(APyFloat::ieee_bias(exp_bits))
+        exp_bits, man_bits, bias ? *bias : APyFloat::ieee_bias(exp_bits)
     );
 }
 
@@ -161,7 +161,7 @@ APyFloat APyFloat::from_integer(
     check_mantissa_format(man_bits, "APyFloat.from_integer");
 
     APyFixed apyfixed = APyFixed::from_unspecified_integer(value);
-    const exp_t bias = opt_bias.value_or(ieee_bias(exp_bits));
+    const exp_t bias = opt_bias ? *opt_bias : ieee_bias(exp_bits);
     APyFloatData data = floating_point_from_fixed_point(
         std::begin(apyfixed._data), // src_cbegin
         std::end(apyfixed._data),   // src_cend_it
@@ -182,7 +182,7 @@ APyFloat APyFloat::from_fixed(
     check_exponent_format(exp_bits, "APyFloat.from_fixed");
     check_mantissa_format(man_bits, "APyFloat.from_fixed");
 
-    const exp_t bias = opt_bias.value_or(APyFloat::ieee_bias(exp_bits));
+    const exp_t bias = opt_bias ? *opt_bias : APyFloat::ieee_bias(exp_bits);
     APyFloatData data = floating_point_from_fixed_point(
         std::begin(apyfixed._data), // src_cbegin
         std::end(apyfixed._data),   // src_cend_it
@@ -205,8 +205,8 @@ APyFloat APyFloat::cast(
 {
     const auto actual_exp_bits = new_exp_bits.value_or(exp_bits);
     const auto actual_man_bits = new_man_bits.value_or(man_bits);
-    const auto actual_bias = new_bias.value_or(ieee_bias(actual_exp_bits));
-    const auto qntz = arg_qntz.value_or(get_float_quantization_mode());
+    const auto actual_bias = new_bias ? *new_bias : ieee_bias(actual_exp_bits);
+    const auto qntz = arg_qntz ? *arg_qntz : get_float_quantization_mode();
 
     check_exponent_format(actual_exp_bits, "APyFloat.cast");
     check_mantissa_format(actual_man_bits, "APyFloat.cast");
@@ -399,7 +399,7 @@ APyFloat APyFloat::from_bits(
 APyFloat
 APyFloat::one(std::uint8_t exp_bits, std::uint8_t man_bits, std::optional<exp_t> bias)
 {
-    const exp_t res_bias = bias.value_or(APyFloat::ieee_bias(exp_bits));
+    const exp_t res_bias = bias ? *bias : APyFloat::ieee_bias(exp_bits);
     return APyFloat(0, res_bias, 0, exp_bits, man_bits, res_bias);
 }
 
@@ -1357,22 +1357,22 @@ APyFloat APyFloat::normalized() const
  */
 APyFloat APyFloat::cast_to_double(std::optional<QuantizationMode> qntz) const
 {
-    return checked_cast(11, 52, 1023, qntz.value_or(get_float_quantization_mode()));
+    return checked_cast(11, 52, 1023, qntz ? *qntz : get_float_quantization_mode());
 }
 
 APyFloat APyFloat::cast_to_single(std::optional<QuantizationMode> qntz) const
 {
-    return checked_cast(8, 23, 127, qntz.value_or(get_float_quantization_mode()));
+    return checked_cast(8, 23, 127, qntz ? *qntz : get_float_quantization_mode());
 }
 
 APyFloat APyFloat::cast_to_half(std::optional<QuantizationMode> qntz) const
 {
-    return checked_cast(5, 10, 15, qntz.value_or(get_float_quantization_mode()));
+    return checked_cast(5, 10, 15, qntz ? *qntz : get_float_quantization_mode());
 }
 
 APyFloat APyFloat::cast_to_bfloat16(std::optional<QuantizationMode> qntz) const
 {
-    return checked_cast(8, 7, 127, qntz.value_or(get_float_quantization_mode()));
+    return checked_cast(8, 7, 127, qntz ? *qntz : get_float_quantization_mode());
 }
 
 APyFloat APyFloat::next_up() const

--- a/src/apyfloatarray.cc
+++ b/src/apyfloatarray.cc
@@ -57,7 +57,7 @@ APyFloatArray::APyFloatArray(
     : APyArray(python_iterable_extract_shape(sign_seq, "APyFloatArray.__init__"))
     , exp_bits { exp_bits }
     , man_bits { man_bits }
-    , bias { bias.value_or(ieee_bias(exp_bits)) }
+    , bias { bias ? *bias : ieee_bias(exp_bits) }
 {
     constexpr std::string_view caller_name = "APyFloatArray.__init__";
 
@@ -123,7 +123,7 @@ APyFloatArray::APyFloatArray(
     : APyArray(shape)
     , exp_bits(exp_bits)
     , man_bits(man_bits)
-    , bias(bias.value_or(APyFloat::ieee_bias(exp_bits)))
+    , bias(bias ? *bias : APyFloat::ieee_bias(exp_bits))
 {
 }
 
@@ -1671,8 +1671,8 @@ APyFloatArray APyFloatArray::cast(
     return _cast(
         actual_exp_bits,
         actual_man_bits,
-        new_bias.value_or(APyFloat::ieee_bias(actual_exp_bits)),
-        quantization.value_or(get_float_quantization_mode())
+        new_bias ? *new_bias : APyFloat::ieee_bias(actual_exp_bits),
+        quantization ? *quantization : get_float_quantization_mode()
     );
 }
 
@@ -1687,7 +1687,7 @@ APyFloatArray APyFloatArray::_cast(
         new_exp_bits,
         new_man_bits,
         new_bias,
-        quantization.value_or(get_float_quantization_mode())
+        quantization ? *quantization : get_float_quantization_mode()
     );
 }
 

--- a/src/apytypes_context.cc
+++ b/src/apytypes_context.cc
@@ -15,7 +15,7 @@ APyFloatQuantizationContext::APyFloatQuantizationContext(
     const QuantizationMode& new_mode, std::optional<std::uint64_t> seed
 )
     : context_mode { new_mode }
-    , context_seed { seed.value_or(std::random_device {}()) }
+    , context_seed { seed ? *seed : std::random_device {}() }
     , context_engine { context_seed }
 {
     // Previous state must be captured on `enter_context()`
@@ -99,8 +99,9 @@ APyFloatAccumulatorContext::APyFloatAccumulatorContext(
     new_mode.exp_bits = exp_bits.value();
     new_mode.man_bits = man_bits.value();
     new_mode.bias = bias;
-    new_mode.quantization = quantization.value_or(get_float_quantization_mode());
-    new_mode.seed = seed.value_or(std::random_device {}());
+    new_mode.quantization
+        = quantization ? *quantization : get_float_quantization_mode();
+    new_mode.seed = seed ? *seed : std::random_device {}();
     new_mode.rng_engine = std::mt19937_64(new_mode.seed);
 
     // Setup the context mode


### PR DESCRIPTION
This PR removes all `std::optional::value_or` that are used with arguments that required function evaluation. I opted to leave `value_or` when no computations where required as a consequence of using it, as I think the code reads better. 

Closes #216.

# PR Summary

## PR Checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

- [x] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- N/A new and changed code is tested
- N/A relevant changes added to [CHANGELOG.md](https://github.com/apytypes/apytypes/blob/main/CHANGELOG.md)
- N/A new functionality is documented
