### PR TITLE
src: add `APY_ASSERT()` configurable assertion

### DIFF
--- a/.github/workflows/tests-ub-sanitizers.yml
+++ b/.github/workflows/tests-ub-sanitizers.yml
@@ -43,6 +43,7 @@ jobs:
         git fetch --tags
         python -m pip install .[test] -v              \
           -Csetup-args="-Db_sanitize=undefined"       \
+          -Csetup-args="-Db_ndebug=false"             \
           -Csetup-args="-Dlimb_size=${{ matrix.limb-size }}"
     - name: Test with pytest
       run: |

--- a/meson.build
+++ b/meson.build
@@ -20,19 +20,36 @@ if get_option('limb_size') == 'native'
         '-DCOMPILER_LIMB_SIZE=NATIVE',
         language: ['cpp', 'c'],
     )
-endif
-if get_option('limb_size') == '32'
+elif get_option('limb_size') == '32'
     add_project_arguments(
         '-DCOMPILER_LIMB_SIZE=32',
         language: ['cpp', 'c'],
     )
-endif
-if get_option('limb_size') == '64'
+elif get_option('limb_size') == '64'
     add_project_arguments(
         '-DCOMPILER_LIMB_SIZE=64',
         language: ['cpp', 'c'],
     )
+else
+    error('APyTypes option `limb_size` not properly set')
 endif
+
+# Specify the APyTypes assertion style. Exactly one of `python_exception` or
+# `c_assertion`
+if get_option('assertion_style') == 'python_exception'
+    add_project_arguments(
+        '-DASSERTION_STYLE=1',
+        language: ['cpp', 'c'],
+    )
+elif get_option('assertion_style') == 'c_assertion'
+    add_project_arguments(
+        '-DASSERTION_STYLE=2',
+        language: ['cpp', 'c'],
+    )
+else
+    error('APyTypes option `assertion_style` not properly set')
+endif
+
 
 # Disable nanobind leak warnings on release builds
 if get_option('buildtype') == 'release'

--- a/meson.options
+++ b/meson.options
@@ -1,1 +1,32 @@
-option('limb_size', type : 'combo', choices : ['native', '32', '64'], value : 'native')
+#
+# Specify the size, in bits, of limbs used throughout APyTypes for multi-precision
+# arithmetic. If the setting `native` is used, the build process tries to determine the
+# best suitable limb size automatically.
+#
+option(
+  'limb_size',
+  type : 'combo',
+  choices : ['native', '32', '64'],
+  value : 'native'
+)
+
+#
+# Specify the `APY_ASSERT()` assertion style used in the build of APyTypes. Choices are,
+#
+# (*) `python_exception` :
+#        This setting makes APyTypes throw a Python `RuntimeError` on assertion failure.
+#        This is useful, for example, in the APyTypes Pytest test suite, as assertion
+#        failures show up as a regular failed tests with the assertion error message.
+# (*) `c_assertion` :
+#        This setting makes APyTypes assertions use default C-style assertion defined in
+#        the header file `cassert` (`assert.h`).
+#
+# Regardless of option, the assertions are only ever armed if APyTypes is built with the
+# Meson option `b_ndebug == false`.
+#
+option(
+  'assertion_style',
+  type : 'combo',
+  choices : [ 'python_exception', 'c_assertion' ],
+  value: 'python_exception'
+)

--- a/src/apyarray.h
+++ b/src/apyarray.h
@@ -95,7 +95,7 @@ public:
     std::vector<std::size_t>
     compute_slice_shape(const std::vector<std::variant<nb::int_, nb::slice>>& key) const
     {
-        assert(key.size() <= _shape.size());
+        APY_ASSERT(key.size() <= _shape.size());
         std::vector<std::size_t> shape;
 
         // Elements in the key tuple
@@ -306,7 +306,7 @@ public:
     std::variant<ARRAY_TYPE, scalar_variant_t<ARRAY_TYPE>>
     get_item_tuple(const std::vector<std::variant<nb::int_, nb::slice>>& tuple) const
     {
-        assert(tuple.size() <= _shape.size());
+        APY_ASSERT(tuple.size() <= _shape.size());
         using SCALAR_TYPE = scalar_variant_t<ARRAY_TYPE>;
         using RESULT_TYPE = std::variant<ARRAY_TYPE, SCALAR_TYPE>;
 
@@ -329,7 +329,7 @@ public:
             SCALAR_TYPE result = static_cast<const ARRAY_TYPE*>(this)->create_scalar();
             std::size_t item_idx = 0;
             for (std::size_t i = 0; i < tuple.size(); i++) {
-                assert(std::holds_alternative<nb::int_>(tuple[i]));
+                APY_ASSERT(std::holds_alternative<nb::int_>(tuple[i]));
                 auto axis = static_cast<std::ptrdiff_t>(std::get<nb::int_>(tuple[i]));
                 axis = adjust_integer_index(axis, i, "__getitem__");
                 item_idx += strides[i] * axis;
@@ -559,7 +559,7 @@ public:
         const std::vector<std::variant<nb::int_, nb::slice>>& key, const ARRAY_TYPE& val
     )
     {
-        assert(key.size() <= _shape.size());
+        APY_ASSERT(key.size() <= _shape.size());
 
         // Make sure that all bit specifiers in `*this` and `val` are equal.
         if (!static_cast<const ARRAY_TYPE*>(this)->is_same_spec(val)) {
@@ -569,7 +569,7 @@ public:
             );
             throw nb::value_error(error_msg.c_str());
         }
-        assert(_itemsize == val._itemsize);
+        APY_ASSERT(_itemsize == val._itemsize);
 
         // Compute the slice shape
         std::vector<std::size_t> slice_shape = compute_slice_shape(key);
@@ -683,9 +683,9 @@ public:
             );
             throw nb::value_error(err_msg.c_str());
         }
-        assert(_itemsize == val._itemsize);
-        assert(_shape.size() > 0);
-        assert(val._shape.size() > 0);
+        APY_ASSERT(_itemsize == val._itemsize);
+        APY_ASSERT(_shape.size() > 0);
+        APY_ASSERT(val._shape.size() > 0);
 
         // Compute the slice `ndim`
         std::size_t slice_ndim = _ndim - key.ndim() + 1;
