### PR TITLE
src: fix `fx` and `fp` complex detection for Numpy arrays

### DIFF
--- a/lib/apytypes/_utils.py
+++ b/lib/apytypes/_utils.py
@@ -123,7 +123,7 @@ def fx(
         else:
             try:
                 return APyFixedArray.from_float(value, int_bits, frac_bits, bits)
-            except ValueError:
+            except TypeError:
                 return APyCFixedArray.from_complex(value, int_bits, frac_bits, bits)
     else:
         if isinstance(value, complex):
@@ -241,7 +241,7 @@ def fp(
         else:
             try:
                 return APyFloatArray.from_float(value, exp_bits, man_bits, bias)
-            except ValueError:
+            except TypeError:
                 return APyCFloatArray.from_float(value, exp_bits, man_bits, bias)
     else:
         if isinstance(value, complex):

--- a/lib/test/apycfloatarray/test_constructors.py
+++ b/lib/test/apycfloatarray/test_constructors.py
@@ -7,24 +7,24 @@ from apytypes import APyCFixed, APyCFloat, APyCFloatArray, APyFixed, APyFloat
 def test_constructor_raises():
     with pytest.raises(ValueError, match=r"APyCFloatArray\.__init__: shape mismatch"):
         _ = APyCFloatArray([1], [5, 2, 5], [4], 10, 10)
-    with pytest.raises(ValueError, match=r"APyCFloatArray\.__init__: unexpected type"):
+    with pytest.raises(TypeError, match=r"APyCFloatArray\.__init__: unexpected type"):
         _ = APyCFloatArray([1, 2], [5, 2], [4, "str"], 10, 10)
-    with pytest.raises(ValueError, match=r"APyCFloatArray\.__init__: unexpected type"):
+    with pytest.raises(TypeError, match=r"APyCFloatArray\.__init__: unexpected type"):
         _ = APyCFloatArray(["foo"], [5], [4], 10, 10)
-    with pytest.raises(ValueError, match=r"APyCFloatArray\.__init__: unexpected type"):
+    with pytest.raises(TypeError, match=r"APyCFloatArray\.__init__: unexpected type"):
         _ = APyCFloatArray([1], ["foo"], [4], 10, 10)
-    with pytest.raises(ValueError, match=r"APyCFloatArray\.__init__: unexpected type"):
+    with pytest.raises(TypeError, match=r"APyCFloatArray\.__init__: unexpected type"):
         _ = APyCFloatArray([1], [5], ["foo"], 10, 10)
     with pytest.raises(
-        ValueError, match=r"APyCFloatArray\.__init__: unexpected type when traversing"
+        TypeError, match=r"APyCFloatArray\.__init__: unexpected type when traversing"
     ):
         _ = APyCFloatArray([1.0], [4], [4], 10, 10)
     with pytest.raises(
-        ValueError, match=r"APyCFloatArray\.__init__: unexpected type when traversing"
+        TypeError, match=r"APyCFloatArray\.__init__: unexpected type when traversing"
     ):
         _ = APyCFloatArray([True], [range], [4], 10, 10)
     with pytest.raises(
-        ValueError, match=r"APyCFloatArray\.__init__: unexpected type when traversing"
+        TypeError, match=r"APyCFloatArray\.__init__: unexpected type when traversing"
     ):
         _ = APyCFloatArray([True], [4], [APyCFloatArray], 10, 10)
     with pytest.raises(

--- a/lib/test/apycfloatarray/test_methods.py
+++ b/lib/test/apycfloatarray/test_methods.py
@@ -13,7 +13,7 @@ def test_from_bits():
         APyCFloatArray.from_bits([0], 300, 5)
 
     with pytest.raises(
-        ValueError, match=r"APyCFloatArray\.from_bits: unexpected type when traversing"
+        TypeError, match=r"APyCFloatArray\.from_bits: unexpected type when traversing"
     ):
         APyCFloatArray.from_bits(["0"], 5, 10)
 

--- a/lib/test/apyfixedarray/test_constructors.py
+++ b/lib/test/apyfixedarray/test_constructors.py
@@ -23,7 +23,7 @@ def test_homogeneous_shape(fixed_array: type[APyCFixedArray]):
         _ = fixed_array([range(3), [3, 4, 5], (7, 8)], bits=10, int_bits=10)
     with pytest.raises(ValueError, match=r"APyC?FixedArray.__init__: inhomogeneous"):
         _ = fixed_array([range(4), [3, 4, 5], (6, 7, 8)], bits=10, int_bits=10)
-    with pytest.raises(ValueError, match=r"APyC?FixedArray.__init__: unexpected type"):
+    with pytest.raises(TypeError, match=r"APyC?FixedArray.__init__: unexpected type"):
         _ = fixed_array(["a", 5], bits=10, int_bits=10)
     with pytest.raises(ValueError, match=r"APyC?FixedArray.__init__: inhomogeneous"):
         _ = fixed_array([1, 2, 3, [4, 5]], bits=10, int_bits=10)
@@ -60,7 +60,7 @@ def test_array_floating_point_construction(fixed_array: type[APyCFixedArray]):
     a = fixed_array.from_float([-1.0, -1.25, -2.99], bits=4, frac_bits=1)
     assert a.is_identical(fixed_array([-2, -3, -6], bits=4, frac_bits=1))
 
-    with pytest.raises(ValueError, match=r"APyC?FixedArray.from_[a-z]+: unexpected"):
+    with pytest.raises(TypeError, match=r"APyC?FixedArray.from_[a-z]+: unexpected"):
         _ = fixed_array.from_float([1.0, 2.0, None], int_bits=13, frac_bits=12)
 
     a = fixed_array.from_float([-1.0, -2.0, -3.0, -4.0], bits=4, frac_bits=0)

--- a/lib/test/apyfloatarray/test_constructors.py
+++ b/lib/test/apyfloatarray/test_constructors.py
@@ -7,24 +7,24 @@ from apytypes import APyCFloatArray, APyFixed, APyFloatArray
 def test_constructor_raises():
     with pytest.raises(ValueError, match=r"APyFloatArray\.__init__: shape mismatch"):
         _ = APyFloatArray([1], [5, 2], [4], 10, 10)
-    with pytest.raises(ValueError, match=r"APyFloatArray\.__init__: unexpected type"):
+    with pytest.raises(TypeError, match=r"APyFloatArray\.__init__: unexpected type"):
         _ = APyFloatArray([1, 2], [5, 2], [4, "str"], 10, 10)
-    with pytest.raises(ValueError, match=r"APyFloatArray\.__init__: unexpected type"):
+    with pytest.raises(TypeError, match=r"APyFloatArray\.__init__: unexpected type"):
         _ = APyFloatArray(["foo"], [5], [4], 10, 10)
-    with pytest.raises(ValueError, match=r"APyFloatArray\.__init__: unexpected type"):
+    with pytest.raises(TypeError, match=r"APyFloatArray\.__init__: unexpected type"):
         _ = APyFloatArray([1], ["foo"], [4], 10, 10)
-    with pytest.raises(ValueError, match=r"APyFloatArray\.__init__: unexpected type"):
+    with pytest.raises(TypeError, match=r"APyFloatArray\.__init__: unexpected type"):
         _ = APyFloatArray([1], [5], ["foo"], 10, 10)
     with pytest.raises(
-        ValueError, match=r"APyFloatArray\.__init__: unexpected type when traversing"
+        TypeError, match=r"APyFloatArray\.__init__: unexpected type when traversing"
     ):
         _ = APyFloatArray([1.0], [4], [4], 10, 10)
     with pytest.raises(
-        ValueError, match=r"APyFloatArray\.__init__: unexpected type when traversing"
+        TypeError, match=r"APyFloatArray\.__init__: unexpected type when traversing"
     ):
         _ = APyFloatArray([True], [range], [4], 10, 10)
     with pytest.raises(
-        ValueError, match=r"APyFloatArray\.__init__: unexpected type when traversing"
+        TypeError, match=r"APyFloatArray\.__init__: unexpected type when traversing"
     ):
         _ = APyFloatArray([True], [4], [APyFloatArray], 10, 10)
     with pytest.raises(
@@ -213,7 +213,7 @@ def test_special_value_numpy_from_double():
 def test_from_numpy_raises():
     np = pytest.importorskip("numpy")
     a = np.asarray([[1e-323, float("inf")], [float("nan"), 0.0]], dtype="half")
-    with pytest.raises(TypeError, match="APyFloatArray::_set_values_from_ndarray"):
+    with pytest.raises(TypeError, match=r"APyFloatArray::from_array\(\): unsupported"):
         APyFloatArray.from_float(a, 14, 60)
 
 

--- a/lib/test/apyfloatarray/test_methods.py
+++ b/lib/test/apyfloatarray/test_methods.py
@@ -125,7 +125,7 @@ def test_array_from_float_raises(float_array: type[APyCFloatArray]):
         _ = float_array.from_float([0], 5, -300)
 
     with pytest.raises(
-        ValueError,
+        TypeError,
         match=r"APyC?FloatArray\.from_(float)|(complex): "
         + r"unexpected type when traversing iterable sequence: <class 'str'>",
     ):
@@ -323,12 +323,12 @@ def test_from_bits():
         APyFloatArray.from_bits([0], 300, 5)
 
     with pytest.raises(
-        ValueError, match=r"APyFloatArray\.from_bits: unexpected type when traversing"
+        TypeError, match=r"APyFloatArray\.from_bits: unexpected type when traversing"
     ):
         APyFloatArray.from_bits(["0"], 5, 10)
 
     with pytest.raises(
-        ValueError,
+        TypeError,
         match="Invalid",
     ):
         APyFloatArray.from_bits([1, 10, 1.0, 5], 5, 10)

--- a/lib/test/test_utils.py
+++ b/lib/test/test_utils.py
@@ -102,18 +102,44 @@ def test_fp():
 
 def test_fx_numpy():
     np = pytest.importorskip("numpy")
-    a = np.array([[0.1, 0.2], [0.3, 0.4]])
-    assert fx(a, 0, 9).is_identical(APyFixedArray.from_array(a, 0, 9))
+    a_real = np.array([[0.1, 0.2], [0.3, 0.4]])
+    assert fx(a_real, 0, 9).is_identical(APyFixedArray.from_array(a_real, 0, 9))
+    assert fx(a_real[0, 0], 0, 9).is_identical(APyFixed.from_float(a_real[0, 0], 0, 9))
+    assert fx(a_real[0, 0], 0, 9, force_complex=True).is_identical(
+        APyCFixed.from_float(a_real[0, 0], 0, 9)
+    )
 
-    assert fx(a[0, 0], 0, 9).is_identical(APyFixed.from_float(a[0, 0], 0, 9))
+    a_cplx = np.array([[0.1 + 0.2j, 2j], [-1, -0.25j]])
+    assert fx(a_cplx, 0, 9).is_identical(APyCFixedArray.from_complex(a_cplx, 0, 9))
+    assert fx(a_cplx[0, 0], 0, 9).is_identical(
+        APyCFixed.from_complex(a_cplx[0, 0], 0, 9)
+    )
+    assert fx(a_cplx[1, 0], 0, 9).is_identical(APyCFixed.from_float(a_cplx[1, 0], 0, 9))
+    assert fx(a_cplx[1, 0], 0, 9, force_complex=True).is_identical(
+        APyCFixed.from_complex(a_cplx[1, 0], 0, 9)
+    )
 
 
 def test_fp_numpy():
     np = pytest.importorskip("numpy")
     a = np.array([[0.1, 0.2], [0.3, 0.4]])
     assert fp(a, 3, 9).is_identical(APyFloatArray.from_array(a, 3, 9))
-
     assert fp(a[0, 0], 3, 9).is_identical(APyFloat.from_float(a[0, 0], 3, 9))
+    assert fp(a[0, 0], 3, 9, force_complex=True).is_identical(
+        APyCFloat.from_float(a[0, 0], 3, 9)
+    )
+
+    a_cplx = np.array([[0.1 + 0.2j, 2j], [-1, -0.25j]])
+    assert fp(a_cplx, 3, 9).is_identical(APyCFloatArray.from_complex(a_cplx, 3, 9))
+    assert fp(a_cplx[0, 0], 3, 9).is_identical(
+        APyCFloat.from_complex(a_cplx[0, 0], 3, 9)
+    )
+    assert fp(a_cplx[1, 0], 3, 9).is_identical(
+        APyCFloat.from_float(a_cplx[1, 0].real, 3, 9)
+    )
+    assert fp(a_cplx[1, 0], 3, 9, force_complex=True).is_identical(
+        APyCFloat.from_complex(a_cplx[1, 0], 3, 9)
+    )
 
 
 def test_fn():

--- a/src/apyfloatarray.cc
+++ b/src/apyfloatarray.cc
@@ -65,13 +65,14 @@ APyFloatArray::APyFloatArray(
     const auto exps_shape = python_iterable_extract_shape(exp_seq, caller_name);
     const auto mans_shape = python_iterable_extract_shape(man_seq, caller_name);
     if (!((signs_shape == exps_shape) && (signs_shape == mans_shape))) {
-        throw std::domain_error(
+        throw nb::value_error(
             fmt::format(
                 "APyFloatArray.__init__: shape mismatch, sign: {}, exp: {}, man: {}",
                 tuple_string_from_vec(signs_shape),
                 tuple_string_from_vec(exps_shape),
                 tuple_string_from_vec(mans_shape)
             )
+                .c_str()
         );
     }
 
@@ -88,7 +89,7 @@ APyFloatArray::APyFloatArray(
 
             return; // initialization completed
         }
-        throw std::domain_error(
+        throw nb::value_error(
             "APyFloatArray.__init__: if any input iterable is ndarray, than all input "
             "iterables must be ndarray"
         );
@@ -444,12 +445,13 @@ APyFloatArray::matmul(const APyFloatArray& rhs) const
     }
 
     // Unsupported `__matmul__` dimensionality, raise exception
-    throw std::length_error(
+    throw nb::value_error(
         fmt::format(
             "APyFloatArray.__matmul__: input shape mismatch, lhs: {}, rhs: {}",
             tuple_string_from_vec(_shape),
             tuple_string_from_vec(rhs._shape)
         )
+            .c_str()
     );
 }
 
@@ -592,7 +594,7 @@ APyFloatArray APyFloatArray::fullrange(
     const APyFloat apy_stop = APyFloat::from_number(stop, exp_bits, man_bits, bias);
 
     if (apy_start.is_nan() || apy_stop.is_nan()) {
-        throw nanobind::value_error(
+        throw nb::value_error(
             "APyFloatArray.fullrange: start or stop is NaN, cannot compute range"
         );
     }
@@ -1414,8 +1416,7 @@ void APyFloatArray::_set_values_from_ndarray(const nb::ndarray<nb::c_contig>& nd
     // the `dtype`. Seems hard to achieve with nanobind, but please fix this if you
     // find out how this can be achieved.
     throw nb::type_error(
-        "APyFloatArray::_set_values_from_ndarray(): "
-        "unsupported `dtype` expecting integer/float"
+        "APyFloatArray::from_array(): unsupported `dtype` expecting integer/float"
     );
 }
 
@@ -1461,7 +1462,7 @@ APyFloatArray APyFloatArray::from_bits(
             result._data[i]
                 = f.update_from_bits(nb::cast<nb::int_>(py_obj[i])).get_data();
         } else {
-            throw std::domain_error("Invalid Python objects in sequence");
+            throw nb::type_error("Invalid Python objects in sequence");
         }
     }
 

--- a/src/python_util.h
+++ b/src/python_util.h
@@ -508,7 +508,7 @@ python_iterable_extract_shape(
  * store handles to them them in a `std::vector<nb::object>`. The sequence is walked in
  * a depth-first manner and all elements must match `(nb::isinstance<PyTypes> || ...)`.
  * If any object in the sequence `py_seq` does not match any `PyTypes` (or another
- * Python sequence) a `std::domain_error` exception is raised.
+ * Python sequence) a `nb::type_error` exception is raised.
  */
 template <typename... PyTypes>
 [[maybe_unused]] static std::vector<nanobind::object>
@@ -548,7 +548,7 @@ python_iterable_walk(const nanobind::iterable& py_seq, std::string_view err_pref
                     err_prefix,
                     nb::repr(nb::cast<nb::type_object>(err_obj.type())).c_str()
                 );
-                throw std::domain_error(err_msg);
+                throw nb::type_error(err_msg.c_str());
             }
         }
     }


### PR DESCRIPTION
# PR Summary

Fixes automatic complex detection in `fp` and `fx` when Numpy arrays are used to construct complex-valued arrays. Also changed some raised `ValueError` into `TypeError` for cases where the error is with the type.

#### Problem example:

```python
from apytypes import *

# This already worked:
a = fp([1 + 2j, -1], exp_bits=8, man_bits=15)

# This has been fixed and is working now:
b = fp(np.array([1 + 2j, -1]), exp_bits=8, man_bits=15)
```


## PR Checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

- N/A "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] new and changed code is tested
- N/A relevant changes added to [CHANGELOG.md](https://github.com/apytypes/apytypes/blob/main/CHANGELOG.md)
- N/A new functionality is documented