@@ -1564,8 +1564,8 @@ private:
         std::string_view summary_sep = "..."
     ) const
     {
-        assert(n_cols > 0);
-        assert(axis < _shape.size());
+        APY_ASSERT(n_cols > 0);
+        APY_ASSERT(axis < _shape.size());
 
         // Is this dimension going to be summarized?
         bool is_summary_dim = is_summary && (_shape[axis] > 2 * edge_items);
@@ -1668,7 +1668,7 @@ public:
         std::size_t summary_edge_items = 3
     ) const
     {
-        assert(formatters.size());
+        APY_ASSERT(formatters.size());
         if (_nitems == 0) {
             using VEC_T = std::vector<std::vector<std::string>>;
             std::string brackets = std::string(_ndim, '[') + std::string(_ndim, ']');
@@ -1685,14 +1685,14 @@ public:
         std::vector<std::vector<std::string>> formats {};
         for (auto&& formatter : formatters) {
             auto format = _array_format_apply_formatter(formatter, padding);
-            assert(format.size() == _nitems);
+            APY_ASSERT(format.size() == _nitems);
             formats.emplace_back(std::move(format));
         }
-        assert(formats.size() == formatters.size());
+        APY_ASSERT(formats.size() == formatters.size());
 
         // Determine number of elements to display on each line (number of columns)
         std::size_t element_width = formats[0][0].length();
-        assert(element_width > 0);
+        APY_ASSERT(element_width > 0);
 
         // Determine if summary view should be used
         bool is_summary = is_summary_allow && (_nitems > summary_threshold_nitems);

--- a/src/apycfixed.cc
+++ b/src/apycfixed.cc
@@ -24,7 +24,6 @@ namespace nb = nanobind;
 
 // Standard header includes
 #include <algorithm> // std::copy, std::max, std::transform, etc...
-#include <cassert>   // assert()
 #include <cmath>     // std::isinf, std::isnan
 #include <cstring>   // std::memcpy
 #include <iterator>  // std::back_inserter
@@ -130,8 +129,8 @@ template <typename _IT>
 APyCFixed::APyCFixed(int bits, int int_bits, _IT begin, _IT end)
     : APyCFixed(bits, int_bits)
 {
-    assert(std::distance(begin, end) >= 0);
-    assert(std::distance(begin, end) <= 2 * ptrdiff_t(bits_to_limbs(bits)));
+    APY_ASSERT(std::distance(begin, end) >= 0);
+    APY_ASSERT(std::distance(begin, end) <= 2 * ptrdiff_t(bits_to_limbs(bits)));
 
     // Copy data into resulting vector
     std::copy(begin, end, _data.begin());
@@ -323,7 +322,7 @@ APyCFixed APyCFixed::operator/(const APyCFixed& rhs) const
         __int128 rhs_real, rhs_imag;
         // div_bits = bits() + 2 * rhs.bits() + 1, so rhs.bits() is guaranteed to be <=
         // APY_LIMB_SIZE_BITS
-        assert(unsigned(rhs.bits()) <= APY_LIMB_SIZE_BITS);
+        APY_ASSERT(unsigned(rhs.bits()) <= APY_LIMB_SIZE_BITS);
         rhs_real = (__int128)apy_limb_signed_t(rhs._data[0]);
         rhs_imag = (__int128)apy_limb_signed_t(rhs._data[1]);
         __int128 lhs_real, lhs_imag;
@@ -359,7 +358,7 @@ APyCFixed APyCFixed::operator/(const APyCFixed& rhs) const
         std::int64_t rhs_real, rhs_imag;
         // div_bits = bits() + 2 * rhs.bits() + 1, so rhs.bits() is guaranteed to be <=
         // APY_LIMB_SIZE_BITS
-        assert(unsigned(rhs.bits()) <= APY_LIMB_SIZE_BITS);
+        APY_ASSERT(unsigned(rhs.bits()) <= APY_LIMB_SIZE_BITS);
         rhs_real = (std::int64_t)apy_limb_signed_t(rhs._data[0]);
         rhs_imag = (std::int64_t)apy_limb_signed_t(rhs._data[1]);
         std::int64_t lhs_real, lhs_imag;
@@ -699,7 +698,7 @@ APyCFixed APyCFixed::rdiv(const APyFixed& lhs) const
 #if (COMPILER_LIMB_SIZE == 64)
 #if defined(__SIZEOF_INT128__)
     if (unsigned(div_bits) <= 2 * APY_LIMB_SIZE_BITS) {
-        assert(unsigned(bits()) <= APY_LIMB_SIZE_BITS);
+        APY_ASSERT(unsigned(bits()) <= APY_LIMB_SIZE_BITS);
         if (unsigned(lhs.bits()) <= APY_LIMB_SIZE_BITS) {
             __int128 num = (__int128)apy_limb_signed_t(lhs._data[0]);
             __int128 den_real = (__int128)apy_limb_signed_t(_data[0]);
@@ -719,7 +718,7 @@ APyCFixed APyCFixed::rdiv(const APyFixed& lhs) const
                 result._data[3] = apy_limb_t(res_imag >> APY_LIMB_SIZE_BITS);
             }
         } else {
-            assert(unsigned(res_bits) > APY_LIMB_SIZE_BITS);
+            APY_ASSERT(unsigned(res_bits) > APY_LIMB_SIZE_BITS);
             __int128 num = (__int128)(lhs._data[0])
                 | ((__int128)apy_limb_signed_t(lhs._data[1]) << APY_LIMB_SIZE_BITS);
             __int128 den_real = (__int128)apy_limb_signed_t(_data[0]);
@@ -740,7 +739,7 @@ APyCFixed APyCFixed::rdiv(const APyFixed& lhs) const
 #endif
 #if (COMPILER_LIMB_SIZE == 32)
     if (unsigned(div_bits) <= 2 * APY_LIMB_SIZE_BITS) {
-        assert(unsigned(bits()) <= APY_LIMB_SIZE_BITS);
+        APY_ASSERT(unsigned(bits()) <= APY_LIMB_SIZE_BITS);
         if (unsigned(lhs.bits()) <= APY_LIMB_SIZE_BITS) {
             std::int64_t num = (std::int64_t)apy_limb_signed_t(lhs._data[0]);
             std::int64_t den_real = (std::int64_t)apy_limb_signed_t(_data[0]);
@@ -760,7 +759,7 @@ APyCFixed APyCFixed::rdiv(const APyFixed& lhs) const
                 result._data[3] = apy_limb_t(res_imag >> APY_LIMB_SIZE_BITS);
             }
         } else {
-            assert(unsigned(res_bits) > APY_LIMB_SIZE_BITS);
+            APY_ASSERT(unsigned(res_bits) > APY_LIMB_SIZE_BITS);
             std::int64_t num = (std::int64_t)(lhs._data[0])
                 | ((std::int64_t)apy_limb_signed_t(lhs._data[1]) << APY_LIMB_SIZE_BITS);
             std::int64_t den_real = (std::int64_t)apy_limb_signed_t(_data[0]);
@@ -1317,8 +1316,8 @@ APyCFixed APyCFixed::from_double(
         int frac_bits = result.frac_bits();
         result._data[0] = fixed_point_from_double_single_limb(value, frac_bits, shift);
     } else {
-        assert(result._data.size() >= 4);
-        assert(result._data.size() % 2 == 0);
+        APY_ASSERT(result._data.size() >= 4);
+        APY_ASSERT(result._data.size() % 2 == 0);
         fixed_point_from_double(
             value,
             result.real_begin(),
@@ -1376,8 +1375,8 @@ APyCFixed APyCFixed::from_complex(
         result._data[0] = fixed_point_from_double_single_limb(real, frac_bits, shift);
         result._data[1] = fixed_point_from_double_single_limb(imag, frac_bits, shift);
     } else {
-        assert(result._data.size() >= 4);
-        assert(result._data.size() % 2 == 0);
+        APY_ASSERT(result._data.size() >= 4);
+        APY_ASSERT(result._data.size() % 2 == 0);
         fixed_point_from_double(
             real, result.real_begin(), result.real_end(), result._bits, result._int_bits
         );

--- a/src/apycfixed_util.h
+++ b/src/apycfixed_util.h
@@ -482,8 +482,8 @@ struct ComplexRealFixedPointInnerProduct {
         op2_abs = ScratchVector<apy_limb_t, 8>(src2_limbs);
 
         if (acc_mode.has_value()) {
-            assert(acc_mode->bits == dst_spec.bits);
-            assert(acc_mode->int_bits == dst_spec.int_bits);
+            APY_ASSERT(acc_mode->bits == dst_spec.bits);
+            APY_ASSERT(acc_mode->int_bits == dst_spec.int_bits);
             product_bits = src1_spec.bits + src2_spec.bits;
             product_int_bits = src1_spec.int_bits + src2_spec.int_bits;
             f = &F::inner_product</*is_acc_context=*/true>;
@@ -512,9 +512,9 @@ private:
         CIt src1, CIt src2, It dst, std::size_t N, std::size_t M, std::size_t DST_STEP
     ) const
     {
-        assert(src1_limbs == 1);
-        assert(src2_limbs == 1);
-        assert(dst_limbs == 1);
+        APY_ASSERT(src1_limbs == 1);
+        APY_ASSERT(src2_limbs == 1);
+        APY_ASSERT(dst_limbs == 1);
         for (std::size_t m = 0; m < M; m++) {
             auto A_it = src1 + 2 * N * m;
             auto b_it = src2;
@@ -532,9 +532,9 @@ private:
         CIt src1, CIt src2, It dst, std::size_t N, std::size_t M, std::size_t DST_STEP
     ) const
     {
-        assert(src1_limbs == 1);
-        assert(src2_limbs == 1);
-        assert(dst_limbs == 2);
+        APY_ASSERT(src1_limbs == 1);
+        APY_ASSERT(src2_limbs == 1);
+        APY_ASSERT(dst_limbs == 2);
 
         for (std::size_t m = 0; m < M; m++) {
             auto A_it = src1 + 2 * N * m;
@@ -854,8 +854,8 @@ struct ComplexFixedPointInnerProduct {
 
         if (acc_mode.has_value()) {
             // Accumulator mode set, use the accumulator inner product
-            assert(acc_mode->bits == dst_spec.bits);
-            assert(acc_mode->int_bits == dst_spec.int_bits);
+            APY_ASSERT(acc_mode->bits == dst_spec.bits);
+            APY_ASSERT(acc_mode->int_bits == dst_spec.int_bits);
             product_bits = src1_spec.bits + src2_spec.bits;
             product_int_bits = src1_spec.int_bits + src2_spec.int_bits;
             f = &F::inner_product</*is_acc_context=*/true>;
@@ -887,9 +887,9 @@ private:
         CIt src1, CIt src2, It dst, std::size_t N, std::size_t M, std::size_t DST_STEP
     ) const
     {
-        assert(src1_limbs == 1);
-        assert(src2_limbs == 1);
-        assert(dst_limbs == 1);
+        APY_ASSERT(src1_limbs == 1);
+        APY_ASSERT(src2_limbs == 1);
+        APY_ASSERT(dst_limbs == 1);
         for (std::size_t m = 0; m < M; m++) {
             auto A_it = src1 + 2 * N * m;
             auto acc = dst + m * 2 * DST_STEP;
@@ -908,9 +908,9 @@ private:
         CIt src1, CIt src2, It dst, std::size_t N, std::size_t M, std::size_t DST_STEP
     ) const
     {
-        assert(src1_limbs == 1);
-        assert(src2_limbs == 1);
-        assert(dst_limbs == 2);
+        APY_ASSERT(src1_limbs == 1);
+        APY_ASSERT(src2_limbs == 1);
+        APY_ASSERT(dst_limbs == 2);
 
         for (std::size_t m = 0; m < M; m++) {
             auto A_it = src1 + 2 * N * m;

--- a/src/apycfixedarray.cc
+++ b/src/apycfixedarray.cc
@@ -69,7 +69,7 @@ APyCFixedArray::APyCFixedArray(
     auto python_objs = python_iterable_walk<nb::int_>(seq, "APyCFixedArray.__init__");
 
     // If the walked sequence of Python integers is
-    assert(python_objs.size() == _nitems || python_objs.size() == 2 * _nitems);
+    APY_ASSERT(python_objs.size() == _nitems || python_objs.size() == 2 * _nitems);
     bool is_inner_dim_complex = (python_objs.size() == 2 * _nitems);
 
     if (is_inner_dim_complex) {
@@ -523,7 +523,7 @@ APyCFixedArray APyCFixedArray::operator*(const APyCFixedArray& rhs) const
                 }
             }
         } else {
-            assert(unsigned(rhs.bits()) <= APY_LIMB_SIZE_BITS);
+            APY_ASSERT(unsigned(rhs.bits()) <= APY_LIMB_SIZE_BITS);
             // Left-hand side does not fit in single limb, but right-hand side does.
             VECTORIZE_LOOP
             for (std::size_t i = 0; i < result._nitems * 2; i += 2) {
@@ -696,7 +696,7 @@ APyCFixedArray APyCFixedArray::operator*(const APyCFixed& rhs) const
                 }
             }
         } else {
-            assert(unsigned(rhs.bits()) <= APY_LIMB_SIZE_BITS);
+            APY_ASSERT(unsigned(rhs.bits()) <= APY_LIMB_SIZE_BITS);
             // Left-hand side does not fit in single limb, but right-hand side does.
             VECTORIZE_LOOP
             for (std::size_t i = 0; i < result._nitems * 2; i += 2) {
@@ -779,7 +779,7 @@ APyCFixedArray APyCFixedArray::operator*(const APyFixed& rhs) const
             }
             return result; // early exit
         } else {
-            assert(unsigned(rhs.bits()) <= APY_LIMB_SIZE_BITS);
+            APY_ASSERT(unsigned(rhs.bits()) <= APY_LIMB_SIZE_BITS);
             VECTORIZE_LOOP
             for (std::size_t i = 0; i < result._nitems; i++) {
                 complex_real_multiplication_2_1_2(
@@ -903,7 +903,7 @@ APyCFixedArray APyCFixedArray::operator/(const APyFixedArray& rhs) const
                 }
             }
         } else {
-            assert(unsigned(bits()) <= APY_LIMB_SIZE_BITS);
+            APY_ASSERT(unsigned(bits()) <= APY_LIMB_SIZE_BITS);
             for (std::size_t i = 0; i < _nitems; i++) {
                 denominator = (__int128)rhs._data[2 * i];
                 denominator |= (__int128)(apy_limb_signed_t)rhs._data[2 * i + 1]
@@ -985,7 +985,7 @@ APyCFixedArray APyCFixedArray::operator/(const APyFixedArray& rhs) const
                 }
             }
         } else {
-            assert(unsigned(bits()) <= APY_LIMB_SIZE_BITS);
+            APY_ASSERT(unsigned(bits()) <= APY_LIMB_SIZE_BITS);
             for (std::size_t i = 0; i < _nitems; i++) {
                 denominator = (std::int64_t)rhs._data[2 * i];
                 denominator |= (std::int64_t)(apy_limb_signed_t)rhs._data[2 * i + 1]
@@ -1259,7 +1259,7 @@ APyCFixedArray APyCFixedArray::operator/(const APyCFixedArray& rhs) const
         //          2 * rhs.bits()
         // Denominator is always single limb, so we can use 128-bit integer for
         // intermediate result without overflow
-        assert(unsigned(rhs.bits()) <= APY_LIMB_SIZE_BITS);
+        APY_ASSERT(unsigned(rhs.bits()) <= APY_LIMB_SIZE_BITS);
         auto rhs_bits = unsigned(rhs.bits());
         // Check for pairwise-zero complex denominators
         if (simd::vector_any_zero_pairwise(rhs._data.begin(), rhs._data.size())) {
@@ -1308,7 +1308,7 @@ APyCFixedArray APyCFixedArray::operator/(const APyCFixedArray& rhs) const
         } else {
             // If left-hand side does not fit in single limb, then result also
             // cannot fit in single limb.
-            assert(unsigned(res_bits) > APY_LIMB_SIZE_BITS);
+            APY_ASSERT(unsigned(res_bits) > APY_LIMB_SIZE_BITS);
             for (std::size_t i = 0; i < result._nitems * 4; i += 4) {
                 __int128 den_real
                     = (__int128)apy_limb_signed_t(rhs._data[(i >> 1) + 0]);
@@ -1343,7 +1343,7 @@ APyCFixedArray APyCFixedArray::operator/(const APyCFixedArray& rhs) const
         //          2 * rhs.bits()
         // Denominator is always single limb, so we can use 128-bit integer for
         // intermediate result without overflow
-        assert(unsigned(rhs.bits()) <= APY_LIMB_SIZE_BITS);
+        APY_ASSERT(unsigned(rhs.bits()) <= APY_LIMB_SIZE_BITS);
         auto rhs_bits = unsigned(rhs.bits());
         // Check for pairwise-zero complex denominators
         if (simd::vector_any_zero_pairwise(rhs._data.begin(), rhs._data.size())) {
@@ -1395,7 +1395,7 @@ APyCFixedArray APyCFixedArray::operator/(const APyCFixedArray& rhs) const
         } else {
             // If left-hand side does not fit in single limb, then result also
             // cannot fit in single limb.
-            assert(unsigned(res_bits) > APY_LIMB_SIZE_BITS);
+            APY_ASSERT(unsigned(res_bits) > APY_LIMB_SIZE_BITS);
             for (std::size_t i = 0; i < result._nitems * 4; i += 4) {
                 std::int64_t den_real
                     = (std::int64_t)apy_limb_signed_t(rhs._data[(i >> 1) + 0]);
@@ -1518,7 +1518,7 @@ APyCFixedArray APyCFixedArray::operator/(const APyCFixed& rhs) const
         //          2 * rhs.bits()
         // Denominator is always single limb, so we can use 128-bit integer for
         // intermediate result without overflow
-        assert(unsigned(rhs.bits()) <= APY_LIMB_SIZE_BITS);
+        APY_ASSERT(unsigned(rhs.bits()) <= APY_LIMB_SIZE_BITS);
         __int128 den_real = (__int128)apy_limb_signed_t(rhs._data[0]);
         __int128 den_imag = (__int128)apy_limb_signed_t(rhs._data[1]);
         __int128 den = den_real * den_real + den_imag * den_imag;
@@ -1558,7 +1558,7 @@ APyCFixedArray APyCFixedArray::operator/(const APyCFixed& rhs) const
         } else {
             // If left-hand side does not fit in single limb, then result also
             // cannot fit in single limb.
-            assert(unsigned(res_bits) > APY_LIMB_SIZE_BITS);
+            APY_ASSERT(unsigned(res_bits) > APY_LIMB_SIZE_BITS);
             VECTORIZE_LOOP
             for (std::size_t i = 0; i < result._nitems * 4; i += 4) {
                 __int128 num_real = (__int128)(_data[i + 0])
@@ -1589,7 +1589,7 @@ APyCFixedArray APyCFixedArray::operator/(const APyCFixed& rhs) const
         //          2 * rhs.bits()
         // Denominator is always single limb, so we can use 128-bit integer for
         // intermediate result without overflow
-        assert(unsigned(rhs.bits()) <= APY_LIMB_SIZE_BITS);
+        APY_ASSERT(unsigned(rhs.bits()) <= APY_LIMB_SIZE_BITS);
         std::int64_t den_real = (std::int64_t)apy_limb_signed_t(rhs._data[0]);
         std::int64_t den_imag = (std::int64_t)apy_limb_signed_t(rhs._data[1]);
         std::int64_t den = den_real * den_real + den_imag * den_imag;
@@ -1631,7 +1631,7 @@ APyCFixedArray APyCFixedArray::operator/(const APyCFixed& rhs) const
         } else {
             // If left-hand side does not fit in single limb, then result also
             // cannot fit in single limb.
-            assert(unsigned(res_bits) > APY_LIMB_SIZE_BITS);
+            APY_ASSERT(unsigned(res_bits) > APY_LIMB_SIZE_BITS);
             VECTORIZE_LOOP
             for (std::size_t i = 0; i < result._nitems * 4; i += 4) {
                 std::int64_t num_real = (std::int64_t)(_data[i + 0])
@@ -1769,7 +1769,7 @@ APyCFixedArray APyCFixedArray::rdiv_real(const APyFixed& lhs) const
 #if defined(__SIZEOF_INT128__)
     // Double limb result specialization
     if (unsigned(div_bits) <= 2 * APY_LIMB_SIZE_BITS) {
-        assert(unsigned(bits()) <= APY_LIMB_SIZE_BITS);
+        APY_ASSERT(unsigned(bits()) <= APY_LIMB_SIZE_BITS);
         if (unsigned(lhs.bits()) <= APY_LIMB_SIZE_BITS) {
             __int128 num = (__int128)apy_limb_signed_t(lhs._data[0]);
             if (unsigned(res_bits) <= APY_LIMB_SIZE_BITS) {
@@ -1813,7 +1813,7 @@ APyCFixedArray APyCFixedArray::rdiv_real(const APyFixed& lhs) const
                 }
             }
         } else {
-            assert(unsigned(res_bits) > APY_LIMB_SIZE_BITS);
+            APY_ASSERT(unsigned(res_bits) > APY_LIMB_SIZE_BITS);
             __int128 num = (__int128)(lhs._data[0])
                 | (__int128)apy_limb_signed_t(lhs._data[1]) << APY_LIMB_SIZE_BITS;
 
@@ -1846,7 +1846,7 @@ APyCFixedArray APyCFixedArray::rdiv_real(const APyFixed& lhs) const
 #elif (COMPILER_LIMB_SIZE == 32)
     // Double limb result specialization
     if (unsigned(div_bits) <= 2 * APY_LIMB_SIZE_BITS) {
-        assert(unsigned(bits()) <= APY_LIMB_SIZE_BITS);
+        APY_ASSERT(unsigned(bits()) <= APY_LIMB_SIZE_BITS);
         if (unsigned(lhs.bits()) <= APY_LIMB_SIZE_BITS) {
             std::int64_t num = (std::int64_t)apy_limb_signed_t(lhs._data[0]);
             if (unsigned(res_bits) <= APY_LIMB_SIZE_BITS) {
@@ -1894,7 +1894,7 @@ APyCFixedArray APyCFixedArray::rdiv_real(const APyFixed& lhs) const
                 }
             }
         } else {
-            assert(unsigned(res_bits) > APY_LIMB_SIZE_BITS);
+            APY_ASSERT(unsigned(res_bits) > APY_LIMB_SIZE_BITS);
             std::int64_t num = (std::int64_t)(lhs._data[0])
                 | (std::int64_t)apy_limb_signed_t(lhs._data[1]) << APY_LIMB_SIZE_BITS;
 
@@ -2022,7 +2022,7 @@ APyCFixedArray APyCFixedArray::rdiv(const APyCFixed& lhs) const
         //          2 * rhs.bits()
         // Denominator is always single limb, so we can use 128-bit integer for
         // intermediate result without overflow
-        assert(unsigned(bits()) <= APY_LIMB_SIZE_BITS);
+        APY_ASSERT(unsigned(bits()) <= APY_LIMB_SIZE_BITS);
         // Check for pairwise-zero complex denominators
         if (simd::vector_any_zero_pairwise(_data.begin(), _data.size())) {
             PyErr_SetString(PyExc_ZeroDivisionError, "fixed-point division by zero");
@@ -2063,7 +2063,7 @@ APyCFixedArray APyCFixedArray::rdiv(const APyCFixed& lhs) const
         } else {
             // If left-hand side does not fit in single limb, then result also
             // cannot fit in single limb.
-            assert(unsigned(res_bits) > APY_LIMB_SIZE_BITS);
+            APY_ASSERT(unsigned(res_bits) > APY_LIMB_SIZE_BITS);
             __int128 num_real = (__int128)(lhs._data[0])
                 | (__int128)apy_limb_signed_t(lhs._data[1]) << APY_LIMB_SIZE_BITS;
             __int128 num_imag = (__int128)(lhs._data[2])
@@ -2105,7 +2105,7 @@ APyCFixedArray APyCFixedArray::rdiv(const APyCFixed& lhs) const
         //          2 * rhs.bits()
         // Denominator is always single limb, so we can use 128-bit integer for
         // intermediate result without overflow
-        assert(unsigned(bits()) <= APY_LIMB_SIZE_BITS);
+        APY_ASSERT(unsigned(bits()) <= APY_LIMB_SIZE_BITS);
         // Check for pairwise-zero complex denominators
         if (simd::vector_any_zero_pairwise(_data.begin(), _data.size())) {
             PyErr_SetString(PyExc_ZeroDivisionError, "fixed-point division by zero");
@@ -2150,7 +2150,7 @@ APyCFixedArray APyCFixedArray::rdiv(const APyCFixed& lhs) const
         } else {
             // If left-hand side does not fit in single limb, then result also
             // cannot fit in single limb.
-            assert(unsigned(res_bits) > APY_LIMB_SIZE_BITS);
+            APY_ASSERT(unsigned(res_bits) > APY_LIMB_SIZE_BITS);
             std::int64_t num_real = (std::int64_t)(lhs._data[0])
                 | (std::int64_t)apy_limb_signed_t(lhs._data[1]) << APY_LIMB_SIZE_BITS;
             std::int64_t num_imag = (std::int64_t)(lhs._data[2])
@@ -2597,7 +2597,7 @@ APyCFixedArray APyCFixedArray::conj() const
         }
     } else {
         // No additional limbs required
-        assert(_itemsize == res._itemsize);
+        APY_ASSERT(_itemsize == res._itemsize);
         const std::size_t DST_N = res._itemsize / 2;
         for (std::size_t i = 0; i < res._nitems; i++) {
             auto src = std::begin(_data) + i * _itemsize;
@@ -2870,8 +2870,8 @@ APyCFixedArray APyCFixedArray::from_complex(
                 = fixed_point_from_double_single_limb(val, res.frac_bits(), shift);
         };
     } else {
-        assert(result._itemsize >= 4);
-        assert(result._itemsize % 2 == 0);
+        APY_ASSERT(result._itemsize >= 4);
+        APY_ASSERT(result._itemsize % 2 == 0);
         from_fp = [](APyCFixedArray& res, std::size_t i, double val, unsigned) {
             fixed_point_from_double(
                 val,
@@ -3059,7 +3059,7 @@ bool APyCFixedArray::_check_and_set_bits_from_ndarray(
 )
 {
     static_assert(APY_LIMB_SIZE_BITS == 32 || APY_LIMB_SIZE_BITS == 64);
-    assert(ndarray.ndim() > 0);
+    APY_ASSERT(ndarray.ndim() > 0);
 
     bool is_complex_collapse = ndarray.shape(ndarray.ndim() - 1) == 2;
     std::size_t data_offset = is_complex_collapse ? (_itemsize / 2) : _itemsize;
@@ -3156,8 +3156,8 @@ void APyCFixedArray::_set_values_from_ndarray(const nb::ndarray<nb::c_contig>& n
                     );                                                                 \
                 }                                                                      \
             } else {                                                                   \
-                assert(_itemsize >= 4);                                                \
-                assert(_itemsize % 2 == 0);                                            \
+                APY_ASSERT(_itemsize >= 4);                                            \
+                APY_ASSERT(_itemsize % 2 == 0);                                        \
                 for (std::size_t i = 0; i < ndarray.size(); i++) {                     \
                     std::complex<double> cplx = view.data()[i];                        \
                     fixed_point_from_double(                                           \
@@ -3195,8 +3195,8 @@ void APyCFixedArray::_set_values_from_ndarray(const nb::ndarray<nb::c_contig>& n
                     _data[2 * i + 1] = 0;                                              \
                 }                                                                      \
             } else {                                                                   \
-                assert(_itemsize >= 4);                                                \
-                assert(_itemsize % 2 == 0);                                            \
+                APY_ASSERT(_itemsize >= 4);                                            \
+                APY_ASSERT(_itemsize % 2 == 0);                                        \
                 for (std::size_t i = 0; i < ndarray.size(); i++) {                     \
                     fixed_point_from_double(                                           \
                         view.data()[i],                                                \
@@ -3264,8 +3264,8 @@ APyCFixedArray::matmul(const APyCFixedArray& rhs) const
 {
     using RESULT_TYPE = std::variant<APyCFixedArray, APyCFixed>;
 
-    assert(ndim() >= 1);
-    assert(rhs.ndim() >= 1);
+    APY_ASSERT(ndim() >= 1);
+    APY_ASSERT(rhs.ndim() >= 1);
 
     if (ndim() == 1 && rhs.ndim() == 1) {
         if (_shape[0] == rhs._shape[0]) {
@@ -3311,8 +3311,8 @@ APyCFixedArray::matmul(const APyFixedArray& rhs) const
 {
     using RESULT_TYPE = std::variant<APyCFixedArray, APyCFixed>;
 
-    assert(ndim() >= 1);
-    assert(rhs.ndim() >= 1);
+    APY_ASSERT(ndim() >= 1);
+    APY_ASSERT(rhs.ndim() >= 1);
 
     if (ndim() == 1 && rhs.ndim() == 1) {
         if (_shape[0] == rhs._shape[0]) {
@@ -3351,8 +3351,8 @@ APyCFixedArray::rmatmul(const APyFixedArray& lhs) const
 {
     using RESULT_TYPE = std::variant<APyCFixedArray, APyCFixed>;
 
-    assert(lhs.ndim() >= 1);
-    assert(ndim() >= 1);
+    APY_ASSERT(lhs.ndim() >= 1);
+    APY_ASSERT(ndim() >= 1);
 
     if (lhs.ndim() == 1 && ndim() == 1) {
         if (lhs._shape[0] == _shape[0]) {
@@ -3548,7 +3548,7 @@ APyCFixedArray APyCFixedArray::outer_product(const APyCFixedArray& rhs) const
                 }
             }
         } else {
-            assert(unsigned(rhs.bits()) <= APY_LIMB_SIZE_BITS);
+            APY_ASSERT(unsigned(rhs.bits()) <= APY_LIMB_SIZE_BITS);
             // Left operand uses two limbs, right operand fits in one limb.
             auto size = res._itemsize * rhs._shape[0];
             for (std::size_t y = 0; y < _shape[0]; y++) {

--- a/src/apycfloat.h
+++ b/src/apycfloat.h
@@ -44,7 +44,7 @@ public:
     {
         using iterator_value_type = typename RANDOM_ACCESS_ITERATOR::value_type;
         static_assert(std::is_same_v<iterator_value_type, APyFloatData>);
-        assert(n == 2);
+        APY_ASSERT(n == 2);
 
         real() = src_it[0];
         imag() = src_it[1];
@@ -58,7 +58,7 @@ public:
     {
         using iterator_value_type = typename RANDOM_ACCESS_ITERATOR::value_type;
         static_assert(std::is_same_v<iterator_value_type, APyFloatData>);
-        assert(n == 2);
+        APY_ASSERT(n == 2);
 
         dst_it[0] = real();
         dst_it[1] = imag();

--- a/src/apycfloatarray.cc
+++ b/src/apycfloatarray.cc
@@ -112,8 +112,8 @@ APyCFloatArray::APyCFloatArray(
     auto mans = python_iterable_walk<nb::int_>(man_seq, NAME);
 
     // If the walked sequence of Python integers is
-    assert(signs.size() == exps.size() && signs.size() == mans.size());
-    assert(signs.size() == _nitems || signs.size() == 2 * _nitems);
+    APY_ASSERT(signs.size() == exps.size() && signs.size() == mans.size());
+    APY_ASSERT(signs.size() == _nitems || signs.size() == 2 * _nitems);
     bool is_inner_dim_complex = (signs.size() == 2 * _nitems);
 
     std::size_t complex_multiplier = is_inner_dim_complex ? 1 : 2;
@@ -396,7 +396,7 @@ void APyCFloatArray::_set_values_from_ndarray(const nb::ndarray<nb::c_contig>& n
 
 void APyCFloatArray::_set_sign_bits_from_ndarray(const nb::ndarray<nb::c_contig>& array)
 {
-    assert(array.ndim() == _ndim || array.ndim() - 1 == _ndim);
+    APY_ASSERT(array.ndim() == _ndim || array.ndim() - 1 == _ndim);
 
     if (_check_and_set_sign_bits_from_ndarray<bool>(array))
         return;
@@ -429,7 +429,7 @@ void APyCFloatArray::_set_sign_bits_from_ndarray(const nb::ndarray<nb::c_contig>
 
 void APyCFloatArray::_set_exp_bits_from_ndarray(const nb::ndarray<nb::c_contig>& array)
 {
-    assert(array.ndim() == _ndim || array.ndim() - 1 == _ndim);
+    APY_ASSERT(array.ndim() == _ndim || array.ndim() - 1 == _ndim);
 
     if (_check_and_set_exp_bits_from_ndarray<std::int64_t>(array))
         return;
@@ -460,7 +460,7 @@ void APyCFloatArray::_set_exp_bits_from_ndarray(const nb::ndarray<nb::c_contig>&
 
 void APyCFloatArray::_set_man_bits_from_ndarray(const nb::ndarray<nb::c_contig>& array)
 {
-    assert(array.ndim() == _ndim || array.ndim() - 1 == _ndim);
+    APY_ASSERT(array.ndim() == _ndim || array.ndim() - 1 == _ndim);
 
     if (_check_and_set_man_bits_from_ndarray<std::int64_t>(array))
         return;
@@ -502,7 +502,7 @@ APyCFloatArray APyCFloatArray::from_bits(
     if (nb::isinstance<nb::ndarray<>>(seq)) {
         const auto ndarray = nb::cast<nb::ndarray<nb::c_contig>>(seq);
 
-        assert(ndarray.ndim() > 0);
+        APY_ASSERT(ndarray.ndim() > 0);
         std::vector<std::size_t> shape(ndarray.ndim(), 0);
         VECTORIZE_LOOP
         for (std::size_t i = 0; i < ndarray.ndim(); i++) {
@@ -534,7 +534,7 @@ APyCFloatArray APyCFloatArray::from_bits(
     auto python_objs = python_iterable_walk<nb::int_>(seq, "APyCFloatArray.from_bits");
 
     // If the walked sequence of Python integers is
-    assert(
+    APY_ASSERT(
         python_objs.size() == result._nitems || python_objs.size() == 2 * result._nitems
     );
     bool is_inner_dim_complex = (python_objs.size() == 2 * result._nitems);
@@ -1531,8 +1531,8 @@ APyCFloatArray APyCFloatArray::nancumprod(std::optional<nb::int_> py_axis) const
 std::variant<APyCFloatArray, APyCFloat>
 APyCFloatArray::matmul(const APyCFloatArray& rhs) const
 {
-    assert(ndim() >= 1);
-    assert(rhs.ndim() >= 1);
+    APY_ASSERT(ndim() >= 1);
+    APY_ASSERT(rhs.ndim() >= 1);
 
     using RESULT_TYPE = std::variant<APyCFloatArray, APyCFloat>;
     if (ndim() == 1 && rhs.ndim() == 1) {

--- a/src/apyfixed.cc
+++ b/src/apyfixed.cc
@@ -24,7 +24,6 @@ namespace nb = nanobind;
 
 // Standard header includes
 #include <algorithm>        // std::copy, std::max, std::transform, etc...
-#include <cassert>          // assert()
 #include <cmath>            // std::isinf, std::isnan
 #include <cstddef>          // std::size_t
 #include <cstring>          // std::memcpy
@@ -78,7 +77,7 @@ template <typename _IT>
 APyFixed::APyFixed(int bits, int int_bits, _IT begin, _IT end)
     : APyFixed(bits, int_bits)
 {
-    assert(std::distance(begin, end) >= 0);
+    APY_ASSERT(std::distance(begin, end) >= 0);
 
     // Copy data into resulting vector
     std::size_t it_elements = std::distance(begin, end);
@@ -1223,7 +1222,7 @@ APyFixed APyFixed::from_double(
         result._data[0]
             = fixed_point_from_double_single_limb(value, result.frac_bits(), shift);
     } else {
-        assert(result._data.size() > 1);
+        APY_ASSERT(result._data.size() > 1);
         fixed_point_from_double(
             value,
             std::begin(result._data),

--- a/src/apyfixed_util.h
+++ b/src/apyfixed_util.h
@@ -485,7 +485,7 @@ static APY_INLINE void _quantize_stoch_weighted(
             limb_vector_asr(it_begin, it_end, bits_to_qntz);
         } else {
             // General path, can quantize infinitely many limbs
-            assert(limbs_to_qntz > 1);
+            APY_ASSERT(limbs_to_qntz > 1);
             ScratchVector<apy_limb_t> rnd_words(limbs_to_qntz);
             for (auto&& rnd_word : rnd_words) {
                 rnd_word = get_random_uint64();
@@ -706,7 +706,7 @@ static APY_INLINE void fixed_point_cast_unsafe(
     OverflowMode v_mode
 )
 {
-    assert(std::distance(src_begin, src_end) <= std::distance(dst_begin, dst_end));
+    APY_ASSERT(std::distance(src_begin, src_end) <= std::distance(dst_begin, dst_end));
 
     // Copy data into the result region and sign extend
     limb_vector_copy_sign_extend(src_begin, src_end, dst_begin, dst_end);
@@ -972,8 +972,8 @@ static APY_INLINE void fixed_point_division_precomputed_denominator(
     ScratchVector<apy_limb_t, 16>& scratch
 )
 {
-    assert(den_significant_limbs > 0);
-    assert(quotient_limbs >= std::distance(numerator_begin, numerator_end));
+    APY_ASSERT(den_significant_limbs > 0);
+    APY_ASSERT(quotient_limbs >= std::distance(numerator_begin, numerator_end));
 
     // Compute absolute value of numerator
     auto abs_num_begin = std::begin(scratch);
@@ -1103,8 +1103,8 @@ struct FixedPointInnerProduct {
             if (dst_limbs == 1) {
                 // Specialization #1: the resulting number of limbs is exactly one and
                 // no accumulator mode has been set. Use the SIMD inner product.
-                assert(src1_limbs == 1);
-                assert(src2_limbs == 1);
+                APY_ASSERT(src1_limbs == 1);
+                APY_ASSERT(src2_limbs == 1);
                 f = &FixedPointInnerProduct::inner_product_simd;
                 return;
             } else if (dst_limbs == 2 && src1_limbs == 1 && src2_limbs == 1) {
@@ -1123,8 +1123,8 @@ struct FixedPointInnerProduct {
 
         if (acc_mode.has_value()) {
             // Accumulator mode set, use the accumulator inner product
-            assert(acc_mode->bits == dst_spec.bits);
-            assert(acc_mode->int_bits == dst_spec.int_bits);
+            APY_ASSERT(acc_mode->bits == dst_spec.bits);
+            APY_ASSERT(acc_mode->int_bits == dst_spec.int_bits);
             product_bits = src1_spec.bits + src2_spec.bits;
             product_int_bits = src1_spec.int_bits + src2_spec.int_bits;
             if (dst_limbs <= src1_limbs + src2_limbs) {
@@ -1164,9 +1164,9 @@ private:
         CIt src1, CIt src2, It dst, std::size_t N, std::size_t M, std::size_t DST_STEP
     ) const
     {
-        assert(src1_limbs == 1);
-        assert(src2_limbs == 1);
-        assert(dst_limbs == 1);
+        APY_ASSERT(src1_limbs == 1);
+        APY_ASSERT(src2_limbs == 1);
+        APY_ASSERT(dst_limbs == 1);
         for (std::size_t m = 0; m < M; m++) {
             dst[m * DST_STEP] = simd::vector_multiply_accumulate(src1 + m * N, src2, N);
         }
@@ -1176,9 +1176,9 @@ private:
         CIt src1, CIt src2, It dst, std::size_t N, std::size_t M, std::size_t DST_STEP
     ) const
     {
-        assert(src1_limbs == 1);
-        assert(src2_limbs == 1);
-        assert(dst_limbs == 2);
+        APY_ASSERT(src1_limbs == 1);
+        APY_ASSERT(src2_limbs == 1);
+        APY_ASSERT(dst_limbs == 2);
         for (std::size_t m = 0; m < M; m++) {
             auto A_it = src1 + src1_limbs * N * m;
 #if (COMPILER_LIMB_SIZE == 64)
@@ -1398,7 +1398,7 @@ void fixed_point_from_double(
          * Limb vector size is *NOT* wide enough to accommodate the full mantissa of a
          * double-precision floating point number.
          */
-        assert(std::distance(begin_it, end_it) >= 2);
+        APY_ASSERT(std::distance(begin_it, end_it) >= 2);
         if (left_shift_amnt >= 0) {
             *(begin_it + 0) = (man & 0xFFFFFFFF);
             *(begin_it + 1) = (man >> 32);
@@ -1465,7 +1465,7 @@ private:
     template <std::size_t CONSTEXPR_N_LIMBS>
     double to_double_direct(RANDOM_ACCESS_IT begin_it, RANDOM_ACCESS_IT end_it) const
     {
-        assert(std::distance(begin_it, end_it) == CONSTEXPR_N_LIMBS);
+        APY_ASSERT(std::distance(begin_it, end_it) == CONSTEXPR_N_LIMBS);
 
         // Unused argument...
         (void)end_it;
@@ -1644,7 +1644,7 @@ void fixed_point_from_integer(
 )
 {
     static_assert(std::is_integral_v<INT_TYPE>, "`INT_TYPE` must be of integer type");
-    assert(begin_it < end_it);
+    APY_ASSERT(begin_it < end_it);
 
     const int frac_bits = bits - int_bits;
     constexpr bool INT_IS_SIGNED = std::is_signed_v<INT_TYPE>;
@@ -1668,7 +1668,7 @@ void fixed_point_from_integer(
         if (std::distance(begin_it, end_it) * APY_LIMB_SIZE_BYTES < sizeof(INT_TYPE)) {
             // The whole integer *does not* fit into the destination limb vector. Shift
             // the data in the temporary array and then copy the result.
-            assert(std::distance(begin_it, end_it) == 1);
+            APY_ASSERT(std::distance(begin_it, end_it) == 1);
             if (frac_bits >= 0) {
                 limb_vector_lsl(std::begin(tmp_arr), std::end(tmp_arr), frac_bits);
             } else {
@@ -1682,7 +1682,7 @@ void fixed_point_from_integer(
         } else {
             // The whole integer fits into the destination limb vector. Copy the data
             // and perform shift on destination limb vector
-            assert(std::distance(begin_it, end_it) >= 2);
+            APY_ASSERT(std::distance(begin_it, end_it) >= 2);
             std::copy_n(std::begin(tmp_arr), 2, begin_it);
             std::fill(begin_it + 2, end_it, limb_fill_val);
             if (frac_bits >= 0) {
@@ -1752,7 +1752,7 @@ static APY_INLINE std::function<
     void(typename VECTOR_TYPE::iterator, typename VECTOR_TYPE::const_iterator)>
 fold_accumulate(std::size_t src_limbs, std::size_t acc_limbs)
 {
-    assert(src_limbs >= 1 && acc_limbs >= 1 && acc_limbs >= src_limbs);
+    APY_ASSERT(src_limbs >= 1 && acc_limbs >= 1 && acc_limbs >= src_limbs);
     if (acc_limbs == 1) {
         /* single limb specialization */
         return [](auto acc_it, auto src_it) { *acc_it += *src_it; };
@@ -1816,7 +1816,7 @@ static APY_INLINE std::function<
     void(typename VECTOR_TYPE::iterator, typename VECTOR_TYPE::const_iterator)>
 fold_complex_accumulate(std::size_t src_limbs, std::size_t acc_limbs)
 {
-    assert(src_limbs >= 1 && acc_limbs >= 1 && acc_limbs >= src_limbs);
+    APY_ASSERT(src_limbs >= 1 && acc_limbs >= 1 && acc_limbs >= src_limbs);
     if (acc_limbs == 1) {
         /* single limb (one real, one imag) specialization */
         return [](auto acc_it, auto src_it) {

--- a/src/apyfixedarray.cc
+++ b/src/apyfixedarray.cc
@@ -488,7 +488,7 @@ APyFixedArray APyFixedArray::operator*(const APyFixedArray& rhs) const
                 result._data[i * 2 + 1] = high + high2;
             }
         } else {
-            assert(unsigned(rhs.bits()) <= APY_LIMB_SIZE_BITS);
+            APY_ASSERT(unsigned(rhs.bits()) <= APY_LIMB_SIZE_BITS);
             // Left-hand side is two limbs, right-hand side is single limb
             VECTORIZE_LOOP
             for (std::size_t i = 0; i < _nitems; i++) {
@@ -662,7 +662,7 @@ APyCFixedArray APyFixedArray::operator*(const APyCFixed& rhs) const
                 return result;
             }
         } else {
-            assert(unsigned(rhs.bits()) <= APY_LIMB_SIZE_BITS);
+            APY_ASSERT(unsigned(rhs.bits()) <= APY_LIMB_SIZE_BITS);
             // Left-hand side is two limbs, right-hand side is single limb
             VECTORIZE_LOOP
             for (std::size_t i = 0; i < _nitems; i++) {
@@ -852,7 +852,7 @@ APyFixedArray APyFixedArray::operator/(const APyFixedArray& rhs) const
                 }
             }
         } else {
-            assert(unsigned(bits()) <= APY_LIMB_SIZE_BITS);
+            APY_ASSERT(unsigned(bits()) <= APY_LIMB_SIZE_BITS);
             VECTORIZE_LOOP
             for (std::size_t i = 0; i < _nitems; i++) {
                 denominator = (__int128)rhs._data[2 * i];
@@ -908,7 +908,7 @@ APyFixedArray APyFixedArray::operator/(const APyFixedArray& rhs) const
                 }
             }
         } else {
-            assert(unsigned(bits()) <= APY_LIMB_SIZE_BITS);
+            APY_ASSERT(unsigned(bits()) <= APY_LIMB_SIZE_BITS);
             VECTORIZE_LOOP
             for (std::size_t i = 0; i < _nitems; i++) {
 
@@ -1067,8 +1067,8 @@ APyFixedArray APyFixedArray::operator/(const APyFixed& rhs) const
     std::size_t den_significant_limbs
         = significant_limbs(std::begin(abs_den), std::end(abs_den));
 
-    assert(den_significant_limbs > 0);
-    assert(result._itemsize >= den_significant_limbs);
+    APY_ASSERT(den_significant_limbs > 0);
+    APY_ASSERT(result._itemsize >= den_significant_limbs);
 
     // Absolute value left-shifted numerator
     ScratchVector<apy_limb_t> abs_num(result._itemsize);
@@ -1081,7 +1081,7 @@ APyFixedArray APyFixedArray::operator/(const APyFixed& rhs) const
         apy_limb_t carry = apy_inplace_left_shift(
             abs_den.begin(), abs_den.begin() + den_significant_limbs, inv.norm_shift
         );
-        assert(carry == 0);
+        APY_ASSERT(carry == 0);
         (void)carry; // Avoid unused-warning
     }
     for (std::size_t i = 0; i < _nitems; i++) {
@@ -1476,8 +1476,8 @@ ThirdPartyArray<bool> APyFixedArray::is_zero() const
 std::variant<APyFixedArray, APyFixed>
 APyFixedArray::matmul(const APyFixedArray& rhs) const
 {
-    assert(ndim() >= 1);
-    assert(rhs.ndim() >= 1);
+    APY_ASSERT(ndim() >= 1);
+    APY_ASSERT(rhs.ndim() >= 1);
 
     using RESULT_TYPE = std::variant<APyFixedArray, APyFixed>;
     if (ndim() == 1 && rhs.ndim() == 1) {
@@ -2223,7 +2223,7 @@ APyFixedArray APyFixedArray::from_numbers(
                 = fixed_point_from_double_single_limb(val, res.frac_bits(), shift);
         };
     } else { /* result._itemsize > 1 */
-        assert(result._itemsize > 1);
+        APY_ASSERT(result._itemsize > 1);
         from_fp = [](APyFixedArray& res, std::size_t i, double val, unsigned) {
             fixed_point_from_double(
                 val,

--- a/src/apyfloat.cc
+++ b/src/apyfloat.cc
@@ -439,7 +439,7 @@ APyFloat& APyFloat::update_from_bits(nb::int_ python_long_int_bit_pattern)
 
 APyFloat& APyFloat::update_from_bits(std::uint64_t bits)
 {
-    assert((1 + exp_bits + man_bits) <= 64);
+    APY_ASSERT((1 + exp_bits + man_bits) <= 64);
 
     man = bits & man_mask();
     bits >>= man_bits;

--- a/src/apyfloat.h
+++ b/src/apyfloat.h
@@ -45,7 +45,7 @@ public:
     {
         using iterator_value_type = typename RANDOM_ACCESS_ITERATOR::value_type;
         static_assert(std::is_same_v<iterator_value_type, APyFloatData>);
-        assert(n == 1);
+        APY_ASSERT(n == 1);
         sign = src_it->sign;
         man = src_it->man;
         exp = src_it->exp;
@@ -59,7 +59,7 @@ public:
     {
         using iterator_value_type = typename RANDOM_ACCESS_ITERATOR::value_type;
         static_assert(std::is_same_v<iterator_value_type, APyFloatData>);
-        assert(n == 1);
+        APY_ASSERT(n == 1);
         dst_it->sign = sign;
         dst_it->man = man;
         dst_it->exp = exp;

--- a/src/apyfloat_util.h
+++ b/src/apyfloat_util.h
@@ -938,7 +938,7 @@ APyFloatData floating_point_from_fixed_point(
     QuantizationMode q_mode = QuantizationMode::RND_CONV
 )
 {
-    assert(std::distance(cbegin_it, cend_it) == ptrdiff_t(bits_to_limbs(bits)));
+    APY_ASSERT(std::distance(cbegin_it, cend_it) == ptrdiff_t(bits_to_limbs(bits)));
 
     if (limb_vector_is_zero(cbegin_it, cend_it)) {
         return { 0, 0, 0 };
@@ -951,7 +951,7 @@ APyFloatData floating_point_from_fixed_point(
 
     // Extract leading zeros in the fixed-point number
     std::size_t fx_lz = limb_vector_leading_zeros(std::begin(fx_abs), std::end(fx_abs));
-    assert(fx_lz > 0);
+    APY_ASSERT(fx_lz > 0);
     std::size_t bits_last_limb = ((bits - 1) % APY_LIMB_SIZE_BITS) + 1;
     fx_lz -= (APY_LIMB_SIZE_BITS - bits_last_limb);
 
@@ -973,7 +973,7 @@ APyFloatData floating_point_from_fixed_point(
     // `fixed_point_cast_unsafe` is safe to use because `fx_man` is guaranteed have as
     // many limbs as `fx_abs`.
     ScratchVector<apy_limb_t, 8> fx_man(bits_to_limbs(std::max(3 + man_bits, bits)));
-    assert(fx_man.size() >= fx_abs.size());
+    APY_ASSERT(fx_man.size() >= fx_abs.size());
     fixed_point_cast_unsafe(
         std::begin(fx_abs), // src_begin
         std::end(fx_abs),   // src_end

--- a/src/apyfloatarray.cc
+++ b/src/apyfloatarray.cc
@@ -414,8 +414,8 @@ template ComparissonArray APyFloatArray::operator>=(const APyFloat& rhs) const;
 std::variant<APyFloatArray, APyFloat>
 APyFloatArray::matmul(const APyFloatArray& rhs) const
 {
-    assert(ndim() >= 1);
-    assert(rhs.ndim() >= 1);
+    APY_ASSERT(ndim() >= 1);
+    APY_ASSERT(rhs.ndim() >= 1);
 
     using RESULT_TYPE = std::variant<APyFloatArray, APyFloat>;
     if (ndim() == 1 && rhs.ndim() == 1) {
@@ -1433,7 +1433,7 @@ APyFloatArray APyFloatArray::from_bits(
     if (nb::isinstance<nb::ndarray<>>(python_bit_patterns)) { // ndarray
         const auto ndarray = nb::cast<nb::ndarray<nb::c_contig>>(python_bit_patterns);
 
-        assert(ndarray.ndim() > 0);
+        APY_ASSERT(ndarray.ndim() > 0);
         std::vector<std::size_t> shape(ndarray.ndim(), 0);
         VECTORIZE_LOOP
         for (std::size_t i = 0; i < ndarray.ndim(); i++) {
@@ -1514,7 +1514,7 @@ void APyFloatArray::_set_bits_from_ndarray(const nb::ndarray<nb::c_contig>& ndar
 
 void APyFloatArray::_set_sign_bits_from_ndarray(const nb::ndarray<nb::c_contig>& array)
 {
-    assert(array.ndim() == _ndim);
+    APY_ASSERT(array.ndim() == _ndim);
 
     if (_check_and_set_sign_bits_from_ndarray<bool>(array))
         return;
@@ -1547,7 +1547,7 @@ void APyFloatArray::_set_sign_bits_from_ndarray(const nb::ndarray<nb::c_contig>&
 
 void APyFloatArray::_set_exp_bits_from_ndarray(const nb::ndarray<nb::c_contig>& array)
 {
-    assert(array.ndim() == _ndim);
+    APY_ASSERT(array.ndim() == _ndim);
 
     if (_check_and_set_exp_bits_from_ndarray<std::int64_t>(array))
         return;
@@ -1578,7 +1578,7 @@ void APyFloatArray::_set_exp_bits_from_ndarray(const nb::ndarray<nb::c_contig>& 
 
 void APyFloatArray::_set_man_bits_from_ndarray(const nb::ndarray<nb::c_contig>& array)
 {
-    assert(array.ndim() == _ndim);
+    APY_ASSERT(array.ndim() == _ndim);
 
     if (_check_and_set_man_bits_from_ndarray<std::int64_t>(array))
         return;

--- a/src/apytypes_fwd.h
+++ b/src/apytypes_fwd.h
@@ -13,6 +13,42 @@
 #include <tuple>
 
 /*
+ * APyTypes debugging assertions
+ */
+
+#ifdef NDEBUG
+
+// When `NDEBUG` is set, `APY_ASSERT(...) will parse the argument list and fail if its
+// expression is semantically erroneous. The compiler will, however, not emit any code
+// after semantically checking the expression.
+#define APY_ASSERT(...) ((void)sizeof(static_cast<bool>(__VA_ARGS__)))
+
+#elif (ASSERTION_STYLE == 1) // 1: python_exception
+
+// When `NDEBUG` is not set and when the `ASSERTION_STYLE` is set to `python_exception`,
+// assertions will throw a std::runtime_error on assertion failure which is translated
+// by nanobind into a `RuntimeError` in the Python environment.
+#define APY_ASSERT(...)                                                                \
+    do {                                                                               \
+        if (!(__VA_ARGS__)) {                                                          \
+            throw std::runtime_error(                                                  \
+                std::string(__FILE__ ":") + std::to_string(__LINE__)                   \
+                + ": assertion failed: " #__VA_ARGS__                                  \
+            );                                                                         \
+        }                                                                              \
+    } while (0)
+
+#else // 2: c_assertion
+
+// When `NDEBUG` is not set and the `ASSERTION_STYLE` is set to `c_assertion`,
+// `APY_ASSERT` will emit regular C assertions that calls `std::abort()` on assertion
+// failure. This will take down the whole Python interpreter.
+#include <cassert>
+#define APY_ASSERT(...) assert((__VA_ARGS__))
+
+#endif
+
+/*
  * Conditional inlining of utility functions if profiling `_APY_PROFILING`
  */
 #ifdef _APY_PROFILING

--- a/src/apytypes_mp.cc
+++ b/src/apytypes_mp.cc
@@ -11,9 +11,9 @@ apy_limb_t apy_inplace_left_shift(
     apy_limb_t* dest, const std::size_t limbs, const unsigned int shift_amount
 )
 {
-    assert(limbs > 0);
-    assert(shift_amount > 0);
-    assert(shift_amount < APY_LIMB_SIZE_BITS);
+    APY_ASSERT(limbs > 0);
+    APY_ASSERT(shift_amount > 0);
+    APY_ASSERT(shift_amount < APY_LIMB_SIZE_BITS);
 
     const unsigned int overlap = APY_LIMB_SIZE_BITS - shift_amount;
     std::size_t n = limbs - 1;
@@ -34,9 +34,9 @@ apy_limb_t apy_inplace_right_shift(
     apy_limb_t* dest, const std::size_t limbs, const unsigned int shift_amount
 )
 {
-    assert(limbs > 0);
-    assert(shift_amount > 0);
-    assert(shift_amount < APY_LIMB_SIZE_BITS);
+    APY_ASSERT(limbs > 0);
+    APY_ASSERT(shift_amount > 0);
+    APY_ASSERT(shift_amount < APY_LIMB_SIZE_BITS);
 
     const unsigned int overlap = APY_LIMB_SIZE_BITS - shift_amount;
     apy_limb_t low_limb = dest[0];
@@ -59,9 +59,9 @@ apy_limb_t apy_left_shift(
     const unsigned int shift_amount
 )
 {
-    assert(limbs > 0);
-    assert(shift_amount > 0);
-    assert(shift_amount < APY_LIMB_SIZE_BITS);
+    APY_ASSERT(limbs > 0);
+    APY_ASSERT(shift_amount > 0);
+    APY_ASSERT(shift_amount < APY_LIMB_SIZE_BITS);
 
     const unsigned int overlap = APY_LIMB_SIZE_BITS - shift_amount;
     std::size_t n = limbs - 1;
@@ -87,9 +87,9 @@ apy_limb_t apy_rshift(
     const unsigned int shift_amount
 )
 {
-    assert(limbs > 0);
-    assert(shift_amount > 0);
-    assert(shift_amount < APY_LIMB_SIZE_BITS);
+    APY_ASSERT(limbs > 0);
+    APY_ASSERT(shift_amount > 0);
+    APY_ASSERT(shift_amount < APY_LIMB_SIZE_BITS);
 
     const unsigned int overlap = APY_LIMB_SIZE_BITS - shift_amount;
     apy_limb_t low_limb = *src++;
@@ -115,7 +115,7 @@ apy_limb_t apy_submul_single_limb(
     apy_limb_t* dest, const apy_limb_t* src0, std::size_t limbs, apy_limb_t src1
 )
 {
-    assert(limbs > 0);
+    APY_ASSERT(limbs > 0);
 
     // TODO: Rewrite to use __int128 on supported architectures
     auto [carry, subtrahend] = long_unsigned_mult(src0[0], src1);
@@ -140,8 +140,8 @@ apy_limb_t apy_unsigned_multiplication(
     const std::size_t src1_limbs
 )
 {
-    assert(src0_limbs >= src1_limbs);
-    assert(src1_limbs > 0);
+    APY_ASSERT(src0_limbs >= src1_limbs);
+    APY_ASSERT(src1_limbs > 0);
 
 #if COMPILER_LIMB_SIZE == 64 && defined(__SIZEOF_INT128__)
     std::memset(dest, 0, (src0_limbs + src1_limbs) * sizeof(*dest));
@@ -198,7 +198,7 @@ apy_limb_t apy_unsigned_square(
     apy_limb_t* dest, const apy_limb_t* src, const std::size_t src_limbs
 )
 {
-    assert(src_limbs > 0);
+    APY_ASSERT(src_limbs > 0);
 
     // Zero the output buffer
     std::memset(dest, 0, 2 * src_limbs * sizeof(*dest));
@@ -451,10 +451,10 @@ APyDivInverse::APyDivInverse(
     const apy_limb_t* denominator, const std::size_t denominator_limbs
 )
 {
-    assert(denominator_limbs > 0);
+    APY_ASSERT(denominator_limbs > 0);
     switch (denominator_limbs) {
     case 1:
-        assert(denominator[0] > 0);
+        APY_ASSERT(denominator[0] > 0);
         norm_shift = leading_zeros(denominator[0]);
         norm_denominator_1 = denominator[0] << norm_shift;
         norm_denominator_0 = 0;
@@ -462,7 +462,7 @@ APyDivInverse::APyDivInverse(
     case 2:
         norm_denominator_1 = denominator[1];
         norm_denominator_0 = denominator[0];
-        assert(norm_denominator_1 > 0);
+        APY_ASSERT(norm_denominator_1 > 0);
         norm_shift = leading_zeros(norm_denominator_1);
         if (norm_shift > 0) {
             norm_denominator_1 = (norm_denominator_1 << norm_shift)
@@ -473,7 +473,7 @@ APyDivInverse::APyDivInverse(
     default:
         norm_denominator_1 = denominator[denominator_limbs - 1];
         norm_denominator_0 = denominator[denominator_limbs - 2];
-        assert(norm_denominator_1 > 0);
+        APY_ASSERT(norm_denominator_1 > 0);
         norm_shift = leading_zeros(norm_denominator_1);
         if (norm_shift > 0) {
             norm_denominator_1 = (norm_denominator_1 << norm_shift)
@@ -493,7 +493,7 @@ apy_limb_t apy_division_single_limb_preinverted(
     const APyDivInverse* inv
 )
 {
-    assert(quotient != NULL);
+    APY_ASSERT(quotient != NULL);
 
     apy_limb_t remainder;
 
@@ -613,10 +613,10 @@ void apy_division_multiple_limbs_preinverted(
     const APyDivInverse* inv
 )
 {
-    assert(denominator_limbs > 2);
-    assert(numerator_limbs >= denominator_limbs);
-    assert(quotient != NULL);
-    assert((inv->norm_denominator_1 & APY_LIMB_MSBWEIGHT) != 0);
+    APY_ASSERT(denominator_limbs > 2);
+    APY_ASSERT(numerator_limbs >= denominator_limbs);
+    APY_ASSERT(quotient != NULL);
+    APY_ASSERT((inv->norm_denominator_1 & APY_LIMB_MSBWEIGHT) != 0);
 
     const bool needs_norm = inv->norm_shift > 0;
 
@@ -682,7 +682,7 @@ void apy_division_multiple_limbs_preinverted(
     if (needs_norm) {
         apy_limb_t carry
             = apy_inplace_right_shift(numerator, denominator_limbs, inv->norm_shift);
-        assert(carry == 0);
+        APY_ASSERT(carry == 0);
         (void)carry; // Avoid unused-warning
     }
 }

--- a/src/apytypes_mp.h
+++ b/src/apytypes_mp.h
@@ -5,7 +5,6 @@
 #ifndef __APYTYPES_MP_H__
 #define __APYTYPES_MP_H__
 
-#include <cassert>  // assert
 #include <cstddef>  // std::size_t
 #include <cstdint>  // std::int64_t, std::uint64_t, std::int32_t, std::uint32_t
 #include <iterator> // std::distance
@@ -27,9 +26,11 @@ template <class RANDOM_ACCESS_ITERATOR_INOUT, class RANDOM_ACCESS_ITERATOR_IN>
     RANDOM_ACCESS_ITERATOR_IN src_end
 )
 {
-    assert(dest_begin < dest_end);
-    assert(src_begin < src_end);
-    assert(std::distance(dest_begin, dest_end) >= std::distance(src_begin, src_end));
+    APY_ASSERT(dest_begin < dest_end);
+    APY_ASSERT(src_begin < src_end);
+    APY_ASSERT(
+        std::distance(dest_begin, dest_end) >= std::distance(src_begin, src_end)
+    );
 
     apy_limb_t carry = 0;
 
@@ -57,7 +58,7 @@ template <class RANDOM_ACCESS_ITERATOR_INOUT, class RANDOM_ACCESS_ITERATOR_IN>
     const std::size_t limbs
 )
 {
-    assert(limbs > 0);
+    APY_ASSERT(limbs > 0);
 
     // Specialized first iteration
     apy_limb_t src1_0 = src1[0];
@@ -83,7 +84,7 @@ template <
     RANDOM_ACCESS_ITERATOR_IN2 src1
 )
 {
-    assert(dest_begin < dest_end);
+    APY_ASSERT(dest_begin < dest_end);
 
     // Specialized first iteration
     apy_limb_t src1_0 = *src1;
@@ -143,7 +144,7 @@ template <class RANDOM_ACCESS_ITERATOR_INOUT>
     const apy_limb_t src
 )
 {
-    assert(begin_it < end_it);
+    APY_ASSERT(begin_it < end_it);
 
     /* src is initial "carry" */
     apy_limb_t carry = src;
@@ -161,7 +162,7 @@ template <class RANDOM_ACCESS_ITERATOR_INOUT>
     RANDOM_ACCESS_ITERATOR_INOUT begin_it, RANDOM_ACCESS_ITERATOR_INOUT end_it
 )
 {
-    assert(begin_it < end_it);
+    APY_ASSERT(begin_it < end_it);
 
     apy_limb_t carry = 1;
     for (auto it = begin_it; it != end_it && carry; ++it) {
@@ -181,7 +182,7 @@ template <class RANDOM_ACCESS_ITERATOR_INOUT, class RANDOM_ACCESS_ITERATOR_IN>
     RANDOM_ACCESS_ITERATOR_IN src_begin
 )
 {
-    assert(dest_begin < dest_end);
+    APY_ASSERT(dest_begin < dest_end);
 
     apy_limb_t carry = 0;
 
@@ -222,7 +223,7 @@ static APY_INLINE apy_limb_t apy_mul_add_accumulate(
     apy_limb_t* dest, const apy_limb_t* src, const std::size_t limbs
 )
 {
-    assert(limbs > 0);
+    APY_ASSERT(limbs > 0);
 
     // Specialized first iteration
     dest[0] += src[0];
@@ -254,7 +255,7 @@ template <class RANDOM_ACCESS_ITERATOR_INOUT>
     RANDOM_ACCESS_ITERATOR_INOUT begin_it, RANDOM_ACCESS_ITERATOR_INOUT end_it
 )
 {
-    assert(begin_it < end_it);
+    APY_ASSERT(begin_it < end_it);
 
     // Carry phase: negate limbs until carry is consumed
     auto it = begin_it;
@@ -282,7 +283,7 @@ template <class RANDOM_ACCESS_ITERATOR_IN, class RANDOM_ACCESS_ITERATOR_OUT>
     RANDOM_ACCESS_ITERATOR_OUT dest_begin
 )
 {
-    assert(src_begin < src_end);
+    APY_ASSERT(src_begin < src_end);
 
     auto dest_it = dest_begin;
     auto src_it = src_begin;
@@ -314,7 +315,7 @@ template <class RANDOM_ACCESS_ITERATOR_INOUT>
     const apy_limb_t src
 )
 {
-    assert(begin_it < end_it);
+    APY_ASSERT(begin_it < end_it);
 
     /* src is initial "carry" */
     apy_limb_t carry = src;
@@ -337,7 +338,7 @@ template <class RANDOM_ACCESS_ITERATOR_INOUT, class RANDOM_ACCESS_ITERATOR_IN>
     RANDOM_ACCESS_ITERATOR_IN src_begin
 )
 {
-    assert(dest_begin < dest_end);
+    APY_ASSERT(dest_begin < dest_end);
 
     apy_limb_t carry = 0;
     auto dest_it = dest_begin;
@@ -359,7 +360,7 @@ apy_inplace_reversed_subtraction_same_length(
     RANDOM_ACCESS_ITERATOR_IN src_begin
 )
 {
-    assert(dest_begin < dest_end);
+    APY_ASSERT(dest_begin < dest_end);
 
     // Specialized first iteration
     apy_limb_t carry = 0;
@@ -381,7 +382,7 @@ apy_inplace_reversed_subtraction_same_length(
     const std::size_t limbs
 )
 {
-    assert(limbs > 0);
+    APY_ASSERT(limbs > 0);
 
     // Specialized first iteration
     apy_limb_t carry = (src0[0] < src1[0]);
@@ -439,9 +440,9 @@ template <class RANDOM_ACCESS_ITERATOR_INOUT>
     const unsigned int shift_amount
 )
 {
-    assert(begin_it < end_it);
-    assert(shift_amount > 0);
-    assert(shift_amount < APY_LIMB_SIZE_BITS);
+    APY_ASSERT(begin_it < end_it);
+    APY_ASSERT(shift_amount > 0);
+    APY_ASSERT(shift_amount < APY_LIMB_SIZE_BITS);
 
     const unsigned int overlap = APY_LIMB_SIZE_BITS - shift_amount;
     auto it = end_it;
@@ -477,9 +478,9 @@ apy_limb_t apy_inplace_right_shift(
     unsigned int shift_amount
 )
 {
-    assert(begin_it < end_it);
-    assert(shift_amount > 0);
-    assert(shift_amount < APY_LIMB_SIZE_BITS);
+    APY_ASSERT(begin_it < end_it);
+    APY_ASSERT(shift_amount > 0);
+    APY_ASSERT(shift_amount < APY_LIMB_SIZE_BITS);
 
     const unsigned int overlap = APY_LIMB_SIZE_BITS - shift_amount;
     apy_limb_t low_limb = *begin_it;
@@ -546,9 +547,9 @@ void apy_unsigned_division(
 {
     auto denominator_limbs = std::distance(denominator_begin, denominator_end);
     auto numerator_limbs = std::distance(numerator_begin, numerator_end);
-    assert(denominator_begin < denominator_end);
-    assert(numerator_begin < numerator_end);
-    assert(numerator_limbs >= denominator_limbs);
+    APY_ASSERT(denominator_begin < denominator_end);
+    APY_ASSERT(numerator_begin < numerator_end);
+    APY_ASSERT(numerator_limbs >= denominator_limbs);
 
     auto inv = APyDivInverse(denominator_begin.data(), denominator_limbs);
     if (denominator_limbs > 2 && inv.norm_shift > 0) {
@@ -559,7 +560,7 @@ void apy_unsigned_division(
             denominator_limbs,
             inv.norm_shift
         );
-        assert(carry == 0);
+        APY_ASSERT(carry == 0);
         (void)carry; // Avoid unused-warning
         apy_division_multiple_limbs_preinverted(
             &*quotient,
@@ -594,10 +595,10 @@ void apy_unsigned_division_preinverted(
 {
     auto denominator_limbs = std::distance(denominator_begin, denominator_end);
     auto numerator_limbs = std::distance(numerator_begin, numerator_end);
-    assert(numerator_begin < numerator_end);
-    assert(denominator_begin < denominator_end);
-    assert(denominator_limbs > 0);
-    assert(numerator_limbs >= denominator_limbs);
+    APY_ASSERT(numerator_begin < numerator_end);
+    APY_ASSERT(denominator_begin < denominator_end);
+    APY_ASSERT(denominator_limbs > 0);
+    APY_ASSERT(numerator_limbs >= denominator_limbs);
 
     switch (denominator_limbs) {
     case 1:
@@ -639,7 +640,7 @@ void apy_division_double_limbs_preinverted(
     const APyDivInverse* inv
 )
 {
-    assert(std::distance(numerator_begin, numerator_end) >= 2);
+    APY_ASSERT(std::distance(numerator_begin, numerator_end) >= 2);
 
     const bool needs_norm = inv->norm_shift > 0;
 
@@ -664,7 +665,7 @@ void apy_division_double_limbs_preinverted(
 
     // Denormalize numerator back
     if (needs_norm) {
-        assert(
+        APY_ASSERT(
             (numerator_0 & (APY_NUMBER_MASK >> (APY_LIMB_SIZE_BITS - inv->norm_shift)))
             == 0
         );

--- a/src/apytypes_scratch_vector.h
+++ b/src/apytypes_scratch_vector.h
@@ -11,11 +11,12 @@
 #ifndef _APYTYPES_SCRATCH_VECTOR_H
 #define _APYTYPES_SCRATCH_VECTOR_H
 
+#include "apytypes_fwd.h"
+
 #include <fmt/format.h>
 
 #include <algorithm>        // std::copy, std::copy_n
 #include <array>            // std::array
-#include <cassert>          // assert
 #include <cstddef>          // std::size_t, std::ptrdiff_t
 #include <initializer_list> // std::initializer_list
 #include <iterator>         // std::begin, std::end, std::make_reverse_iterator
@@ -247,12 +248,12 @@ public:
     const_reference back() const { return *std::prev(cend()); }
     reference operator[](size_type pos)
     {
-        assert(pos < _size);
+        APY_ASSERT(pos < _size);
         return _ptr[pos];
     }
     const_reference operator[](size_type pos) const
     {
-        assert(pos < _size);
+        APY_ASSERT(pos < _size);
         return _ptr[pos];
     }
 

--- a/src/apytypes_simd.cc
+++ b/src/apytypes_simd.cc
@@ -690,7 +690,9 @@ namespace HWY_NAMESPACE { // required: unique per target
         const std::size_t size
     )
     {
-        assert((size & 1U) == 0U && "size must be even for vector_add_const_even_odd");
+        APY_ASSERT(
+            (size & 1U) == 0U && "size must be even for vector_add_const_even_odd"
+        );
         constexpr const hn::ScalableTag<apy_limb_t> d;
         const std::size_t lanes = hn::Lanes(d);
         const std::size_t size_simd = size - size % lanes;
@@ -822,7 +824,9 @@ namespace HWY_NAMESPACE { // required: unique per target
         const std::size_t size
     )
     {
-        assert((size & 1U == 0U) && "size must be even for vector_sub_const_even_odd");
+        // APY_ASSERT(
+        //     (size & 1U) == 0U && "size must be even for vector_sub_const_even_odd"
+        // );
         constexpr const hn::ScalableTag<apy_limb_t> d;
         const std::size_t lanes = hn::Lanes(d);
         const std::size_t size_simd = size - size % lanes;
@@ -920,7 +924,9 @@ namespace HWY_NAMESPACE { // required: unique per target
         const std::size_t size
     )
     {
-        assert((size & 1U) == 0U && "size must be even for vector_rsub_const_even_odd");
+        APY_ASSERT(
+            (size & 1U) == 0U && "size must be even for vector_rsub_const_even_odd"
+        );
         constexpr const hn::ScalableTag<apy_limb_t> d;
         const std::size_t lanes = hn::Lanes(d);
         const std::size_t size_simd = size - size % lanes;

--- a/src/apytypes_util.h
+++ b/src/apytypes_util.h
@@ -21,6 +21,7 @@
 #include <optional>         // std::optional, std::nullopt
 #include <regex>            // std::regex, std::regex_replace
 #include <sstream>          // std::stringstream
+#include <stdexcept>        // std::runtime_error
 #include <string>           // std::string
 #include <tuple>            // std::tuple
 #include <type_traits>      // std::is_same_v
@@ -61,7 +62,7 @@ template <typename T> using remove_cvref_t = typename remove_cvref<T>::type;
 bits_to_limbs(std::size_t bits)
 {
     static_assert(APY_LIMB_SIZE_BITS == 64 || APY_LIMB_SIZE_BITS == 32);
-    assert(bits > 0);
+    APY_ASSERT(bits > 0);
 
     if constexpr (APY_LIMB_SIZE_BITS == 64) {
         return ((bits - 1) >> 6) + 1;
@@ -75,7 +76,7 @@ template <class RANDOM_ACCESS_ITERATOR>
 [[maybe_unused, nodiscard]] static APY_INLINE std::size_t
 significant_limbs(RANDOM_ACCESS_ITERATOR begin, RANDOM_ACCESS_ITERATOR end)
 {
-    assert(begin <= end);
+    APY_ASSERT(begin <= end);
 
     auto is_non_zero = [](auto n) { return n != 0; };
     auto back_non_zero_it = std::find_if(
@@ -89,7 +90,7 @@ template <class RANDOM_ACCESS_ITERATOR>
 [[maybe_unused, nodiscard]] static APY_INLINE std::size_t
 limb_vector_leading_zeros(RANDOM_ACCESS_ITERATOR begin, RANDOM_ACCESS_ITERATOR end)
 {
-    assert(begin <= end);
+    APY_ASSERT(begin <= end);
 
     auto is_non_zero = [](auto n) { return n != 0; };
     auto rev_non_zero_it = std::find_if(
@@ -110,7 +111,7 @@ template <class RANDOM_ACCESS_ITERATOR>
 [[maybe_unused, nodiscard]] static APY_INLINE std::size_t
 limb_vector_trailing_zeros(RANDOM_ACCESS_ITERATOR begin, RANDOM_ACCESS_ITERATOR end)
 {
-    assert(begin <= end);
+    APY_ASSERT(begin <= end);
 
     auto is_non_zero = [](auto n) { return n != 0; };
     auto non_zero_it = std::find_if(begin, end, is_non_zero);
@@ -129,7 +130,7 @@ template <class RANDOM_ACCESS_ITERATOR>
 [[maybe_unused, nodiscard]] static APY_INLINE std::size_t
 limb_vector_leading_ones(RANDOM_ACCESS_ITERATOR begin, RANDOM_ACCESS_ITERATOR end)
 {
-    assert(begin <= end);
+    APY_ASSERT(begin <= end);
 
     auto is_not_all_ones = [](auto n) { return n != apy_limb_t(-1); };
     auto rev_not_all_ones_it = std::find_if(
@@ -497,7 +498,7 @@ template <class RANDOM_ACCESS_ITERATOR>
     RANDOM_ACCESS_ITERATOR it_begin, RANDOM_ACCESS_ITERATOR it_end, unsigned shift_amnt
 )
 {
-    assert(it_begin < it_end);
+    APY_ASSERT(it_begin < it_end);
 
     // Return early if no shift or no vector
     if (!shift_amnt) {
@@ -538,7 +539,7 @@ template <class RANDOM_ACCESS_ITERATOR>
     RANDOM_ACCESS_ITERATOR it_begin, RANDOM_ACCESS_ITERATOR it_end, unsigned shift_amnt
 )
 {
-    assert(it_begin < it_end);
+    APY_ASSERT(it_begin < it_end);
 
     // Return early if no shift or no vector
     if (!shift_amnt) {
@@ -575,7 +576,7 @@ static APY_INLINE void limb_vector_lsl_inner(
     unsigned int limb_shift
 )
 {
-    assert(it_begin < it_end);
+    APY_ASSERT(it_begin < it_end);
 
     if (limb_skip) {
         std::copy_backward(it_begin, it_end - limb_skip, it_end);
@@ -598,7 +599,7 @@ template <class RANDOM_ACCESS_ITERATOR>
     RANDOM_ACCESS_ITERATOR it_begin, RANDOM_ACCESS_ITERATOR it_end, unsigned shift_amnt
 )
 {
-    assert(it_begin < it_end);
+    APY_ASSERT(it_begin < it_end);
 
     // Return early if no shift or no vector
     if (!shift_amnt) {
@@ -621,7 +622,7 @@ template <class RANDOM_ACCESS_ITERATOR>
     RANDOM_ACCESS_ITERATOR it_begin, RANDOM_ACCESS_ITERATOR it_end, unsigned n
 )
 {
-    assert(it_begin <= it_end);
+    APY_ASSERT(it_begin <= it_end);
 
     unsigned bit_idx = n % APY_LIMB_SIZE_BITS;
     unsigned limb_idx = n / APY_LIMB_SIZE_BITS;
@@ -654,7 +655,7 @@ template <class RANDOM_ACCESS_ITERATOR1, class RANDOM_ACCESS_ITERATOR2>
 {
     static_assert(std::is_same_v<remove_cvref_t<decltype(*src1)>, apy_limb_t>);
     static_assert(std::is_same_v<remove_cvref_t<decltype(*src2)>, apy_limb_t>);
-    assert(limbs > 0);
+    APY_ASSERT(limbs > 0);
 
     if (src1[limbs - 1] != src2[limbs - 1]) {
         return apy_limb_signed_t(src1[limbs - 1]) < apy_limb_signed_t(src2[limbs - 1]);
@@ -677,7 +678,7 @@ template <class RANDOM_ACCESS_ITERATOR>
     RANDOM_ACCESS_ITERATOR it_begin, RANDOM_ACCESS_ITERATOR it_end, unsigned n
 )
 {
-    assert(it_begin < it_end);
+    APY_ASSERT(it_begin < it_end);
 
     unsigned limb_idx = n / APY_LIMB_SIZE_BITS;
     std::size_t limbs = std::distance(it_begin, it_end);
@@ -763,7 +764,7 @@ template <class RANDOM_ACCESS_ITERATOR>
 )
 {
     (void)cbegin_it;
-    assert(cbegin_it < cend_it);
+    APY_ASSERT(cbegin_it < cend_it);
     return apy_limb_signed_t(*std::prev(cend_it)) < 0;
 }
 
@@ -772,7 +773,7 @@ template <class RANDOM_ACCESS_ITERATOR>
 [[maybe_unused, nodiscard]] static APY_INLINE bool
 limb_vector_is_zero(RANDOM_ACCESS_ITERATOR cbegin_it, RANDOM_ACCESS_ITERATOR cend_it)
 {
-    assert(cbegin_it <= cend_it);
+    APY_ASSERT(cbegin_it <= cend_it);
     return std::all_of(cbegin_it, cend_it, [](auto n) { return n == 0; });
 }
 
@@ -785,8 +786,8 @@ template <class RANDOM_ACCESS_ITERATOR>
 )
 {
     (void)cend_it;
-    assert(cbegin_it < cend_it);
-    assert(std::distance(cbegin_it, cend_it) >= (n ? bits_to_limbs(n) : 0));
+    APY_ASSERT(cbegin_it < cend_it);
+    APY_ASSERT(std::distance(cbegin_it, cend_it) >= (n ? bits_to_limbs(n) : 0));
 
     // The full limbs can be reduced as full integers
     const unsigned full_limbs = n / APY_LIMB_SIZE_BITS;
@@ -818,8 +819,8 @@ template <class RANDOM_ACCESS_ITERATOR>
 )
 {
     (void)cend_it;
-    assert(cbegin_it < cend_it);
-    assert(std::distance(cbegin_it, cend_it) >= (n ? bits_to_limbs(n) : 0));
+    APY_ASSERT(cbegin_it < cend_it);
+    APY_ASSERT(std::distance(cbegin_it, cend_it) >= (n ? bits_to_limbs(n) : 0));
 
     unsigned bit_idx = n % APY_LIMB_SIZE_BITS;
     unsigned limb_idx = n / APY_LIMB_SIZE_BITS;
@@ -836,7 +837,7 @@ template <class RANDOM_ACCESS_ITERATOR>
 )
 {
     (void)end_it;
-    assert(begin_it < end_it);
+    APY_ASSERT(begin_it < end_it);
 
     unsigned bit_idx = n % APY_LIMB_SIZE_BITS;
     unsigned limb_idx = n / APY_LIMB_SIZE_BITS;
@@ -854,7 +855,7 @@ template <class RANDOM_ACCESS_ITERATOR_IN, class RANDOM_ACCESS_ITERATOR_OUT>
     RANDOM_ACCESS_ITERATOR_OUT res_it
 )
 {
-    assert(cbegin_it < cend_it);
+    APY_ASSERT(cbegin_it < cend_it);
     return apy_negate(cbegin_it, cend_it, res_it);
 }
 
@@ -864,7 +865,7 @@ template <class RANDOM_ACCESS_ITERATOR_IN>
     RANDOM_ACCESS_ITERATOR_IN cbegin_it, RANDOM_ACCESS_ITERATOR_IN cend_it
 )
 {
-    assert(cbegin_it < cend_it);
+    APY_ASSERT(cbegin_it < cend_it);
     return apy_inplace_negate(cbegin_it, cend_it);
 }
 
@@ -874,7 +875,7 @@ template <class RANDOM_ACCESS_ITERATOR_IN>
     RANDOM_ACCESS_ITERATOR_IN cbegin_it, RANDOM_ACCESS_ITERATOR_IN cend_it
 )
 {
-    assert(cbegin_it < cend_it);
+    APY_ASSERT(cbegin_it < cend_it);
     return apy_inplace_add_one_lsb(cbegin_it, cend_it);
 }
 
@@ -956,8 +957,8 @@ template <typename RANDOM_ACCESS_ITERATOR_IN, typename RANDOM_ACCESS_ITERATOR_OU
     RANDOM_ACCESS_ITERATOR_OUT dst_end
 )
 {
-    assert(src_begin <= src_end);
-    assert(dst_begin <= dst_end);
+    APY_ASSERT(src_begin <= src_end);
+    APY_ASSERT(dst_begin <= dst_end);
     std::size_t src_n = std::distance(src_begin, src_end);
     std::size_t dst_n = std::distance(dst_begin, dst_end);
     limb_vector_copy_n_sign_extend(src_begin, src_n, dst_begin, dst_n);
@@ -991,7 +992,7 @@ template <typename RANDOM_ACCESS_IT>
 limb_vector_to_u64_vec(RANDOM_ACCESS_IT begin_it, RANDOM_ACCESS_IT end_it)
 {
     static_assert(APY_LIMB_SIZE_BITS == 64 || APY_LIMB_SIZE_BITS == 32);
-    assert(begin_it <= end_it);
+    APY_ASSERT(begin_it <= end_it);
 
     if constexpr (APY_LIMB_SIZE_BITS == 64) {
         return std::vector<uint64_t>(begin_it, end_it);
@@ -1017,7 +1018,7 @@ template <typename VEC_RETURN_TYPE, typename RANDOM_ACCESS_IT>
 limb_vector_from_u64_vec(RANDOM_ACCESS_IT begin_it, RANDOM_ACCESS_IT end_it)
 {
     static_assert(APY_LIMB_SIZE_BITS == 64 || APY_LIMB_SIZE_BITS == 32);
-    assert(begin_it <= end_it);
+    APY_ASSERT(begin_it <= end_it);
 
     if constexpr (APY_LIMB_SIZE_BITS == 64) {
         return VEC_RETURN_TYPE(begin_it, end_it);
@@ -1109,7 +1110,7 @@ template <typename RANDOM_ACCESS_ITERATOR_INOUT>
     std::size_t itemsize
 )
 {
-    assert(begin_it <= end_it);
+    APY_ASSERT(begin_it <= end_it);
     auto n_items = std::distance(begin_it, end_it) / itemsize;
     VECTORIZE_LOOP
     for (std::size_t i = 0; i < (n_items + 1) / 2; i++) {

--- a/src/broadcast.h
+++ b/src/broadcast.h
@@ -113,8 +113,8 @@ static APY_INLINE std::vector<std::size_t> smallest_broadcastable_shape(
 
     // Reverse the dimensions and return
     std::reverse(std::begin(result), std::end(result));
-    assert(is_broadcastable(shape1, result));
-    assert(is_broadcastable(shape2, result));
+    APY_ASSERT(is_broadcastable(shape1, result));
+    APY_ASSERT(is_broadcastable(shape2, result));
     return result;
 }
 

--- a/src/python_util.h
+++ b/src/python_util.h
@@ -111,7 +111,7 @@ limb_vec_from_py_long_vec(const std::size_t count, const PyLongObject* py_long)
     auto data = GET_OB_DIGIT(py_long);
     constexpr std::size_t data_size = sizeof(data[0]);
 
-    assert(data_size * POSIX_CHAR_BITS - PYLONG_BITS_IN_DIGIT > 0);
+    APY_ASSERT(data_size * POSIX_CHAR_BITS - PYLONG_BITS_IN_DIGIT > 0);
 
     std::size_t limb_vec_size = bits_to_limbs(count * PYLONG_BITS_IN_DIGIT);
     std::vector<apy_limb_t> limb_vec = std::vector<apy_limb_t>(limb_vec_size);
@@ -134,45 +134,45 @@ limb_vec_from_py_long_vec(const std::size_t count, const PyLongObject* py_long)
         for (std::size_t j = 0; j < WHOLE_BYTES; j++) {
             byte = *dp;
             dp -= endian;
-            assert(lbits < (int)APY_LIMB_SIZE_BITS);
-            assert(limb <= (((apy_limb_t)1) << lbits) - 1);
+            APY_ASSERT(lbits < (int)APY_LIMB_SIZE_BITS);
+            APY_ASSERT(limb <= (((apy_limb_t)1) << lbits) - 1);
 
             limb |= (apy_limb_t)byte << lbits;
             lbits += POSIX_CHAR_BITS;
             if (lbits >= (int)APY_LIMB_SIZE_BITS) {
                 *limb_vec_tmp_ptr++ = limb & APY_NUMBER_MASK;
                 lbits -= APY_LIMB_SIZE_BITS;
-                assert(lbits < POSIX_CHAR_BITS);
+                APY_ASSERT(lbits < POSIX_CHAR_BITS);
                 limb = byte >> (POSIX_CHAR_BITS - lbits);
             }
         }
         // Process remaining bits
-        assert(REMAINING_BITS != 0);
+        APY_ASSERT(REMAINING_BITS != 0);
         byte = *dp & REMAINING_BITS_MASK;
         dp -= endian;
-        assert(lbits < (int)APY_LIMB_SIZE_BITS);
-        assert(limb <= (((apy_limb_t)1) << lbits) - 1);
+        APY_ASSERT(lbits < (int)APY_LIMB_SIZE_BITS);
+        APY_ASSERT(limb <= (((apy_limb_t)1) << lbits) - 1);
 
         limb |= (apy_limb_t)byte << lbits;
         lbits += REMAINING_BITS;
         if (lbits >= (int)APY_LIMB_SIZE_BITS) {
             *limb_vec_tmp_ptr++ = limb & APY_NUMBER_MASK;
             lbits -= APY_LIMB_SIZE_BITS;
-            assert(lbits < REMAINING_BITS);
+            APY_ASSERT(lbits < REMAINING_BITS);
             limb = byte >> (REMAINING_BITS - lbits);
         }
         dp += woffset;
     }
 
     if (lbits != 0) {
-        assert(lbits <= (int)APY_LIMB_SIZE_BITS);
+        APY_ASSERT(lbits <= (int)APY_LIMB_SIZE_BITS);
         *limb_vec_tmp_ptr++ = limb;
     }
 
-    assert(limb_vec_tmp_ptr == limb_vec.data() + limb_vec_size);
+    APY_ASSERT(limb_vec_tmp_ptr == limb_vec.data() + limb_vec_size);
 
     /* low byte of word after most significant */
-    assert(
+    APY_ASSERT(
         dp
         == (unsigned char*)data + count * data_size
             + (endian >= 0 ? (apy_size_t)data_size - 1 : 0)
@@ -285,7 +285,7 @@ template <class RANDOM_ACCESS_ITERATOR>
     }
 
     std::size_t limb_vec_size = limb_vec_abs.size();
-    assert(limb_vec_size > 0);
+    APY_ASSERT(limb_vec_size > 0);
     // Number of significant bits in the absolute value limb vector
     std::size_t significant_bits
         = APY_LIMB_SIZE_BITS * limb_vec_size - leading_zeros(limb_vec_abs.back());
@@ -302,11 +302,11 @@ template <class RANDOM_ACCESS_ITERATOR>
     // Export the intermediate data to the Python integer
     // Relevant parts from mpz_export
     const std::size_t py_limb_size = sizeof(GET_OB_DIGIT(result)[0]);
-    assert(py_limb_size * POSIX_CHAR_BITS - PYLONG_BITS_IN_DIGIT > 0);
+    APY_ASSERT(py_limb_size * POSIX_CHAR_BITS - PYLONG_BITS_IN_DIGIT > 0);
 
     apy_limb_t* limb_vec_tmp_ptr = limb_vec_abs.data();
 
-    assert(limb_vec_tmp_ptr[limb_vec_size - 1] != 0);
+    APY_ASSERT(limb_vec_tmp_ptr[limb_vec_size - 1] != 0);
 
     int endian = HOST_ENDIAN;
 
@@ -336,7 +336,7 @@ template <class RANDOM_ACCESS_ITERATOR>
             dp -= endian;
         }
         // Process remaining bits
-        assert(REMAINING_BITS != 0);
+        APY_ASSERT(REMAINING_BITS != 0);
         if (lbits >= REMAINING_BITS) {
             *dp = limb & REMAINING_BITS_MASK;
             limb >>= REMAINING_BITS;
@@ -358,10 +358,10 @@ template <class RANDOM_ACCESS_ITERATOR>
         dp += woffset;
     }
 
-    assert(limb_vec_tmp_ptr == limb_vec_abs.data() + limb_vec_size);
+    APY_ASSERT(limb_vec_tmp_ptr == limb_vec_abs.data() + limb_vec_size);
 
     /* low byte of word after most significant */
-    assert(
+    APY_ASSERT(
         dp
         == (unsigned char*)&GET_OB_DIGIT(result)[0] + python_digits * py_limb_size
             + (endian >= 0 ? (apy_size_t)py_limb_size - 1 : 0)
@@ -370,7 +370,7 @@ template <class RANDOM_ACCESS_ITERATOR>
     // End of relevant parts from mpz_export
 
     // If this ever triggers, normalize result by removing trailing zero digits
-    assert(GET_OB_DIGIT(result)[python_digits - 1] != 0);
+    APY_ASSERT(GET_OB_DIGIT(result)[python_digits - 1] != 0);
 
     PyLong_SetSignAndDigitCount(result, sign, python_digits);
 
@@ -483,15 +483,15 @@ python_iterable_extract_shape(
         for (std::size_t i = 0; i < ndarray.ndim(); i++) {
             result[i] = ndarray.shape_ptr()[i];
         }
-        assert(result.size());
+        APY_ASSERT(result.size());
     } else {
         result = _python_iterable_extract_shape_recursive_descent<ExcludedPyTypes...>(
             seq, err_prefix
         );
-        assert(result.size());
+        APY_ASSERT(result.size());
     }
 
-    assert(result.size());
+    APY_ASSERT(result.size());
     if constexpr (IS_COMPLEX_COLLAPSE) {
         if (result.back() == 2) {
             result.pop_back();


### PR DESCRIPTION
# PR Summary

This PR adds a new C++ macro `APY_ASSERT()` that is defined in `src/apytypes_fwd.h`.

The new assertion macro throws a Python `RuntimeError` on assertion failure instead of calling `std::abort()` which is done when using regular `assert()`. This may be useful in the APyTypes test suite, as the assertion message wont get lost as a consequence of abnormal shutdown of the Python interpreter. Instead, the point test that caused the failure will log the assertion message and report it through Pytest.

Just like with a regular `assert()`, `APY_ASSERT()` assertions are only armed if the macro `NDEBUG` is unset during build. 


### Example:

```
____________________________________________________________________ test_issue_818_mre1_pt2[uint64-10-10-APyCFixedArray] ____________________________________________________________________
                                                                                                                                                                                              
fixed_array = <class 'apytypes._apytypes.APyCFixedArray'>, int_bits = 10, frac_bits = 10, dt = 'uint64'                                                                                       
                                                                                                                                                                                              
    @pytest.mark.parametrize("fixed_array", [APyFixedArray, APyCFixedArray])                                                                                                                  
    @pytest.mark.parametrize("int_bits", [10, 100, 1000])                                                                                                                                     
    @pytest.mark.parametrize("frac_bits", [-5, 0, 10])                                                                                                                                        
    @pytest.mark.parametrize("dt", ["uint8", "uint16", "uint32", "uint64"])                                                                                                                   
    def test_issue_818_mre1_pt2(                                                                                                                                                              
        fixed_array: type[APyCFixedArray], int_bits: int, frac_bits: int, dt: str                                                                                                             
    ):                                                                                                                                                                                        
        """                                                                                                                                                                                   
        MRE1: https://github.com/apytypes/apytypes/issues/818                                                                                                                                 
        """                                                                                                                                                                                   
        np = pytest.importorskip("numpy")                                                                                                                                                     
>       assert fixed_array.from_array(np.array([1], dtype=dt), int_bits, frac_bits) == 1                                                                                                      
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^                                                                                                      

E       RuntimeError: ../src/apytypes_simd.cc:825: assertion failed: (size & 1U == 0U) && "size must be even for vector_sub_const_even_odd"

lib/test/apyfixedarray/test_constructors.py:410: RuntimeError
```

## PR Checklist

- N/A "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] new and changed code is tested
- N/A relevant changes added to [CHANGELOG.md](https://github.com/apytypes/apytypes/blob/main/CHANGELOG.md)
- N/A new functionality is documented
